### PR TITLE
chore: add facets for entityGuid to validation queries

### DIFF
--- a/recipes/newrelic/infra-agent/amazonlinux2.yml
+++ b/recipes/newrelic/infra-agent/amazonlinux2.yml
@@ -20,7 +20,7 @@ keywords:
 processMatch:
   - /infra/
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/infra-agent/centos_rhel.yml
+++ b/recipes/newrelic/infra-agent/centos_rhel.yml
@@ -34,7 +34,7 @@ keywords:
 processMatch:
   - /infra/
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/infra-agent/debian.yml
+++ b/recipes/newrelic/infra-agent/debian.yml
@@ -22,7 +22,7 @@ keywords:
 processMatch:
   - /infra/
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/infra-agent/suse.yml
+++ b/recipes/newrelic/infra-agent/suse.yml
@@ -20,7 +20,7 @@ keywords:
 processMatch:
   - /infra/
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/infra-agent/ubuntu.yml
+++ b/recipes/newrelic/infra-agent/ubuntu.yml
@@ -24,7 +24,7 @@ keywords:
 processMatch:
   - /infra/
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/infra-agent/windows.yml
+++ b/recipes/newrelic/infra-agent/windows.yml
@@ -16,7 +16,7 @@ keywords:
 
 processMatch: []
 
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/nginx/debian.yml
+++ b/recipes/newrelic/nginx/debian.yml
@@ -31,7 +31,7 @@ logMatch:
     attributes:
       logtype: nginx-error
 
-validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/nginx/rhel.yml
+++ b/recipes/newrelic/nginx/rhel.yml
@@ -35,7 +35,7 @@ logMatch:
     attributes:
       logtype: nginx-error
 
-validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}%' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"

--- a/recipes/newrelic/nginx/suse.yml
+++ b/recipes/newrelic/nginx/suse.yml
@@ -28,7 +28,7 @@ logMatch:
     attributes:
       logtype: nginx-error
 
-validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 
 install:
   version: "3"


### PR DESCRIPTION
This PR allows the CLI to pull the host's entity GUID from the validation queries specified in each recipe.