### PR TITLE
fix: use -y to accept prompts

### DIFF
--- a/test/deploy/linux/newrelic-cli/install-recipe/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/newrelic-cli/install-recipe/roles/configure/tasks/main.yml
@@ -46,7 +46,7 @@
   shell: "curl -Ls https://raw.githubusercontent.com/newrelic/newrelic-cli/master/scripts/install.sh | sudo bash"
 
 - name: Run recipes
-  shell: "{{ env_vars }} /usr/local/bin/newrelic install -c {{ item }}"
+  shell: "{{ env_vars }} /usr/local/bin/newrelic install -y -c {{ item }}"
   loop: "{{ recipe_content_url }}"
   register: output
   become: true


### PR DESCRIPTION
Recent changes to the CLI messaging cause a situation where the deployer tests get stuck waiting for the user to confirm y/n to install integrations (even when `-c` flag is passed). 

![image](https://user-images.githubusercontent.com/6722433/106234876-8accdd00-61c7-11eb-98ee-e378a4159958.png)

This change uses the `-y` flag to bypass that restriction until we get a proper fix into the CLI (the original intent of the `-c` flag is prompt wouldn't be required)