### PR TITLE
Updating Mysql OHI integration plays

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -85,9 +85,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
-          EXPECTED=$(echo 'SELECT, REPLICATION')
-          if [ "$CHECK_DB" != "$EXPECTED" ] ; then
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')
+          EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
+          EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi
@@ -112,7 +113,7 @@ install:
           sudo tee /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mysql
 
-          instances: 
+          instances:
             - name: mysql-status
               command: status
               arguments:


### PR DESCRIPTION
This PR updates the MySQL OHI play in 2 ways:
* it now uses the NR_CLI_DB_PORT when checking the database connection (to support databases listening on non standard ports)
* it allows for using the current mysql user if it has  'ALL PRIVILEGES' or 'SELECT, REPLICATION' permissions

The other MySQL OHIs will need to be updated in a similar way, but I wanted to get this first pass in and make sure it was acceptable before completing the work.  Plus I do not have a way to test anything beyond the MySQL setup.