### PR TITLE
Update SQL recipes to use the port when testing the database credent…

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -67,7 +67,7 @@ install:
         - task: assert_pre_req
         - task: setup
         - task: restart
-        
+
     create_user_notification:
       cmds:
         - |
@@ -85,9 +85,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
-          EXPECTED=$(echo 'SELECT, REPLICATION')
-          if [ "$CHECK_DB" != "$EXPECTED" ] ; then
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
+          EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
+          EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi
@@ -108,11 +109,11 @@ install:
 
           sudo cp /etc/newrelic-infra/integrations.d/mysql-config.yml.sample /etc/newrelic-infra/integrations.d/mysql-config.yml;
 
-        - | 
+        - |
           sudo tee /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mysql
 
-          instances: 
+          instances:
             - name: mysql-status
               command: status
               arguments:

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -88,7 +88,7 @@ install:
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
-          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -88,7 +88,7 @@ install:
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
-          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -82,9 +82,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
-          EXPECTED=$(echo 'SELECT, REPLICATION')
-          if [ "$CHECK_DB" != "$EXPECTED" ] ; then
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
+          EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
+          EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi
@@ -108,7 +109,7 @@ install:
           sudo tee -a /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mysql
 
-          instances: 
+          instances:
             - name: mysql-status
               command: status
               arguments:

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -85,7 +85,7 @@ install:
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
-          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] ||  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
+          if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then
             echo -e "[Error]: Provided user has no access to the desired database.\n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration#config for more info."
             exit 2
           fi

--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -50,7 +50,7 @@ install:
     assert_pre_req:
       cmds:
         - powershell -command '$output = Get-Service "newrelic-infra"; if ( -not ($output -like "*newrelic-infra*") ) { Write-Error "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." }'
-        - powershell -command '$output = sqlcmd -S {{.NR_CLI_DB_HOSTNAME}},{{.NR_CLI_DB_HOSTNAME}} -U {{.NR_CLI_DB_USERNAME}} -P "{{.NR_CLI_DB_PASSWORD}}" -Q "SELECT GETDATE()"; if ( -not ($output -like "*rows affected*") ) { Write-Error "Cannot connect to the SQL Server instance {{.NR_CLI_DB_HOSTNAME}} with the provided username {{.NR_CLI_DB_USERNAME}} and password." }'
+        - powershell -command '$output = sqlcmd -S {{.NR_CLI_DB_HOSTNAME}},{{.NR_CLI_DB_PORT}} -U {{.NR_CLI_DB_USERNAME}} -P "{{.NR_CLI_DB_PASSWORD}}" -Q "SELECT GETDATE()"; if ( -not ($output -like "*rows affected*") ) { Write-Error "Cannot connect to the SQL Server instance {{.NR_CLI_DB_HOSTNAME}} with the provided username {{.NR_CLI_DB_USERNAME}} and password." }'
 
     remove_any_previous:
       ignore_error: true

--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -50,7 +50,7 @@ install:
     assert_pre_req:
       cmds:
         - powershell -command '$output = Get-Service "newrelic-infra"; if ( -not ($output -like "*newrelic-infra*") ) { Write-Error "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." }'
-        - powershell -command '$output = sqlcmd -S {{.NR_CLI_DB_HOSTNAME}} -U {{.NR_CLI_DB_USERNAME}} -P "{{.NR_CLI_DB_PASSWORD}}" -Q "SELECT GETDATE()"; if ( -not ($output -like "*rows affected*") ) { Write-Error "Cannot connect to the SQL Server instance {{.NR_CLI_DB_HOSTNAME}} with the provided username {{.NR_CLI_DB_USERNAME}} and password." }'
+        - powershell -command '$output = sqlcmd -S {{.NR_CLI_DB_HOSTNAME}},{{.NR_CLI_DB_HOSTNAME}} -U {{.NR_CLI_DB_USERNAME}} -P "{{.NR_CLI_DB_PASSWORD}}" -Q "SELECT GETDATE()"; if ( -not ($output -like "*rows affected*") ) { Write-Error "Cannot connect to the SQL Server instance {{.NR_CLI_DB_HOSTNAME}} with the provided username {{.NR_CLI_DB_USERNAME}} and password." }'
 
     remove_any_previous:
       ignore_error: true


### PR DESCRIPTION
This PR finishes up the work started in [PR 180](https://github.com/newrelic/open-install-library/pull/180).  The MySQL and SQL install tasks (recipes) were collecting the port the database was running, but not using the port when testing the credentials.