### PR TITLE
feat: add preInstall info

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -46,6 +46,15 @@ inputVars:
   - name: "NR_CLI_FILE_DIR"
     prompt: "SSL Certificate File (if applicable)"
 
+preInstall:
+  info: |2
+      To capture data from the HashiCorp Consul integration, you'll first need to meet these prerequisites:
+      
+      If using ACL, the credentials for the Consul integration must have the following policies: 
+      - agent:read
+      - node:read
+      - service:read
+
 install:
   version: "3"
   silent: true
@@ -53,23 +62,16 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
         - task: restart
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the HashiCorp Consul integration, you'll first need to meet these prerequisites:
-          - If using ACL, the credentials for the Consul integration must have the following policies: agent:read, node:read, and service:read."
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -47,6 +47,15 @@ inputVars:
   - name: "NR_CLI_FILE_DIR"
     prompt: "SSL Certificate File (if applicable)"
 
+preInstall:
+  info: |2
+      To capture data from the HashiCorp Consul integration, you'll first need to meet these prerequisites:
+      
+      If using ACL, the credentials for the Consul integration must have the following policies: 
+      - agent:read
+      - node:read
+      - service:read
+
 install:
   version: "3"
   silent: true
@@ -54,24 +63,19 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
         - task: restart
 
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the HashiCorp Consul integration, you'll first need to meet these prerequisites:
-          - If using ACL, the credentials for the Consul integration must have the following policies: agent:read, node:read, and service:read."
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
+
     setup:
       label: "Installing HashiCorp Consul integration..."
       cmds:
@@ -143,6 +147,7 @@ install:
           EOT
             fi
           fi
+
     restart:
       cmds:
         - sudo systemctl restart newrelic-infra.service

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -39,6 +39,11 @@ inputVars:
   - name: "NR_CLI_CLUSTER_NAME"
     prompt: "HAProxy Cluster Name"
 
+preInstall:
+  info: |2
+      To capture data from the HAProxy integration, you'll first need to meet these prerequisites:
+      - The HAProxy statistics page must enabled and accessible to enable this integration.
+
 install:
   version: "3"
   silent: true
@@ -46,21 +51,15 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "The HAProxy statistics page must enabled and accessible to enable this integration."
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -24,7 +24,7 @@ processMatch:
 
 logMatch:
   - name: haproxy
-    file: /var/log/haproxy.log 
+    file: /var/log/haproxy.log
 
 validationNrql: "SELECT count(*) from HAProxyBackendSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 
@@ -39,38 +39,37 @@ inputVars:
   - name: "NR_CLI_CLUSTER_NAME"
     prompt: "HAProxy Cluster Name"
 
-install:
+preInstall:
+  info: |2
+      To capture data from the HAProxy integration, you'll first need to meet these prerequisites:
+      - The HAProxy statistics page must enabled and accessible to enable this integration.
 
+install:
   version: "3"
   silent: true
 
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "The HAProxy statistics page must enabled and accessible to enable this integration."
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
+
     setup:
       label: "Installing HAProxy integration..."
       cmds:
         - |
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"
         - |
-          sudo yum update -y 
+          sudo yum update -y
         - |
           sudo yum install nri-haproxy -y
         - |

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -65,35 +65,43 @@ inputVars:
   - name: "NR_CLI_CERT_PASSPHRASE"
     prompt: "Passphrase to decrypt the PEM key file (if applicable)"
 
-install:
+preInstall:
+  info: |2
+      You'll need a user with clusterMonitor and listcollections roles to 
+      collect data from this integration. If you'd like to create a new user 
+      please use these commands as reference:
+      
+      In the MongoDB shell, execute the following commands to create a 
+      listCollections role and a new user, then assign clusterMonitor and 
+      listCollections roles to the new user. 
+      Note: username, password, and similar user-specific values must be replaced.
+      
+      In the MongoDB shell, enter
+      > use admin
 
+      Use the following command to create the listCollections role:
+      > db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
+      
+      Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
+      > db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})
+
+install:
   version: "3"
   silent: true
 
   tasks:
     default:
       cmds:
-        - task: create_user_notification
+        - task: assert_pre_req
         - task: setup
         - task: restart
-        
-    create_user_notification:
-      cmds:
-        - |
-          echo "_ Note: These steps must be completed in order for the MongoDB integration to function properly.
-          In the MongoDB shell, enter use admin.
-          Use the following command to create the listCollections role.
-          db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
-          Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
-          db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})"
-
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
         - |
@@ -116,7 +124,7 @@ install:
           if [ -f /etc/newrelic-infra/integrations.d/mongodb-config.yml ]; then
             sudo rm /etc/newrelic-infra/integrations.d/mongodb-config.yml;
           fi
-        - | 
+        - |
           if [ "{{.NR_CLI_SSL}}" == "y" ]; then
             if [ "{{.NR_CLI_SKIP_SSL_VERIFY}}" == "n" ]; then
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -1,4 +1,3 @@
-
 name: mongodb-open-source-integration
 displayName: MongoDB Open Source Integration
 description: New Relic install recipe for default MongoDB Open Source on-host integration (via Infra-Agent)
@@ -59,35 +58,46 @@ inputVars:
   - name: "NR_CLI_CERT_PASSPHRASE"
     prompt: "Passphrase to decrypt the PEM key file (if applicable)"
 
-install:
+preInstall:
+  info: |2
+      You'll need a user with clusterMonitor and listcollections roles to 
+      collect data from this integration. If you'd like to create a new user 
+      please use these commands as reference:
+      
+      In the MongoDB shell, execute the following commands to create a 
+      listCollections role and a new user, then assign clusterMonitor and 
+      listCollections roles to the new user. 
+      Note: username, password, and similar user-specific values must be replaced.
+      
+      In the MongoDB shell, enter
+      > use admin
 
+      Use the following command to create the listCollections role:
+      > db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
+      
+      Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
+      > db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})
+
+install:
   version: "3"
   silent: true
 
   tasks:
     default:
       cmds:
-        - task: create_user_notification
+        - task: assert_pre_req
         - task: setup
         - task: restart
-        
-    create_user_notification:
-      cmds:
-        - |
-          echo "_ Note: These steps must be completed in order for the MongoDB integration to function properly.
-          In the MongoDB shell, enter use admin.
-          Use the following command to create the listCollections role.
-          db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
-          Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
-          db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})"
+
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
+
     setup:
       label: "Installing mongodb integration..."
       cmds:
@@ -101,7 +111,7 @@ install:
           if [ -f /etc/newrelic-infra/integrations.d/mongodb-config.yml ]; then
             sudo rm /etc/newrelic-infra/integrations.d/mongodb-config.yml;
           fi
-        - | 
+        - |
           if [ "{{.NR_CLI_SSL}}" == "y" ]; then
             if [ "{{.NR_CLI_SKIP_SSL_VERIFY}}" == "n" ]; then
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
@@ -164,6 +174,7 @@ install:
                 concurrent_collections: 50
           EOT
           fi
+
     restart:
       cmds:
         - sudo systemctl restart newrelic-infra.service

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -50,31 +50,35 @@ inputVars:
   - name: "NR_CLI_CERT_KEY"
     prompt: "PEM key file (if applicable)"
 
-install:
+preInstall:
+  info: |2
+      You'll need a user with READ permissions to 
+      collect data from this integration. If you'd like to create a new user 
+      please use these commands as reference:
 
+      Note: username, password, and similar user-specific values must be replaced.
+      
+      > CREATE USER newrelic WITH PASSWORD 'PASSWORD'
+      > GRANT SELECT ON pg_stat_database TO newrelic
+      > GRANT SELECT ON pg_stat_database_conflicts TO newrelic
+      > GRANT SELECT ON pg_stat_bgwriter TO newrelic
+
+install:
   version: "3"
   silent: true
 
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - taks: assert_pre_req
         - task: setup
-        
-    create_user_notification:
-      cmds:
-        - |
-          echo "Note: In order for this integration to function you need to either create or have an existing user with READ Permissions on pg_stat_database, pg_stat_database_conflicts and pg_stat_bgwriter.
-          If you\'d like to create a new user with these permissions please follow these steps within your PostgresSQL Instance:
-          CREATE USER newrelic WITH PASSWORD \'PASSWORD\'; GRANT SELECT ON pg_stat_database TO newrelic; GRANT SELECT ON pg_stat_database_conflicts TO newrelic; GRANT SELECT ON pg_stat_bgwriter TO newrelic;"
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 
@@ -132,5 +136,5 @@ install:
                 timeout: 10
           EOT
           fi
-         
+
         - sudo systemctl restart newrelic-infra.service

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -54,32 +54,35 @@ inputVars:
   - name: "NR_CLI_CERT_KEY"
     prompt: "PEM key file (if applicable)"
 
-install:
+preInstall:
+  info: |2
+      You'll need a user with READ permissions to 
+      collect data from this integration. If you'd like to create a new user 
+      please use these commands as reference:
 
+      Note: username, password, and similar user-specific values must be replaced.
+      
+      > CREATE USER newrelic WITH PASSWORD 'PASSWORD'
+      > GRANT SELECT ON pg_stat_database TO newrelic
+      > GRANT SELECT ON pg_stat_database_conflicts TO newrelic
+      > GRANT SELECT ON pg_stat_bgwriter TO newrelic
+
+install:
   version: "3"
   silent: true
 
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - taks: assert_pre_req
         - task: setup
-
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "Note: In order for this integration to function you need to either create or have an existing user with READ Permissions on pg_stat_database, pg_stat_database_conflicts and pg_stat_bgwriter.
-          If you\'d like to create a new user with these permissions please follow these steps within your PostgresSQL Instance:
-          CREATE USER newrelic WITH PASSWORD \'PASSWORD\'; GRANT SELECT ON pg_stat_database TO newrelic; GRANT SELECT ON pg_stat_database_conflicts TO newrelic; GRANT SELECT ON pg_stat_bgwriter TO newrelic;"
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 
@@ -137,5 +140,5 @@ install:
                 timeout: 10
           EOT
           fi
-         
+
         - sudo systemctl restart newrelic-infra.service

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -54,30 +54,28 @@ inputVars:
   - name: "NR_CLI_API_CA_BUNDLE_FILE"
     prompt: "SSL Certificate File (if applicable)"
 
+preInstall:
+  info: |2
+      To capture data from the RabbitMQ integration, you'll first need to meet these prerequisites:
+      - RabbitMQ Management Plugin is configured
+      - RabbitMQ command line tool, rabbitmqctl, is in the PATH of the root user.
+
 install:
   version: "3"
   silent: true
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: rabbitmq_plugin_installed
         - task: setup
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the RabbitMQ integration, you'll first need to meet these prerequisites:
-          - RabbitMQ Management Plugin is configured
-          - RabbitMQ command line tool, rabbitmqctl, is in the PATH of the root user."
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 
@@ -86,7 +84,7 @@ install:
         - |
           PLUGIN_EXIST=$(sudo cat /etc/rabbitmq/enabled_plugins | grep "rabbitmq_management" | wc -l)
           if [ $PLUGIN_EXIST -eq 0 ]; then
-            echo "The RabbitMQ Management plugin is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The RabbitMQ Management plugin is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -59,6 +59,12 @@ inputVars:
   - name: "NR_CLI_API_CA_BUNDLE_FILE"
     prompt: "SSL Certificate File (if applicable)"
 
+preInstall:
+  info: |2
+      To capture data from the RabbitMQ integration, you'll first need to meet these prerequisites:
+      - RabbitMQ Management Plugin is configured
+      - RabbitMQ command line tool, rabbitmqctl, is in the PATH of the root user.
+
 install:
   version: "3"
   silent: true
@@ -66,23 +72,16 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - taks: assert_pre_req
         - task: rabbitmq_plugin_installed
         - task: setup
 
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the RabbitMQ integration, you'll first need to meet these prerequisites:
-          - RabbitMQ Management Plugin is configured
-          - RabbitMQ command line tool, rabbitmqctl, is in the PATH of the root user."
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 
@@ -91,7 +90,7 @@ install:
         - |
           PLUGIN_EXIST=$(sudo cat /etc/rabbitmq/enabled_plugins | grep "rabbitmq_management" | wc -l)
           if [ $PLUGIN_EXIST -eq 0 ]; then
-            echo "The RabbitMQ Management plugin is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The RabbitMQ Management plugin is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -34,31 +34,30 @@ inputVars:
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
     prompt: "Location of varnish.params (omit to check defaults)"
 
+preInstall:
+  info: |2
+      To capture data from the Varnish Cache integration, the location of the varnish.params config file must be known.
+      
+      If the params_config_file input is empty, the following locations will automatically be checked:
+      - /etc/default/varnish/varnish.params
+      - /etc/sysconfig/varnish/varnish.params
+
 install:
   version: "3"
   silent: true
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
         - task: restart
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the Varnish Cache integration, the location of the varnish.params config file must be known.
-          If the params_config_file input is empty, the following locations will automatically be checked:
-          -   /etc/default/varnish/varnish.params
-          -   /etc/sysconfig/varnish/varnish.params"
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -40,6 +40,14 @@ inputVars:
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
     prompt: "Location of varnish.params (omit to check defaults)"
 
+preInstall:
+  info: |2
+      To capture data from the Varnish Cache integration, the location of the varnish.params config file must be known.
+      
+      If the params_config_file input is empty, the following locations will automatically be checked:
+      -  /etc/default/varnish/varnish.params
+      -  /etc/sysconfig/varnish/varnish.params
+
 install:
   version: "3"
   silent: true
@@ -47,25 +55,16 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_user_notification
         - task: assert_pre_req
         - task: setup
         - task: restart
-
-    create_user_notification:
-      cmds:
-        - |
-          echo "To capture data from the Varnish Cache integration, the location of the varnish.params config file must be known.
-          If the params_config_file input is empty, the following locations will automatically be checked:
-          -   /etc/default/varnish/varnish.params
-          -   /etc/sysconfig/varnish/varnish.params"
 
     assert_pre_req:
       cmds:
         - |
           SERVICE_EXIST=$(sudo systemctl status newrelic-infra.service | grep "Active" | wc -l)
           if [ $SERVICE_EXIST -eq 0 ]; then
-            echo "The newrelic-infra agent service is NOT installed on the host, but is required to install this integration." >> /dev/stderr
+            echo "The newrelic-infra agent service is not installed on the host, but is required to install this integration." >> /dev/stderr
             exit 1
           fi
 


### PR DESCRIPTION
Moves existing `create_user_notification` tasks to `preInstall:info`. Still need to add preInstall info to:

* apache
* cassandra
* couchbase
* elasticsearch
* jmx
* memcached
* nginx
* redis
* mssql

Those will be addressed in future PR.