### PR TITLE
chore(mongodb): add rs.initiate() to preInstall helper commands for mongodb

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -70,18 +70,21 @@ preInstall:
       To capture data from the MongoDB integration, you'll first need to meet these prerequisites:
       - MongoDB version requirement (see https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration#comp-req)
       - User with clusterMonitor and listCollections roles
-      
-      In the MongoDB shell, execute the following commands to create a 
-      listCollections role and a new user, then assign clusterMonitor and 
+
+      In the MongoDB shell, execute the following commands to create a
+      listCollections role and a new user, then assign clusterMonitor and
       listCollections roles to the new user.
       Note: username, password, and similar user-specific values must be replaced.
-      
-      In the MongoDB shell, enter
+
+      In the MongoDB shell run the following command
+      > rs.initiate()
+
+      Switch to the admin database
       > use admin
 
       Use the following command to create the listCollections role:
       > db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
-      
+
       Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
       > db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})
 
@@ -130,7 +133,7 @@ install:
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
 
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:
@@ -172,7 +175,7 @@ install:
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
 
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:
@@ -211,7 +214,7 @@ install:
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
 
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -63,18 +63,21 @@ preInstall:
       To capture data from the MongoDB integration, you'll first need to meet these prerequisites:
       - MongoDB version requirement (see https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration#comp-req)
       - User with clusterMonitor and listCollections roles
-      
-      In the MongoDB shell, execute the following commands to create a 
-      listCollections role and a new user, then assign clusterMonitor and 
+
+      In the MongoDB shell, execute the following commands to create a
+      listCollections role and a new user, then assign clusterMonitor and
       listCollections roles to the new user.
       Note: username, password, and similar user-specific values must be replaced.
-      
-      In the MongoDB shell, enter
+
+      In the MongoDB shell run the following commands
+      > rs.initiate()
+
+      Switch to the admin database
       > use admin
 
       Use the following command to create the listCollections role:
       > db.createRole({role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: []})
-      
+
       Use the following commands to create a new user, and assign clusterMonitor and listCollections roles to the user:
       > db.createUser({ user: "username", pwd: "password", roles: [ "clusterMonitor", "listCollections" ]})
 
@@ -122,7 +125,7 @@ install:
             if [ "{{.NR_CLI_SKIP_SSL_VERIFY}}" == "n" ]; then
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:
@@ -143,7 +146,7 @@ install:
             else
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:
@@ -163,7 +166,7 @@ install:
             else
               sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.mongodb
-          instances: 
+          instances:
             - name: all
               command: all
               arguments:


### PR DESCRIPTION
During the `preInstall` step, the user needs to run `rs.initiate()` from the `mongo` shell in order to execute the rest of the commands listed. 

If `rs.initiate()` is not run, the following error occurs when trying to run the suggested commands
```
> db.createRole({ role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: [] })

uncaught exception: Error: not master :
_getErrorWithCode@src/mongo/shell/utils.js:25:13
DB.prototype.createRole@src/mongo/shell/db.js:1675:15
@(shell):1:1
```