### PR TITLE
fix(processMatch): remove // from regex

### DIFF
--- a/examples/sample-linux-infrastructure.yaml
+++ b/examples/sample-linux-infrastructure.yaml
@@ -19,7 +19,7 @@ keywords:
   - Linux2
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/apm/go/linux.yml
+++ b/recipes/newrelic/apm/go/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - go
 
 processMatch:
-  - /go/
+  - go
 
 install:
 

--- a/recipes/newrelic/apm/go/windows.yml
+++ b/recipes/newrelic/apm/go/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - go
 
 processMatch:
-  - /go/
+  - go
 
 install:
 

--- a/recipes/newrelic/apm/java/linux.yml
+++ b/recipes/newrelic/apm/java/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - java
 
 processMatch:
-  - /java/
+  - java
 
 install:
 

--- a/recipes/newrelic/apm/java/windows.yml
+++ b/recipes/newrelic/apm/java/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - java
 
 processMatch:
-  - /java/
+  - java
 
 install:
 

--- a/recipes/newrelic/apm/php/linux.yml
+++ b/recipes/newrelic/apm/php/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - php
 
 processMatch:
-  - /php/
+  - php
 
 install:
 

--- a/recipes/newrelic/apm/python/linux.yml
+++ b/recipes/newrelic/apm/python/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - python
 
 processMatch:
-  - /python/
+  - python
 
 install:
 

--- a/recipes/newrelic/apm/python/windows.yml
+++ b/recipes/newrelic/apm/python/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - python
 
 processMatch:
-  - /python/
+  - python
 
 install:
 

--- a/recipes/newrelic/apm/ruby/linux.yml
+++ b/recipes/newrelic/apm/ruby/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - ruby
 
 processMatch:
-  - /ruby/
+  - ruby
 
 install:
 

--- a/recipes/newrelic/apm/ruby/windows.yml
+++ b/recipes/newrelic/apm/ruby/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - ruby
 
 processMatch:
-  - /ruby/
+  - ruby
 
 install:
 

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -19,7 +19,7 @@ keywords:
   - Linux2
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -18,8 +18,7 @@ keywords:
   - Amazon Linux 2
   - Linux2
 
-processMatch:
-  - infra
+processMatch: []
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -32,8 +32,7 @@ keywords:
   - RHEL 7
   - RHEL 8
 
-processMatch:
-  - infra
+processMatch: []
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -33,7 +33,7 @@ keywords:
   - RHEL 8
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}%' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -20,8 +20,7 @@ keywords:
   - Stretch
   - Buster
 
-processMatch:
-  - infra
+processMatch: []
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -21,7 +21,7 @@ keywords:
   - Buster
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -14,7 +14,7 @@ keywords:
   - Logs
 
 processMatch:
-  - /logs/
+  - logs
 
 validationNrql: "SELECT count(*) from Log where hostname like '{{.HOSTNAME}}%' FACET entity.guids SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -13,8 +13,7 @@ installTargets:
 keywords:
   - Logs
 
-processMatch:
-  - logs
+processMatch: []
 
 validationNrql: "SELECT count(*) from Log where hostname like '{{.HOSTNAME}}%' FACET entity.guids SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/ohi/flex/flex.yml
+++ b/recipes/newrelic/infrastructure/ohi/flex/flex.yml
@@ -13,8 +13,7 @@ installTargets:
 keywords:
   - Flex
 
-processMatch:
-  - /logs/
+processMatch: []
 
 install:
   version: "3"

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -19,7 +19,7 @@ keywords:
   - SLES
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -18,8 +18,7 @@ keywords:
   - Suse
   - SLES
 
-processMatch:
-  - infra
+processMatch: []
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -22,8 +22,7 @@ keywords:
   - Bionic
   - Focal
 
-processMatch:
-  - infra
+processMatch: []
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -23,7 +23,7 @@ keywords:
   - Focal
 
 processMatch:
-  - /infra/
+  - infra
 
 validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
 


### PR DESCRIPTION
Without this change, the regex for several recipes are wrapped in slashes.  The
strings are taken directly as a regex, and don't need the slashes.  Here we
remove those slashes to avoid trying to incorrectly match the processes.