### PR TITLE
Adding debian platform for logs

### DIFF
--- a/recipes/newrelic/infrastructure/logs/debian-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/debian-logs.yml
@@ -9,6 +9,9 @@ repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/
 installTargets:
   - type: host
     os: linux
+    platform: "debian"
+  - type: host
+    os: linux
     platform: "ubuntu"
 
 keywords:


### PR DESCRIPTION
It turns out, those special logs are also needed for Debian linux, I just tested on debian 10 and I don't see a /var/log/secure and see a /var/log/auth.log as well as a /var/log/alternatives.log