### PR TITLE
Fix ubuntu installs for oldest version of ubuntu (<=14.04)

### DIFF
--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -62,7 +62,7 @@ install:
         - sudo apt-get install newrelic-infra -y -qq
       vars:
         UBUNTU_CODENAME:
-          sh: cat /etc/os-release | grep VERSION_CODENAME | awk -F = '{print $2}'
+          sh: cat /etc/lsb-release | grep DISTRIB_CODENAME | awk -F = '{print $2}'
       silent: true
 
     restart:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -57,10 +57,7 @@ install:
     install_infra:
       cmds:
         - sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
-        - |
-          if [ -f /etc/apt/sources.list.d/newrelic-infra.list ]; then
-            sudo rm /etc/apt/sources.list.d/newrelic-infra.list;
-          fi
+        - sudo rm -f /etc/apt/sources.list.d/newrelic-infra.list
         - printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.UBUNTU_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
         - sudo apt-get update -qq
         - sudo apt-get install newrelic-infra -y -qq

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -58,11 +58,11 @@ install:
       cmds:
         - sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
         - sudo rm -f /etc/apt/sources.list.d/newrelic-infra.list
-        - printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.UBUNTU_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+        - printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DISTRIB_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
         - sudo apt-get update -qq
         - sudo apt-get install newrelic-infra -y -qq
       vars:
-        UBUNTU_CODENAME:
+        DISTRIB_CODENAME:
           sh: cat /etc/lsb-release | grep DISTRIB_CODENAME | awk -F = '{print $2}'
       silent: true
 

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -57,6 +57,10 @@ install:
     install_infra:
       cmds:
         - sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+        - |
+          if [ -f /etc/apt/sources.list.d/newrelic-infra.list ]; then
+            sudo rm /etc/apt/sources.list.d/newrelic-infra.list;
+          fi
         - printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.UBUNTU_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
         - sudo apt-get update -qq
         - sudo apt-get install newrelic-infra -y -qq

--- a/test/definitions/infra-agent/ubuntu14-infra.json
+++ b/test/definitions/infra-agent/ubuntu14-infra.json
@@ -1,0 +1,45 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+        "id": "host1",
+        "display_name": "Ubuntu14InfraHost",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.nano",
+        "ami_name": "SupportedImages ubuntu-trusty-14.04-amd64-server*",
+        "user_name": "ubuntu"
+    }],
+
+    "instrumentations": {
+        "resources": [
+          {
+              "id": "nr_infra",
+              "resource_ids": ["host1"],
+              "provider": "newrelic",
+              "source_repository": "https://github.com/newrelic/open-install-library",
+              "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+              "params": {
+                  "recipe_content_url": [
+                      "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml"
+                  ]
+              }
+          },
+          {
+              "id": "nr_infra_is_having_data",
+              "resource_ids": ["host1"],
+              "provider": "newrelic",
+              "source_repository": "https://github.com/newrelic/open-install-library",
+              "deploy_script_path": "test/deploy/assertions/recipe-is-valid/roles",
+              "params": {
+                  "recipe_validation_nrql_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml"
+              }
+          }
+          ]
+      }
+}


### PR DESCRIPTION
This change works on the recent ubuntu and older versions

[ubuntu18.log](https://github.com/newrelic/open-install-library/files/6111946/ubuntu18.log)
[ubuntu14.log](https://github.com/newrelic/open-install-library/files/6111948/ubuntu14.log)
