### PR TITLE
Update infra service dependency

### DIFF
--- a/recipes/newrelic/infrastructure/logs/docker-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/docker-logs.yml
@@ -37,7 +37,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       cmds:

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -34,7 +34,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -126,7 +126,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -61,7 +61,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           STUB_STATUS_ENABLED=$(curl {{.NR_CLI_STATUS_URL}} -s | grep "IdleWorkers:" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -63,7 +63,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           STUB_STATUS_ENABLED=$(curl {{.NR_CLI_STATUS_URL}} -s | grep "IdleWorkers:" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -113,7 +113,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -68,7 +68,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Cassandra integration..."

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -72,7 +72,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Cassandra integration..."

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -69,7 +69,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing HashiCorp Consul integration..."

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -153,7 +153,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -70,7 +70,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing HashiCorp Consul integration..."

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -66,6 +66,7 @@ install:
       cmds:
         - task: assert_pre_req
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -123,7 +124,14 @@ install:
           EOT
           fi
 
-        - sudo systemctl restart newrelic-infra.service
+    restart:
+      cmds:
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -70,7 +70,12 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
+
     setup:
       label: "Installing Couchbase integration..."
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -75,7 +75,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Couchbase integration..."

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -65,6 +65,7 @@ install:
       cmds:
         - taks: assert_pre_req
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -137,7 +138,14 @@ install:
           EOT
           fi
 
-        - sudo systemctl restart newrelic-infra.service
+    restart:
+      cmds:
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -69,7 +69,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Elasticsearch integration..."

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -73,7 +73,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Elasticsearch integration..."

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -66,7 +66,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Elasticsearch integration..."

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -54,6 +54,7 @@ install:
       cmds:
         - task: assert_pre_req
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -96,8 +97,15 @@ install:
                 password: {{.NR_CLI_PASSWORD}}
                 cluster_name: {{.NR_CLI_CLUSTER_NAME}}
           EOT
+
+    restart:
+      cmds:
         - |
-          sudo systemctl restart newrelic-infra.service
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -58,7 +58,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing HAProxy integration..."

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -62,7 +62,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing HAProxy integration..."

--- a/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
@@ -78,7 +78,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing JMX integration..."

--- a/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
@@ -207,7 +207,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/jmx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/jmx/rhel.yml
@@ -82,7 +82,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing JMX integration..."

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -69,7 +69,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Memcached integration..."

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -129,7 +129,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
@@ -66,7 +66,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Memcached integration..."

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -102,7 +102,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           MONGODB_EXISTS=$(mongo --eval 'db.runCommand({ connectionStatus: 1 })' | grep "ok" | awk '{print $1 $2 $3}')
           if [ $MONGODB_EXISTS != "ok:1"]; then

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -252,7 +252,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -95,7 +95,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           MONGODB_EXISTS=$(mongo --eval 'db.runCommand({ connectionStatus: 1 })' | grep "ok" | awk '{print $1 $2 $3}')
           if [ $MONGODB_EXISTS != "ok:1"]; then

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -82,7 +82,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -133,7 +133,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -82,7 +82,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -79,7 +79,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -101,9 +101,15 @@ install:
           EOT
         - |
           sudo chmod 0600 /etc/newrelic-infra/integrations.d/service_checks.yml
+
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -50,7 +50,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -48,7 +48,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -59,7 +59,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           STUB_STATUS_ENABLED=$(curl {{.NR_CLI_STUB_STATUS_URL}} -s | grep "Active connections:" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -55,6 +55,7 @@ install:
       cmds:
         - task: assert_pre_req
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -128,8 +129,15 @@ install:
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
                 status_url: {{.NR_CLI_STUB_STATUS_URL}}
           EOT
+
+    restart:
+      cmds:
         - |
-          sudo systemctl restart newrelic-infra.service
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -63,7 +63,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           STUB_STATUS_ENABLED=$(curl {{.NR_CLI_STUB_STATUS_URL}} -s | grep "Active connections:" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -56,7 +56,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
         - |
           STUB_STATUS_ENABLED=$(curl {{.NR_CLI_STUB_STATUS_URL}} -s | grep "Active connections:" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -77,7 +77,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing PostgreSQL integration..."

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -73,6 +73,7 @@ install:
       cmds:
         - taks: assert_pre_req
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -138,7 +139,14 @@ install:
           EOT
           fi
 
-        - sudo systemctl restart newrelic-infra.service
+    restart:
+      cmds:
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -81,7 +81,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing PostgreSQL integration..."

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -70,6 +70,7 @@ install:
         - task: assert_pre_req
         - task: rabbitmq_plugin_installed
         - task: setup
+        - task: restart
 
     assert_pre_req:
       cmds:
@@ -146,7 +147,15 @@ install:
                 vhosts_regexes:
           EOT
           fi
-        - sudo systemctl restart newrelic-infra.service
+
+    restart:
+      cmds:
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -74,7 +74,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     rabbitmq_plugin_installed:
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -80,7 +80,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     rabbitmq_plugin_installed:
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -68,7 +68,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Redis integration..."

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -139,7 +139,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -72,7 +72,12 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
+
     setup:
       label: "Installing Redis integration..."
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -57,7 +57,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Varnish Cache integration..."

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -100,7 +100,12 @@ install:
 
     restart:
       cmds:
-        - sudo systemctl restart newrelic-infra.service
+        - |
+          if [ -f /etc/init.d/newrelic-infra ]; then
+            sudo /etc/init.d/newrelic-infra restart > /dev/null;
+          else
+            sudo systemctl restart newrelic-infra.service
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -64,7 +64,11 @@ install:
     assert_pre_req:
       cmds:
         - |
-          sudo systemctl is-active --quiet newrelic-infra || (echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr; exit 1)
+          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/new-relic-guided-installation-overview" >> /dev/stderr
+            exit 1
+          fi
 
     setup:
       label: "Installing Varnish Cache integration..."


### PR DESCRIPTION
Detect if infra agent service is started by detecting the process, to be compatible with all linux versions.
Update Debian recipe to restart the infra agent service through init.d if it exists (older ubuntu).