### PR TITLE
Linux2 apache aspnetcore

### DIFF
--- a/test/deploy/linux/.net/install/rhel/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/.net/install/rhel/roles/prepare/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- debug:
+    msg: Install ASP.NET Core 5.0 Runtime
+
+- name: Add Microsoft package signing key and add Microsoft package repository
+  shell: rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+  become: true
+
+- name: Update packages
+  shell: yum update -y
+  become: true
+
+- name: Install ASP.NET Core 5.0 Runtime
+  shell: yum install aspnetcore-runtime-5.0 -y
+  become: true

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/tasks/main.yml
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- debug:
+    msg: Install .NET App
+
+- name: Set default is_selfcontained (default to false)
+  set_fact:
+    is_selfcontained: "false"
+  when: is_selfcontained is undefined
+
+- name: Set default download url for self contained web app
+  set_fact:
+    web_app_url: "https://virtuoso-testing.s3-us-west-2.amazonaws.com/selfcontained-net5webapplication.zip"
+  when: web_app_url is undefined and (is_selfcontained|bool)
+
+- name: Set default download url for framwork dependent web app
+  set_fact:
+    web_app_url: "https://virtuoso-testing.s3-us-west-2.amazonaws.com/frameworkdependent-net5webapplication.zip"
+  when: web_app_url is undefined and (is_selfcontained|bool == False)
+
+- name: Update packages
+  shell: yum update -y
+  become: true
+
+- name: Install depends
+  shell: yum install libicu unzip -y
+  become: true
+
+- name: Copy web app selfcontained-net5webapplication file
+  template:
+    src: selfcontained-net5webapplication.service
+    dest: /etc/systemd/system/selfcontained-net5webapplication.service
+  when: is_selfcontained|bool
+  become: true
+
+- name: Copy web app frameworkdependent-net5webapplication file
+  template:
+    src: frameworkdependent-net5webapplication.service
+    dest: /etc/systemd/system/frameworkdependent-net5webapplication.service
+  when: is_selfcontained|bool == False
+  become: true
+
+- name: Install and start web app
+  shell: |
+    mkdir ~/{{ service_id }}
+    cd ~/{{ service_id }}
+    url="{{ web_app_url }}"
+    curl $url -O
+    zip=$(find . -name "*.zip")
+    name=$(basename $zip .zip)
+    mkdir -p /var/www/$name
+    unzip ./$zip -d /var/www/$name
+    chmod -R 777 /var/www/$name
+    chown -R apache:apache /var/www/$name
+    systemctl daemon-reload
+    systemctl start $name.service
+    echo 'Listen {{ service_port }}' >> /etc/httpd/conf/httpd.conf
+  become: true
+
+- name: Copy apache server selfcontained-net5webapplication status file
+  template:
+    src: selfcontained-net5webapplication.conf
+    dest: /etc/httpd/conf.d/selfcontained-net5webapplication.conf
+  when: is_selfcontained|bool
+  become: true
+
+- name: Copy apache server frameworkdependent-net5webapplication status file
+  template:
+    src: frameworkdependent-net5webapplication.conf
+    dest: /etc/httpd/conf.d/frameworkdependent-net5webapplication.conf
+  when: is_selfcontained|bool == False
+  become: true

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/frameworkdependent-net5webapplication.conf
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/frameworkdependent-net5webapplication.conf
@@ -1,0 +1,8 @@
+# frameworkdependent-net5webapplication
+<VirtualHost *:8081>
+    ProxyPreserveHost On
+    ProxyPass / http://localhost:5001/ retry=0
+    ProxyPassReverse / http://localhost:5001/ retry=0
+    ErrorLog /tmp/frameworkdependent-net5webapplication-error.log
+    CustomLog /tmp/frameworkdependent-net5webapplication-access.log common
+</VirtualHost>

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/frameworkdependent-net5webapplication.service
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/frameworkdependent-net5webapplication.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Framework Dependent .NET 5 APP.NET Core 5 Web app
+
+[Service]
+WorkingDirectory=/var/www/frameworkdependent-net5webapplication/
+ExecStart=/usr/bin/dotnet /var/www/frameworkdependent-net5webapplication/net5webapplication.dll --urls=http://localhost:5001/
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+SyslogIdentifier=frameworkdependent-net5webapplication
+User=apache
+Environment=ASPNETCORE_ENVIRONMENT=Production
+
+[Install]
+WantedBy=multi-user.target

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/selfcontained-net5webapplication.conf
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/selfcontained-net5webapplication.conf
@@ -1,0 +1,8 @@
+# selfcontained-net5webapplication
+<VirtualHost *:8080>
+    ProxyPreserveHost On
+    ProxyPass / http://localhost:5000/ retry=0
+    ProxyPassReverse / http://localhost:5000/ retry=0
+    ErrorLog /tmp/selfcontained-net5webapplication-error.log
+    CustomLog /tmp/selfcontained-net5webapplication-access.log common
+</VirtualHost>

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/selfcontained-net5webapplication.service
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/onbeforestart/templates/selfcontained-net5webapplication.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Self Contained .NET 5 APP.NET Core 5 Web app
+
+[Service]
+WorkingDirectory=/var/www/selfcontained-net5webapplication/
+ExecStart=/var/www/selfcontained-net5webapplication/net5webapplication --urls=http://localhost:5000/
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+SyslogIdentifier=selfcontained-net5webapplication
+User=apache
+Environment=ASPNETCORE_ENVIRONMENT=Production
+
+[Install]
+WantedBy=multi-user.target

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/start/tasks/main.yml
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/start/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- debug:
+    msg: Finish setting up Apache
+
+- name: Copy apache server reverse-proxy status file
+  template:
+    src: reverse-proxy.conf
+    dest: /etc/httpd/conf.d/reverse-proxy.conf
+  become: true
+
+- name: Restart Apache
+  shell: |
+    systemctl restart httpd
+  become: true

--- a/test/deploy/linux/apache/deploy-application/.net/rhel/roles/start/templates/reverse-proxy.conf
+++ b/test/deploy/linux/apache/deploy-application/.net/rhel/roles/start/templates/reverse-proxy.conf
@@ -1,0 +1,3 @@
+<VirtualHost *:*>
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+</VirtualHost>

--- a/test/manual/definitions/apm/.net/linux/linux2-aspnetcore5.json
+++ b/test/manual/definitions/apm/.net/linux/linux2-aspnetcore5.json
@@ -1,0 +1,51 @@
+{
+  "global_tags": {
+    "owning_team": "OpenSource",
+    "Environment": "development",
+    "Department": "Product",
+    "Product": "Virtuoso"
+  },
+
+  "resources": [{
+    "id": "host1",
+    "display_name": "AwsLinux2ASPNETCore",
+    "provider": "aws",
+    "type": "ec2",
+    "size": "t3.nano",
+    "ami_name": "amazonlinux-2-base*",
+    "user_name": "ec2-user"
+  }],
+
+  "services": [{
+    "id": "aspnetcore",
+    "destinations": ["host1"],
+    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "deploy_script_path": "test/deploy/linux/.net/install/rhel/roles",
+    "port": 9998
+    },
+    {
+    "id": "apache1",
+    "destinations": ["host1"],
+    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "deploy_script_path": "test/deploy/linux/apache/install/rhel/roles",
+    "port": 9999
+  },
+  {
+    "id": "dotnet1",
+    "destinations": ["host1"],
+    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "deploy_script_path": "test/deploy/linux/apache/deploy-application/.net/rhel/roles",
+    "port": 8080,
+    "params": {
+      "is_selfcontained": "true"
+    }
+  },
+  {
+    "id": "dotnet2",
+    "destinations": ["host1"],
+    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "deploy_script_path": "test/deploy/linux/apache/deploy-application/.net/rhel/roles",
+    "port": 8081
+  }]
+
+}

--- a/test/manual/definitions/apm/.net/linux/linux2-aspnetcore5.json
+++ b/test/manual/definitions/apm/.net/linux/linux2-aspnetcore5.json
@@ -19,21 +19,21 @@
   "services": [{
     "id": "aspnetcore",
     "destinations": ["host1"],
-    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "source_repository": "https://github.com/newrelic/open-install-library.git",
     "deploy_script_path": "test/deploy/linux/.net/install/rhel/roles",
     "port": 9998
     },
     {
     "id": "apache1",
     "destinations": ["host1"],
-    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "source_repository": "https://github.com/newrelic/open-install-library.git",
     "deploy_script_path": "test/deploy/linux/apache/install/rhel/roles",
     "port": 9999
   },
   {
     "id": "dotnet1",
     "destinations": ["host1"],
-    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "source_repository": "https://github.com/newrelic/open-install-library.git",
     "deploy_script_path": "test/deploy/linux/apache/deploy-application/.net/rhel/roles",
     "port": 8080,
     "params": {
@@ -43,7 +43,7 @@
   {
     "id": "dotnet2",
     "destinations": ["host1"],
-    "source_repository": "https://github.com/jaffinito/open-install-library.git",
+    "source_repository": "https://github.com/newrelic/open-install-library.git",
     "deploy_script_path": "test/deploy/linux/apache/deploy-application/.net/rhel/roles",
     "port": 8081
   }]


### PR DESCRIPTION
- Adds Amazon Linux 2 def with ASP.NET Core and Apache
- Adds new deploy-application section for Apache and RHEL
- deploy-application contains 2 apps, one self contained and one framework dependent
- Both install services and apache confs
- Self contained just runs the executable directly
- Framework dependent uses the dotnet commend to run the DLL

**Note**: The two new apps live in a different S3 than the other apps.  They will need to be moved over at some point and the scripting updated.