### PR TITLE
Remove regex encoding on windows process match

### DIFF
--- a/recipes/newrelic/apm/dotNet/windows/net-install.yml
+++ b/recipes/newrelic/apm/dotNet/windows/net-install.yml
@@ -18,7 +18,7 @@ keywords:
   - core
 
 processMatch:
-  - w3wp\.exe
+  - w3wp.exe
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 

--- a/recipes/newrelic/apm/java/windows.yml
+++ b/recipes/newrelic/apm/java/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - java
 
 processMatch:
-  - java\.exe
+  - java.exe
 
 install:
 

--- a/recipes/newrelic/apm/node/windows.yml
+++ b/recipes/newrelic/apm/node/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - node
 
 processMatch:
-  - node\.exe
+  - node.exe
 
 install:
   version: "3"

--- a/recipes/newrelic/apm/python/windows.yml
+++ b/recipes/newrelic/apm/python/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - python
 
 processMatch:
-  - python\.exe
+  - python.exe
 
 install:
 

--- a/recipes/newrelic/apm/ruby/windows.yml
+++ b/recipes/newrelic/apm/ruby/windows.yml
@@ -14,7 +14,7 @@ keywords:
   - ruby
 
 processMatch:
-  - ruby\.exe
+  - ruby.exe
 
 install:
 


### PR DESCRIPTION
This PR removes the regex encoding from the Windows processMatch values.  This change is a temporary change to get know process to match for Windows.  At the moment when the CLI validates that a recipe with the Recipe Service (using a GraphQL call) there is a problem with encoding the slashes.  This could be an issue with the CLI or with the Recipe Service.

@michaelkro and @Julien4218 looked into this issue and figured this was the easiest/quickest way to handle this issue.  Longer term we should improve how the CLI/Recipe service handle encoding to allow for proper regex expressions in the processMatch field.