### PR TITLE
Wrap application.RemoveAll() in if to check for child nodes

### DIFF
--- a/recipes/newrelic/apm/dotNet/windows/net-install.yml
+++ b/recipes/newrelic/apm/dotNet/windows/net-install.yml
@@ -81,7 +81,9 @@ install:
           $xdoc = New-Object System.Xml.XmlDocument;
           $xdoc.PreserveWhitespace = $true;
           $xdoc.Load($file);
-          $xdoc.configuration.application.RemoveAll();
+          if ($xdoc.GetElementsByTagName("application")[0].HasChildNodes){
+            $xdoc.configuration.application.RemoveAll();
+          }
           if ("{{.NEW_RELIC_REGION}}" -like "STAGING"){
             $xdoc.configuration.service.SetAttribute("host", "staging-collector.newrelic.com")
           }


### PR DESCRIPTION
Fixes the following error by checking if the `application` element has any children and skip if it doesn't:
```
Method invocation failed because [System.String] does not contain a method named 'RemoveAll'.
At line:7 char:1
+ $xdoc.configuration.application.RemoveAll();
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : MethodNotFound
```
