### PR TITLE
fix(docker-logs): build discovered logs config file using a bash array to fix "-" executable error

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -144,3 +144,4 @@ postInstall:
       https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
       
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -172,3 +172,4 @@ postInstall:
       https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
       
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -185,3 +185,4 @@ postInstall:
       https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
       
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+

--- a/recipes/newrelic/infrastructure/logs/debian-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/debian-logs.yml
@@ -109,7 +109,7 @@ install:
           echo -e "verbose: 3\nlog_format: json" | sudo tee -a /etc/newrelic-infra.yml > /dev/null
           sudo sed -i '/^$/d' /etc/newrelic-infra.yml
         - |
-          logFiles=$(echo -n {{.LOG_FILES}})
+          logFiles=$(echo -n "{{.LOG_FILES}}")
           logsStringLength=${#logFiles}
 
           # Keep a count of the valid log files the integration will use.
@@ -138,17 +138,17 @@ install:
             exit 16
           fi
 
-          # Build the discovered.yml logs config file used for Docker logs
-          IFS=', ' read -r discoveredLogFilesArray <<< "$discoveredLogFiles"
+          # Disable glob expansion (necessary for discovered logs)
+          set -f
 
+          # index is incremented to facilitate dynamic name values for each discovered log file path
+          index=0
           if [ $discoveredLogsStringLength -gt 0 ]; then
             echo "logs:" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
 
-            for filePath in "${discoveredLogFilesArray[@]}"
-            do
-              if [ -f $filePath ]; then
-                echo -e "  - name: docker log\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
-              fi
+            for filePath in $(echo -n $discoveredLogFiles | sed "s/,/ /g"); do
+              echo -e "  - name: configured-logs-$index\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+              index=$((index+1))
             done
           fi
 

--- a/recipes/newrelic/infrastructure/logs/debian-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/debian-logs.yml
@@ -84,7 +84,7 @@ install:
         - |
           # First check on empty inputs
           logFiles=$(echo -n {{.LOG_FILES}})
-          discoveredLogFiles=$(echo -n {{.DISCOVERED_LOG_FILES}})
+          discoveredLogFiles=$(echo -n {{.NR_DISCOVERED_LOG_FILES}})
           logsStringLength=${#logFiles}
           discoveredLogsStringLength=${#discoveredLogFiles}
           if [ $logsStringLength -eq 0 ] && { [ $discoveredLogsStringLength -eq 0 ] || [ "$discoveredLogFiles" = "logs: []" ]; }; then
@@ -111,8 +111,6 @@ install:
         - |
           logFiles=$(echo -n {{.LOG_FILES}})
           logsStringLength=${#logFiles}
-          discoveredLogFiles=$(echo -n {{.DISCOVERED_LOG_FILES}})
-          discoveredLogsStringLength=${#discoveredLogFiles}
 
           # Keep a count of the valid log files the integration will use.
           foundLogFilesCount=0
@@ -130,6 +128,9 @@ install:
             done
           fi
 
+          discoveredLogFiles=$(echo -n "{{.NR_DISCOVERED_LOG_FILES | trim}}")
+          discoveredLogsStringLength=${#discoveredLogFiles}
+
           # If the user provides log files that don't exist and we haven't discovered any log files,
           # we cannot proceed with the installation.
           if [ $foundLogFilesCount -eq 0 ] && { [ $discoveredLogsStringLength -eq 0 ] || [ "$discoveredLogFiles" = "logs: []" ]; }; then
@@ -137,8 +138,18 @@ install:
             exit 16
           fi
 
+          # Build the discovered.yml logs config file used for Docker logs
+          IFS=', ' read -r discoveredLogFilesArray <<< "$discoveredLogFiles"
+
           if [ $discoveredLogsStringLength -gt 0 ]; then
-            echo -e "{{.DISCOVERED_LOG_FILES}}" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+            echo "logs:" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+
+            for filePath in "${discoveredLogFilesArray[@]}"
+            do
+              if [ -f $filePath ]; then
+                echo -e "  - name: docker log\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+              fi
+            done
           fi
 
     restart:

--- a/recipes/newrelic/infrastructure/logs/docker-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/docker-logs.yml
@@ -20,7 +20,7 @@ processMatch:
 # https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent#parameters
 logMatch:
   - name: docker log
-    file: /var/lib/docker/containers/*/*.log
+    file: "/var/lib/docker/containers/*/*.log"
 
 validationNrql: "SELECT count(*) from Log where hostname like '{{.HOSTNAME}}%' FACET entity.guids SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -79,8 +79,8 @@ install:
           fi
         - |
           # First check on empty inputs
-          logFiles=$(echo -n {{.LOG_FILES}})
-          discoveredLogFiles=$(echo -n {{.DISCOVERED_LOG_FILES}})
+          logFiles=$(echo -n "{{.LOG_FILES}}")
+          discoveredLogFiles=$(echo -n "{{.DISCOVERED_LOG_FILES}}")
           logsStringLength=${#logFiles}
           discoveredLogsStringLength=${#discoveredLogFiles}
           if [ $logsStringLength -eq 0 ] && { [ $discoveredLogsStringLength -eq 0 ] || [ "$discoveredLogFiles" = "logs: []" ]; }; then
@@ -105,10 +105,8 @@ install:
           echo -e "verbose: 3\nlog_format: json" | sudo tee -a /etc/newrelic-infra.yml > /dev/null
           sudo sed -i '/^$/d' /etc/newrelic-infra.yml
         - |
-          logFiles=$(echo -n {{.LOG_FILES}})
+          logFiles=$(echo -n "{{.LOG_FILES}}")
           logsStringLength=${#logFiles}
-          discoveredLogFiles=$(echo -n {{.DISCOVERED_LOG_FILES}})
-          discoveredLogsStringLength=${#discoveredLogFiles}
 
           # Keep a count of the valid log files the integration will use.
           foundLogFilesCount=0
@@ -126,6 +124,9 @@ install:
             done
           fi
 
+          discoveredLogFiles=$(echo -n "{{.DISCOVERED_LOG_FILES | trim}}")
+          discoveredLogsStringLength=${#discoveredLogFiles}
+
           # If the user provides log files that don't exist and we haven't discovered any log files,
           # we cannot proceed with the installation.
           if [ $foundLogFilesCount -eq 0 ] && { [ $discoveredLogsStringLength -eq 0 ] || [ "$discoveredLogFiles" = "logs: []" ]; }; then
@@ -133,8 +134,18 @@ install:
             exit 16
           fi
 
+          # Build the discovered.yml logs config file used for Docker logs
+          IFS=', ' read -r discoveredLogFilesArray <<< "$discoveredLogFiles"
+
           if [ $discoveredLogsStringLength -gt 0 ]; then
-            echo -e "{{.DISCOVERED_LOG_FILES}}" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+            echo "logs:" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+
+            for filePath in "${discoveredLogFilesArray[@]}"
+            do
+              if [ -f $filePath ]; then
+                echo -e "  - name: docker log\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+              fi
+            done
           fi
 
     restart:

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -124,7 +124,7 @@ install:
             done
           fi
 
-          discoveredLogFiles=$(echo -n "{{.DISCOVERED_LOG_FILES | trim}}")
+          discoveredLogFiles=$(echo -n "{{.NR_DISCOVERED_LOG_FILES | trim}}")
           discoveredLogsStringLength=${#discoveredLogFiles}
 
           # If the user provides log files that don't exist and we haven't discovered any log files,
@@ -134,17 +134,17 @@ install:
             exit 16
           fi
 
-          # Build the discovered.yml logs config file used for Docker logs
-          IFS=', ' read -r discoveredLogFilesArray <<< "$discoveredLogFiles"
+          # Disable glob expansion (necessary for discovered logs)
+          set -f
 
+          # index is incremented to facilitate dynamic name values for each discovered log file path
+          index=0
           if [ $discoveredLogsStringLength -gt 0 ]; then
             echo "logs:" | sudo tee /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
 
-            for filePath in "${discoveredLogFilesArray[@]}"
-            do
-              if [ -f $filePath ]; then
-                echo -e "  - name: docker log\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
-              fi
+            for filePath in $(echo -n $discoveredLogFiles | sed "s/,/ /g"); do
+              echo -e "  - name: configured-logs-$index\n    file: $filePath" | sudo tee -a /etc/newrelic-infra/logging.d/discovered.yml > /dev/null
+              index=$((index+1))
             done
           fi
 

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -80,7 +80,7 @@ install:
         - |
           # First check on empty inputs
           logFiles=$(echo -n "{{.LOG_FILES}}")
-          discoveredLogFiles=$(echo -n "{{.DISCOVERED_LOG_FILES}}")
+          discoveredLogFiles=$(echo -n "{{.NR_DISCOVERED_LOG_FILES}}")
           logsStringLength=${#logFiles}
           discoveredLogsStringLength=${#discoveredLogFiles}
           if [ $logsStringLength -eq 0 ] && { [ $discoveredLogsStringLength -eq 0 ] || [ "$discoveredLogFiles" = "logs: []" ]; }; then

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -160,3 +160,4 @@ postInstall:
       https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
       
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -173,3 +173,4 @@ postInstall:
       https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
       
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -59,3 +59,4 @@ postInstall:
       Infrastructure Agent: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings
 
       Note: Process monitoring has been enabled by default - all other config options are left to the user.
+


### PR DESCRIPTION
The underlying `sh` library used by `go-task` has some subtle differences from a native shell. Glob paths such as `/var/lib/docker/containers/*/*.log` will be expanded to the full file path such as `/var/lib/docker/containers/9483459940/9483459940.log` when trying to use with `echo`. When we try to build the discovered.yml file, we need the glob path and using a bash array avoids using `echo` and keeps the glob path intact.

This will require an update in the CLI as well since we also can't inject a multiple string into the `discoveredLogFiles` bash variable because it causes the `sh` interpreter to silently error.

Depends on: [newrelic/newrelic-cli #792](https://github.com/newrelic/newrelic-cli/pull/792)