### PR TITLE
fix(Infra Ubuntu/Debian): Remove append flag when adding to sources list to avoid malformed source(s)

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -137,9 +137,9 @@ install:
           sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
         - |
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
-            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           else
-            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           fi
         - |
           sudo apt-get update -yq

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -124,9 +124,9 @@ install:
           sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
         - |
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
-            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           else
-            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | sudo tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           fi
         - |
           sudo apt-get update -yq


### PR DESCRIPTION
Our docs say to utilize `sudo tee -a`, repeat runs of this end up creating malformed source entries