### PR TITLE
feat(schema): add support for stability, dependencies, and quickstarts

### DIFF
--- a/docs/recipe-spec/recipe-spec.md
+++ b/docs/recipe-spec/recipe-spec.md
@@ -34,6 +34,35 @@ description: string, required
 # Example: https://github.com/newrelic/infrastructure-agent
 repository: string, required
 
+# Indicates stability level of recipe. Useful for gradually enabling the
+# availablity of a recipe to users as it is developed and tested. Can be
+# thought of as an indicator for how stable/ready a recipe is for general 
+# consumption and can be used to quickly disable problematic recipes.
+# 
+# Usage: # newrelic install --stability=stable
+# 
+# Levels:
+#   disabled - No availability (recipe will not return from NerdGraph)
+#   experimental - Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments.
+#   stable - General availability - ongoing support and compatability is a high priority
+stability: enum, optional # One of [ disabled, experimental, stable ]
+
+# Dependency list for recipes (by name) that must be run successfully prior to attempting
+# the current recipe
+# ex: 
+# dependencies:
+#   - infrastructure-agent-installer
+dependencies: list, optional
+
+# Metadata used to recommend and install Quickstarts (dashboards, alerts, synthetics, etc.)
+# This is filtering criteria for the quickstartSearch endpoint in NerdGraph
+quickstarts: list (object), optional
+  - name: string, required
+    entities: object, optional
+      type: string, required
+      domain: string, required
+    category: string (enum), optional # One of [ newrelic, community ]. Defaults to newrelic.
+
 # Still TBD
 # Indicates the target host/runtime/env where user is trying to install (Note: isn't necessarily where you're running the newrelic-cli from)
 # See http://download.newrelic.com/infrastructure_agent/ for possible permutations
@@ -83,7 +112,7 @@ validationNrql: string, optional
 
 # Metadata to support generating a URL after installation success
 successLinkConfig: object, optional
-  type: string, required        # required link type.  valid values are (host, EXPLORER)
+  type: enum (string), required # One of [ host, EXPLORER ]
   filter: string, optional      # optional filter value for EXPLORER links
 
 # Optional pre-install configuration items.

--- a/docs/recipe-spec/spec.json
+++ b/docs/recipe-spec/spec.json
@@ -3,6 +3,18 @@
   "displayName": "Infrastructure Agent Linux Installer",
   "description": "New Relic install recipe for the Infrastructure agent",
   "repository": "https://github.com/newrelic/infrastructure-agent",
+  "stability": "stable",
+  "dependencies": [
+    "infrastructure-agent-installer"
+  ],
+  "quickstarts": [{
+    "name": "APM",
+    "entities": {
+      "type": "APPLICATION",
+      "domain": "APM"
+    },
+    "category": "newrelic"
+  }],
   "installTargets": [{
     "type": "host",
     "os": "linux",

--- a/validator/schema-v1.json
+++ b/validator/schema-v1.json
@@ -11,6 +11,20 @@
             "displayName": "Infrastructure Agent Linux Installer",
             "description": "New Relic install recipe for the Infrastructure agent",
             "repository": "https://github.com/newrelic/infrastructure-agent",
+            "stability": "stable",
+            "dependencies": [
+                "infrastructure-agent-installer"
+            ],
+            "quickstarts": [
+                {
+                    "name": "APM",
+                    "entities": {
+                        "type": "APPLICATION",
+                        "domain": "APM"
+                    },
+                    "category": "newrelic"
+                }
+            ],
             "installTargets": [
                 {
                     "type": "host",
@@ -118,6 +132,161 @@
                 "https://github.com/newrelic/infrastructure-agent"
             ]
         },
+        "stability": {
+            "$id": "#/properties/stability",
+            "type": "string",
+            "enum": [
+                "disabled",
+                "experimental",
+                "stable"
+            ],
+            "title": "The stability schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "stable"
+            ]
+        },
+        "dependencies": {
+            "$id": "#/properties/dependencies",
+            "type": "array",
+            "title": "The dependencies schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": [],
+            "examples": [
+                [
+                    "infrastructure-agent-installer"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/dependencies/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/dependencies/items/anyOf/0",
+                        "type": "string",
+                        "title": "The first anyOf schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default": "",
+                        "examples": [
+                            "infrastructure-agent-installer"
+                        ]
+                    }
+                ]
+            }
+        },
+        "quickstarts": {
+            "$id": "#/properties/quickstarts",
+            "type": "array",
+            "title": "The quickstarts schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": [],
+            "examples": [
+                [
+                    {
+                        "name": "APM",
+                        "entities": {
+                            "type": "APPLICATION",
+                            "domain": "APM"
+                        },
+                        "category": "newrelic"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/quickstarts/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/quickstarts/items/anyOf/0",
+                        "type": "object",
+                        "title": "The first anyOf schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "name": "APM",
+                                "entities": {
+                                    "type": "APPLICATION",
+                                    "domain": "APM"
+                                },
+                                "category": "newrelic"
+                            }
+                        ],
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/name",
+                                "type": "string",
+                                "title": "The name schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": "",
+                                "examples": [
+                                    "APM"
+                                ]
+                            },
+                            "entities": {
+                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities",
+                                "type": "object",
+                                "title": "The entities schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": {},
+                                "examples": [
+                                    {
+                                        "type": "APPLICATION",
+                                        "domain": "APM"
+                                    }
+                                ],
+                                "required": [
+                                    "type",
+                                    "domain"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities/properties/type",
+                                        "type": "string",
+                                        "title": "The type schema",
+                                        "description": "An explanation about the purpose of this instance.",
+                                        "default": "",
+                                        "examples": [
+                                            "APPLICATION"
+                                        ]
+                                    },
+                                    "domain": {
+                                        "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities/properties/domain",
+                                        "type": "string",
+                                        "title": "The domain schema",
+                                        "description": "An explanation about the purpose of this instance.",
+                                        "default": "",
+                                        "examples": [
+                                            "APM"
+                                        ]
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "category": {
+                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/category",
+                                "type": "string",
+                                "enum": [
+                                    "newrelic",
+                                    "community"
+                                ],
+                                "title": "The category schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": "",
+                                "examples": [
+                                    "newrelic"
+                                ]
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        },
         "installTargets": {
             "$id": "#/properties/installTargets",
             "type": "array",
@@ -163,6 +332,14 @@
                             "type": {
                                 "$id": "#/properties/installTargets/items/anyOf/0/properties/type",
                                 "type": "string",
+                                "enum": [
+                                    "host",
+                                    "application",
+                                    "docker",
+                                    "kubernetes",
+                                    "cloud",
+                                    "serverless"
+                                ],
                                 "title": "The type schema",
                                 "description": "An explanation about the purpose of this instance.",
                                 "default": "",
@@ -173,6 +350,11 @@
                             "os": {
                                 "$id": "#/properties/installTargets/items/anyOf/0/properties/os",
                                 "type": "string",
+                                "enum": [
+                                    "linux",
+                                    "darwin",
+                                    "windows"
+                                ],
                                 "title": "The os schema",
                                 "description": "An explanation about the purpose of this instance.",
                                 "default": "",
@@ -183,6 +365,14 @@
                             "platform": {
                                 "$id": "#/properties/installTargets/items/anyOf/0/properties/platform",
                                 "type": "string",
+                                "enum": [
+                                    "amazon",
+                                    "ubuntu",
+                                    "debian",
+                                    "centos",
+                                    "redhat",
+                                    "suse"
+                                ],
                                 "title": "The platform schema",
                                 "description": "An explanation about the purpose of this instance.",
                                 "default": "",
@@ -193,6 +383,11 @@
                             "platformFamily": {
                                 "$id": "#/properties/installTargets/items/anyOf/0/properties/platformFamily",
                                 "type": "string",
+                                "enum": [
+                                    "debian",
+                                    "rhel",
+                                    "suse"
+                                ],
                                 "title": "The platformFamily schema",
                                 "description": "An explanation about the purpose of this instance.",
                                 "default": "",
@@ -480,7 +675,14 @@
                             },
                             "default": {
                                 "$id": "#/properties/inputVars/items/anyOf/0/properties/default",
-                                "type": ["number","string","boolean","object","array", "null"],
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ],
                                 "title": "The default schema",
                                 "description": "An explanation about the purpose of this instance.",
                                 "default": "",
@@ -509,7 +711,7 @@
             "type": "object",
             "title": "The successLinkConfig schema",
             "description": "An explanation about the purpose of this instance.",
-            "default": "",
+            "default": {},
             "examples": [
                 {
                     "type": "EXPLORER",
@@ -523,11 +725,14 @@
                 "type": {
                     "$id": "#/properties/successLinkConfig/properties/type",
                     "type": "string",
+                    "enum": [
+                        "host",
+                        "EXPLORER"
+                    ],
                     "title": "The type schema",
                     "description": "An explanation about the purpose of this instance.",
                     "default": "",
                     "examples": [
-                        "host",
                         "EXPLORER"
                     ]
                 },
@@ -538,8 +743,7 @@
                     "description": "An explanation about the purpose of this instance.",
                     "default": "",
                     "examples": [
-                        "\"`tags.language` = 'java'\"",
-                        "\"`tags.language` = 'dotnet'\""
+                        "\"`tags.language` = 'java'\""
                     ]
                 }
             },


### PR DESCRIPTION
`stability` is the current term that was chosen to signify which level of recipes we want to expose in the CLI via a flag like `--stability=stable`. Other options I thought of included `library` (`--library=stable`), `category` (`--category=stable`), and `channel` (`--channel=stable`). 

Does stability make the most sense?