### PR TITLE
chore(schema): add infra dependency to OHIs and Logs recipes

### DIFF
--- a/recipes/newrelic/infrastructure/logs/debian-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/debian-logs.yml
@@ -6,6 +6,9 @@ displayName: Logs integration
 description: New Relic install recipe for basic Logging via Infra-Agent
 repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/logs/docker-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/docker-logs.yml
@@ -6,6 +6,9 @@ displayName: Docker Logs integration
 description: New Relic install recipe for docker Logging via Infra-Agent
 repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/logs/logs.yml
+++ b/recipes/newrelic/infrastructure/logs/logs.yml
@@ -6,6 +6,9 @@ displayName: Logs integration
 description: New Relic install recipe for basic Logging via Infra-Agent
 repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/logs/ubuntu-unsupported.yml
+++ b/recipes/newrelic/infrastructure/logs/ubuntu-unsupported.yml
@@ -6,6 +6,9 @@ displayName: Logs integration
 description: New Relic install recipe for basic Logging via Infra-Agent
 repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux
@@ -31,6 +34,6 @@ install:
           echo "Logging is not supported on this ubuntu version, require at least ubuntu version 16.04." >> /dev/stderr
 
 postInstall:
-  info: |
+  info: |2
       Logging is not supported on this ubuntu version. See the minimum requirements on the link below.
       https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/

--- a/recipes/newrelic/infrastructure/logs/windows-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/windows-logs.yml
@@ -6,6 +6,9 @@ displayName: Logs integration
 description: New Relic install recipe for basic Logging via Infra-Agent
 repository: https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: windows

--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -3,6 +3,9 @@ displayName: Apache Open Source Integration
 description: New Relic install recipe for default Apache Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-apache
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -3,6 +3,9 @@ displayName: Apache Open Source Integration
 description: New Relic install recipe for default Apache Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-apache
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -6,6 +6,9 @@ displayName: Cassandra Open Source Integration
 description: New Relic install recipe for default Cassandra Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-cassandra
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -6,6 +6,9 @@ displayName: Cassandra Open Source Integration
 description: New Relic install recipe for default Cassandra Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-cassandra
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -3,6 +3,9 @@ displayName: HashiCorp Consul Open Source Integration
 description: New Relic install recipe for default HashiCorp Consul Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-consul
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -3,6 +3,9 @@ displayName: HashiCorp Consul Open Source Integration
 description: New Relic install recipe for default HashiCorp Consul Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-consul
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -3,6 +3,9 @@ displayName: Couchbase Open Source Integration
 description: New Relic install recipe for default Couchbase Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-couchbase
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -3,6 +3,9 @@ displayName: Couchbase Open Source Integration
 description: New Relic install recipe for default Couchbase Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-couchbase
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -3,6 +3,9 @@ displayName: Elasticsearch Open Source Integration
 description: New Relic install recipe for default Elasticsearch Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-elasticsearch
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -3,6 +3,9 @@ displayName: Elasticsearch Open Source Integration
 description: New Relic install recipe for default Elasticsearch Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-elasticsearch
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux
@@ -155,7 +158,6 @@ install:
                 collect_primaries: true
           EOT
           fi
-
 
     restart:
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -3,6 +3,9 @@ displayName: Elasticsearch Open Source Integration
 description: New Relic install recipe for default Elasticsearch Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-elasticsearch
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -6,6 +6,9 @@ displayName: HAProxy Open Source Integration
 description: New Relic install recipe for default HAProxy Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-haproxy
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -6,6 +6,9 @@ displayName: HAProxy Open Source Integration
 description: New Relic install recipe for default HAProxy Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-haproxy
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/jmx/debian.yml
@@ -6,6 +6,9 @@ displayName: JMX Open Source Integration
 description: New Relic install recipe for default JMX Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-jmx
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/jmx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/jmx/rhel.yml
@@ -6,6 +6,9 @@ displayName: JMX Open Source Integration
 description: New Relic install recipe for default JMX Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-jmx
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -6,6 +6,9 @@ displayName: Memcached Open Source Integration
 description: New Relic install recipe for default Memcached Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-memcached
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
@@ -3,6 +3,9 @@ displayName: Memcached Open Source Integration
 description: New Relic install recipe for default Memcached Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-memcached
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -6,6 +6,9 @@ displayName: MongoDB Open Source Integration
 description: New Relic install recipe for default MongoDB Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-mongodb
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -3,6 +3,9 @@ displayName: MongoDB Open Source Integration
 description: New Relic install recipe for default MongoDB Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-mongodb
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -6,6 +6,9 @@ displayName: MySQL Open Source Integration
 description: New Relic install recipe for default MySQL Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-mysql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -6,6 +6,9 @@ displayName: MySQL Open Source Integration
 description: New Relic install recipe for default MySQL Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-mysql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -6,6 +6,9 @@ displayName: MySQL Open Source Integration
 description: New Relic install recipe for default MySQL Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-mysql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -3,6 +3,9 @@ displayName: Nagios Open Source Integration
 description: New Relic install recipe for default Nagios Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-nagios
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -3,6 +3,9 @@ displayName: nagios Open Source Integration
 description: New Relic install recipe for default Nagios Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-nagios
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -6,6 +6,9 @@ displayName: NGINX Open Source Integration
 description: New Relic install recipe for default NGINX Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-nginx
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -6,6 +6,9 @@ displayName: NGINX Open Source Integration
 description: New Relic install recipe for default NGINX Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-nginx
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -6,6 +6,9 @@ displayName: NGINX Open Source Integration
 description: New Relic install recipe for default NGINX Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-nginx
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -3,6 +3,9 @@ displayName: PostgreSQL Open Source Integration
 description: New Relic install recipe for default Postgres Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-postgresql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -3,6 +3,9 @@ displayName: PostgreSQL Open Source Integration
 description: New Relic install recipe for default Postgres Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-postgresql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -3,6 +3,9 @@ displayName: RabbitMQ Open Source Integration
 description: New Relic install recipe for default RabbitMQ Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-rabbitmq
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -3,6 +3,9 @@ displayName: RabbitMQ Open Source Integration
 description: New Relic install recipe for default RabbitMQ Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-rabbitmq
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -6,6 +6,9 @@ displayName: Redis Open Source Integration
 description: New Relic install recipe for default Redis Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-redis
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -6,6 +6,9 @@ displayName: Redis Open Source Integration
 description: New Relic install recipe for default Redis Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-redis
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -6,6 +6,9 @@ displayName: Microsoft Sql Server Integration Installer
 description: New Relic install recipe for the Microsoft SqlServer Integration
 repository: https://github.com/newrelic/nri-mssql
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: windows

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -3,6 +3,9 @@ displayName: Varnish Cache Open Source Integration
 description: New Relic install recipe for default Varnish Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-varnish
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -3,6 +3,9 @@ displayName: Varnish Cache Open Source Integration
 description: New Relic install recipe for default Varnish Cache Open Source on-host integration (via Infra-Agent)
 repository: https://github.com/newrelic/nri-varnish
 
+dependencies:
+  - infrastructure-agent-installer
+
 installTargets:
   - type: host
     os: linux


### PR DESCRIPTION
Adds infra agent install as a dependency to all OHI and Logs recipes. This is prep for https://github.com/newrelic/newrelic-cli/pull/815

Related: https://newrelic.atlassian.net/browse/VIRTUOSO-684