### PR TITLE
dotnet debian/ubuntu install: add more prereqs

### DIFF
--- a/recipes/newrelic/apm/dotNet/debian-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/debian-systemd.yml
@@ -97,6 +97,22 @@ install:
             echo "This installation recipe for the New Relic .NET agent on Linux only supports services managed by 'systemd'." >> /dev/stderr
             exit 20
           fi
+        - |
+          # Map of tool names to the associated error code
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 cat:13 tee:14"
+
+          for tuple in $required_tools_and_error_codes; do
+            tool=$(echo ${tuple} |cut -d':' -f1)
+            code=$(echo ${tuple} |cut -d':' -f2)
+            echo "tool=$tool, code=$code"
+
+            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+            then
+              echo "This installation recipe for the New Relic .NET agent on Linux requires '${tool}' to be installed." >> /dev/stderr
+              exit ${code}
+            fi
+          done
 
     introspector:
       cmds:

--- a/recipes/newrelic/apm/dotNet/debian-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/debian-systemd.yml
@@ -104,7 +104,6 @@ install:
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
             code=$(echo ${tuple} |cut -d':' -f2)
-            echo "tool=$tool, code=$code"
 
             IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
             if [ "$IS_TOOL_INSTALLED" -eq 0 ]


### PR DESCRIPTION
This adds more checks in the `assert_prereqs` step, to cover the tools we know we need.

I implemented these checks in a compact way, iterating over a list of strings that look like "toolname:exitcode" to handle the association between a particular tool and the expected exit code the recipe should return if that tool is not found.  (I would have used a more legit dictionary, which some versions of `bash` support, but it doesn't appear supported by the `go-task` bash interpreter.