### PR TITLE
fix: mysql password containing spaces causes connection error

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -91,7 +91,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
+          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          {{.NR_CLI_DB_PASSWORD}}
+          EOT
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
           if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -91,7 +91,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')
+          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          {{.NR_CLI_DB_PASSWORD}}
+          EOT
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
           if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -88,7 +88,10 @@ install:
             exit 1
           fi
         - |
-          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p{{.NR_CLI_DB_PASSWORD}} -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
+          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          {{.NR_CLI_DB_PASSWORD}}
+          EOT
+          CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')
           EXPECTED_SELECT_REPLICATION=$(echo 'SELECT, REPLICATION')
           EXPECTED_ALL_PRIVILEGES=$(echo 'ALL PRIVILEGES')
           if [ "$CHECK_DB" != "$EXPECTED_SELECT_REPLICATION" ] &&  [ "$CHECK_DB" != "$EXPECTED_ALL_PRIVILEGES" ]; then


### PR DESCRIPTION
This approach allows the use of a MySQL database password containing spaces, as well as a combination of single/double quotes and other special characters.