### PR TITLE
Ignore apt-get update errors

### DIFF
--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -125,6 +125,8 @@ install:
         - |
           sudo apt-get update -yq
       silent: true
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     add_gpg_key:
       cmds:
@@ -145,6 +147,8 @@ install:
       cmds:
         - |
           sudo apt-get update -yq
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     install_infra:
       cmds:


### PR DESCRIPTION
apt-get update will return an error if any of the sources is unavailable, making the recipe fail for the infra agent. This can happen when the customer's source list contains an error. This is not something we can control and, if the agent is installed correctly, the errors will have no consequences.