### PR TITLE
fix(mysql): remove -d invalid option

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -91,7 +91,7 @@ install:
             exit 1
           fi
         - |
-          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          read -r NR_CLI_DB_PASSWORD <<"EOT"
           {{.NR_CLI_DB_PASSWORD}}
           EOT
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -91,7 +91,7 @@ install:
             exit 1
           fi
         - |
-          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          read -r NR_CLI_DB_PASSWORD <<"EOT"
           {{.NR_CLI_DB_PASSWORD}}
           EOT
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT ALL\|SELECT' | awk '{print $2, $3}')

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -88,7 +88,7 @@ install:
             exit 1
           fi
         - |
-          read -r -d "" NR_CLI_DB_PASSWORD <<"EOT"
+          read -r NR_CLI_DB_PASSWORD <<"EOT"
           {{.NR_CLI_DB_PASSWORD}}
           EOT
           CHECK_DB=$(mysql -u{{.NR_CLI_DB_USERNAME}} --port {{.NR_CLI_DB_PORT}} -p"$NR_CLI_DB_PASSWORD" -e "SHOW GRANTS FOR CURRENT_USER" 2>&1 | grep -v "mysql: [Warning] Using a password on the command line interface can be insecure." | grep 'GRANT SELECT' | awk '{print $2, $3}')


### PR DESCRIPTION
Noah and I discovered the following error while debugging MySQL OHI recipe

```
DEBUG executing recipe mysql-open-source-integration
read: invalid option "-d"
DEBUG Task execution returned error                 err="task: Failed to run task \"default\": task: Failed to run task \"assert_pre_req\": exit status 2"
DEBUG recipe event                                  error="encountered an error while executing mysql-open-source-integration: task: Failed to run task \"default\": task: Failed to run task \"assert_pre_req\": exit status 2" guid= recipe_name=mysql-open-source-integration status=FAILED validationDurationMilliseconds=0
```