### PR TITLE
[Do not merge] Remove vc_redist dependency for infra on windows

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -29,8 +29,6 @@ install:
         - task: remove_any_previous
         - task: download_infra
         - task: install_infra
-        - task: download_vc
-        - task: install_vc
         - task: start_infra
         - task: assert_agent_started
 
@@ -112,14 +110,6 @@ install:
             Add-Content -Path $InfraConfig -Value "staging: true" -Force
           }
           '
-
-    download_vc:
-      cmds:
-        - powershell -command '(New-Object System.Net.WebClient).DownloadFile("https://aka.ms/vs/16/release/vc_redist.x64.exe", "$env:TEMP\vc_redist.x64.exe");'
-
-    install_vc:
-      cmds:
-        - powershell -command 'start-process -FilePath "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install /q /norestart" -Verb RunAs -wait | Out-Null;'
 
     start_infra:
       cmds:

--- a/test/definitions/infra-agent/windows/windows2016.json
+++ b/test/definitions/infra-agent/windows/windows2016.json
@@ -23,8 +23,13 @@
             "id": "nr_infra",
             "resource_ids": ["host1"],
             "provider": "newrelic",
-            "source_repository": "https://github.com/newrelic/open-install-library",
-            "deploy_script_path": "test/deploy/windows/newrelic-cli/install/roles"
+            "source_repository": "https://github.com/newrelic/open-install-library.git",
+            "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
+            "params": {
+                "recipe_content_url": [
+                    "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml"
+                ]
+            }
         },
         {
             "id": "nr_infra_is_having_data",

--- a/test/definitions/ohi/windows/ms-sql-server2019Standard.json
+++ b/test/definitions/ohi/windows/ms-sql-server2019Standard.json
@@ -39,19 +39,8 @@
           "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
           "params": {
               "recipe_content_url": [
-                  "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml",
                   "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml"
               ]
-          }
-      },
-      {
-          "id": "nr_infra_is_having_data",
-          "resource_ids": ["host1"],
-          "provider": "newrelic",
-          "source_repository": "https://github.com/newrelic/open-install-library.git",
-          "deploy_script_path": "test/deploy/assertions/recipe-is-valid/roles",
-          "params": {
-              "recipe_validation_nrql_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml"
           }
       }
       ]


### PR DESCRIPTION
This dependency was used for logging but it's not necessary anymore.