### PR TITLE
Added send_transaction, create_shared, delete_shared, detect_services, and updated restart_services

### DIFF
--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -219,9 +219,11 @@ install:
           # Web server was detected. Send transaction associated with the webserver php.ini
           # and the newrelic.ini file associated with that web server.
           #
-             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
-             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
-             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+          for i in {1..10}; do
+            sleep 1
+            sudo -u $nonpriv_user php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+            #sudo -u www-data php -c /etc/php/7.2/fpm/php.ini -c /etc/php/7.2/fpm/conf.d/newrelic.ini -n --ini &>/dev/null
+          done
           else
           #
           # No web server detected, pure PHP CLI.

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -77,8 +77,20 @@ install:
           do
             priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
             full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $11}')
-            process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
-
+            fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
+            if [ -n "${fpm_nginx_process_name}" ]; then
+              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $14}')
+              fpm_ver=$(echo "${fpm_process_loc}" | sed -n 's/.*\/php\/\([578].[0-9]\)\/.*/\1/p')
+              if [ -n "${fpm_ver}" ]; then
+                # It's fpm.
+                process_name="php${fpm_ver}-fpm"
+              else
+                # It's nginx.
+                process_name=$fpmnginx_process_name
+              fi
+            else
+              process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
+            fi
             nonpriv_user=
 
             if [ -n "${priv_user}" ]; then
@@ -187,7 +199,7 @@ install:
             # Exit with Agent install failure code exit(16)
             exit 16
           fi
-
+   
           #
           # Get the non-privileged user that was previously stored.
           #

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -131,17 +131,27 @@ install:
     restart_services:
       cmds:
         - echo "Restarting the services as needed to pick up newrelic.ini information."
+          #
+          # Case: php-fpm/apache or php-fpm/nginx, only php-fpm needs to be restarted.
+          # Case: apache only or nginx only, they respective service needs to be restarted.
+          # This means only restart the first process in processes_to_restart.txt.
+          #
         - |
           if [ "{{.NR_PHP_RESTART}}" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
-            while read -r process user_name; do
-              echo "Restarting $process as privileged user $user_name"
-              sudo -u $user_name service $process restart
-              echo "Sleeping for 10 seconds to give process time to recover."
-              sleep 10
-            done < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
+            read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
+            echo "Restarting $process as privileged user $user_name"
+            sudo -u $user_name service $process restart
+            echo "Sleeping for 10 seconds to give process time to recover."
+            sleep 10
           else
-            echo "You will need to restart your PHP application in order for instrumentation to be enabled."
+            if [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+              cd {{.TMP_INSTALL_DIR}}
+              read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
+              echo "Please restart  $process as privileged user $user_name for instrumentation to be enabled."
+            else
+              echo "You will need to restart your PHP web server in order for web instrumentation to be enabled."
+            fi
           fi
 
     send_transaction:

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -91,12 +91,12 @@ install:
               #
               echo "$process_name $priv_user" >> {{.TMP_INSTALL_DIR}}/processes_to_restart.txt
               #
-              # Output all processes to be restarted to a file with the following forat:
-              # process_name privileged_user
-              # When initiating the transaction, it will be ONLY be used witt
+              # Save all non-privileged users associated with detected processes.
+              # When initiating the transaction, it will ONLY be used with
               # the first associated non-privileged user because due the reasoning above
               # that the installation logic adheres to, between FPM and Apache,
-              # FPM will be the one to use.
+              # FPM will be the one to use and `newrelic-install.sh` only
+              # installs the `newrelic.ini` in one web location.
               #
               echo "$nonpriv_user" >> {{.TMP_INSTALL_DIR}}/nonpriv_users.txt
             fi

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -71,7 +71,7 @@ install:
           #
           declare -a guided_support=("(fpm)" "(httpd|apache2|apache)" "(nginx)")
 
-          current_user=$(whoami)
+          current_user=$SUDO_USER
 
           for PROCESS in ${guided_support[@]}
           do
@@ -177,7 +177,7 @@ install:
           if [ -f {{.TMP_INSTALL_DIR}}/nonpriv_users.txt ]; then
           nonpriv_user=$(head -1 {{.TMP_INSTALL_DIR}}/nonpriv_users.txt)
           else
-            nonpriv_user=$(whoami)
+            nonpriv_user=$SUDO_USER
           fi
 
           #
@@ -197,9 +197,10 @@ install:
           #
           # No web server detected, pure PHP CLI.
           #
-             php —-ini
-             php —-ini
-             php —-ini
+            echo "Running PHP-CLI with user $SUDO_USER"
+            sudo -u $SUDO_USER php —-ini
+            sudo -u $SUDO_USER php —-ini
+            sudo -u $SUDO_USER php —-ini
           fi
         - echo "Done sending transactions."
 

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -41,11 +41,12 @@ install:
       cmds:
         - task: create_shared
         - task: detect_services
-              #        - task: install_packages
-              #- task: config_newrelic_ini
-              #- task: finalize_agent_config
+        - task: install_packages
+        - task: config_newrelic_ini
+        - task: finalize_agent_config
         - task: restart_services
         - task: send_transaction
+        - task: delete_shared
 
     create_shared:
       cmds:
@@ -61,8 +62,6 @@ install:
           rm -f {{.TMP_INSTALL_DIR}}/nonpriv_users.txt
           rm -f {{.TMP_INSTALL_DIR}}/processes_to_restart.txt
 
-          SUPPORTED_PROCESS=0
-          PROCESS_TERMS=1
           #
           # For guided installs, we currently support `php-fpm`, `apache`, and `nginx`.
           # There is a reason for the order.  According our install script:

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -16,6 +16,8 @@ keywords:
 processMatch:
   - /php-fpm/
 
+validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
+
 inputVars:
   - name: "NR_PHP_APPLICATION"
     prompt: "What is the name of your PHP application?"
@@ -37,6 +39,7 @@ install:
         - task: config_newrelic_ini
         - task: finalize_agent_config
         - task: restart_services
+        - task: send_transaction
 
     install_packages:
       cmds:
@@ -48,7 +51,6 @@ install:
           fi
           DEBIAN_FRONTEND=noninteractive sudo apt update
           DEBIAN_FRONTEND=noninteractive apt -y install newrelic-php5
-
     config_newrelic_ini:
       cmds:
         - echo "TODO: configure newrelic.ini"
@@ -67,3 +69,45 @@ install:
           else
             echo "You will need to restart your PHP application in order for instrumentation to be enabled."
           fi
+    send_transaction:
+      cmds:
+        - echo "Send queryable transactions."
+        - |
+          TMP_INSTALL_DIR="/tmp/php-agent-install"
+          cd $TMP_INSTALL_DIR
+          #
+          # Expand the log files from the most recent installation attempt,
+          # and get the name of the most recent log file.
+          #
+          tar -xvf $(ls -t nrinstall*.tar | head -1)
+          NR_INSTALL_LOG=$(ls -t nrinstall*.log | head -1)
+          #
+          # Get the web server PHP INI directories that the most recent installation attempt used.
+          #
+          WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
+          WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
+          if [ -z "${WEB_PHP_INI_DIR}" ]; then
+              WEB_PHP_INI_DIR=$WEB_NR_INI_DIR
+          fi
+          #
+          # The first transaction initializes the app.
+          # The second transaction is for luck.
+          # The third time’s the charm.
+          #
+          if [ -n "${WEB_PHP_INI_DIR}" ]; then
+          #
+          # Web server was detected. Send transaction associated with the webserver php.ini
+          # and the newrelic.ini file associated with that web server.
+          #
+             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+          else
+          #
+          # No web server detected, pure PHP CLI.
+          #
+             php —-ini
+             php —-ini
+             php —-ini
+          fi
+        - echo "Done sending transactions."

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -51,6 +51,7 @@ install:
           fi
           DEBIAN_FRONTEND=noninteractive sudo apt update
           DEBIAN_FRONTEND=noninteractive apt -y install newrelic-php5
+
     config_newrelic_ini:
       cmds:
         - echo "TODO: configure newrelic.ini"
@@ -82,7 +83,8 @@ install:
           tar -xvf $(ls -t nrinstall*.tar | head -1)
           NR_INSTALL_LOG=$(ls -t nrinstall*.log | head -1)
           #
-          # Get the web server PHP INI directories that the most recent installation attempt used.
+          # Get the web server PHP INI directories that the most recent 
+          # installation attempt used.
           #
           WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
           WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
@@ -104,7 +106,7 @@ install:
              php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
           else
           #
-          # No web server detected, pure PHP CLI.
+          # No web server detected, this was a pure PHP CLI php agent installation.
           #
              php —-ini
              php —-ini

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -70,6 +70,7 @@ install:
           else
             echo "You will need to restart your PHP application in order for instrumentation to be enabled."
           fi
+
     send_transaction:
       cmds:
         - echo "Send queryable transactions."

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -222,16 +222,16 @@ install:
           for i in {1..10}; do
             sleep 1
             sudo -u $nonpriv_user php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
-            #sudo -u www-data php -c /etc/php/7.2/fpm/php.ini -c /etc/php/7.2/fpm/conf.d/newrelic.ini -n --ini &>/dev/null
           done
           else
           #
           # No web server detected, pure PHP CLI.
           #
             echo "Running PHP-CLI with user $SUDO_USER"
-            sudo -u $SUDO_USER php —-ini
-            sudo -u $SUDO_USER php —-ini
-            sudo -u $SUDO_USER php —-ini
+            for i in {1..10}; do
+              sleep 1
+              sudo -u $SUDO_USER php —-ini
+            done
           fi
         - echo "Done sending transactions."
 

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -36,10 +36,12 @@ install:
     default:
       cmds:
         - task: install_packages
+        - task: create_shared
         - task: config_newrelic_ini
         - task: finalize_agent_config
         - task: restart_services
         - task: send_transaction
+        - task: delete_shared
 
     install_packages:
       cmds:
@@ -51,6 +53,12 @@ install:
           fi
           DEBIAN_FRONTEND=noninteractive sudo apt update
           DEBIAN_FRONTEND=noninteractive apt -y install newrelic-php5
+
+    create_shared:
+      cmds:
+        - rm -rf /tmp/php-agent-install
+        - mkdir -p /tmp/php-agent-install
+        - echo "Created temporary directory used for installation."
 
     config_newrelic_ini:
       cmds:
@@ -114,3 +122,9 @@ install:
              php —-ini
           fi
         - echo "Done sending transactions."
+
+    delete_shared:
+      ignore_error: true
+      cmds:
+        - rm -rf /tmp/php-agent-install
+        - echo "Removed temporary directory used for installation."

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -41,9 +41,9 @@ install:
       cmds:
         - task: create_shared
         - task: detect_services
-        - task: install_packages
-        - task: config_newrelic_ini
-        - task: finalize_agent_config
+          #- task: install_packages
+          #- task: config_newrelic_ini
+          #- task: finalize_agent_config
         - task: restart_services
         - task: send_transaction
         - task: delete_shared
@@ -75,10 +75,16 @@ install:
 
           for PROCESS in ${guided_support[@]}
           do
-            nonpriv_user=$(ps -ef | egrep $PROCESS | grep -v grep | grep -v root | head -n1 | awk '{print $1}')
-            priv_user=$(ps -ef | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
-            full_process_name=$(ps -ef | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $8}')
+            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
+            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $11}')
             process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
+
+            nonpriv_user=
+
+            if [ -n "${priv_user}" ]; then
+              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v $priv_user | head -n1 | awk '{print $1}')
+            fi
+
             if [ -n "${process_name}" ]; then
               if [ -z "${nonpriv_user}" ]; then
                 nonpriv_user=$current_user
@@ -130,7 +136,7 @@ install:
             cd {{.TMP_INSTALL_DIR}}
             while read -r process user_name; do
               echo "Restarting $process as privileged user $user_name"
-              sudo -u $user_name $process restart
+              sudo -u $user_name service $process restart
               echo "Sleeping for 10 seconds to give process time to recover."
               sleep 10
             done < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
@@ -148,8 +154,9 @@ install:
           # and get the name of the most recent log file.
           #
 
-          tar_file=$(ls -t nrinstall*.tar | head -1)
-          if [ -f $tar_file ]; then
+          tar_file=$(ls -t nrinstall*.tar 2>/dev/null | head -1)
+
+          if [ -f "${tar_file}" ]; then
             tar xvf $tar_file
             log_file=$(ls -t nrinstall*.log | head -1)
             if  [ -f $log_file ]; then

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -29,19 +29,80 @@ inputVars:
 install:
   version: "3"
 
+  vars:
+    TMP_INSTALL_DIR:
+      sh: mktemp -d /tmp/newrelic-php-agent.XXXXXX
+
   env:
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED: true
 
   tasks:
     default:
       cmds:
-        - task: install_packages
         - task: create_shared
-        - task: config_newrelic_ini
-        - task: finalize_agent_config
+        - task: detect_services
+              #        - task: install_packages
+              #- task: config_newrelic_ini
+              #- task: finalize_agent_config
         - task: restart_services
         - task: send_transaction
-        - task: delete_shared
+
+    create_shared:
+      cmds:
+        - rm -rf {{.TMP_INSTALL_DIR}}
+        - mkdir -p {{.TMP_INSTALL_DIR}}
+        - echo "Created temporary directory {{.TMP_INSTALL_DIR}} for installation."
+
+    detect_services:
+      cmds:
+        - echo "Detect services."
+        - |
+          cd {{.TMP_INSTALL_DIR}}
+          rm -f {{.TMP_INSTALL_DIR}}/nonpriv_users.txt
+          rm -f {{.TMP_INSTALL_DIR}}/processes_to_restart.txt
+
+          SUPPORTED_PROCESS=0
+          PROCESS_TERMS=1
+          #
+          # For guided installs, we currently support `php-fpm`, `apache`, and `nginx`.
+          # There is a reason for the order.  According our install script:
+          # If both Apache and FPM are installed, we want FPM to win:
+          # while there are many ways to end up with libapache2-mod-php5 installed,
+          # it's unlikely php5-fpm will be installed unless FPM is actually in use.
+          #
+          declare -a guided_support=("(fpm)" "(httpd|apache2|apache)" "(nginx)")
+
+          current_user=$(whoami)
+
+          for PROCESS in ${guided_support[@]}
+          do
+            nonpriv_user=$(ps -ef | egrep $PROCESS | grep -v grep | grep -v root | head -n1 | awk '{print $1}')
+            priv_user=$(ps -ef | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
+            full_process_name=$(ps -ef | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $8}')
+            process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
+            if [ -n "${process_name}" ]; then
+              if [ -z "${nonpriv_user}" ]; then
+                nonpriv_user=$current_user
+              fi
+              #
+              # Output all processes to be restarted to a file with the following format:
+              # process_name privileged_user
+              # When the process is restarted, it will be used with the associated
+              # privileged user.
+              #
+              echo "$process_name $priv_user" >> {{.TMP_INSTALL_DIR}}/processes_to_restart.txt
+              #
+              # Output all processes to be restarted to a file with the following forat:
+              # process_name privileged_user
+              # When initiating the transaction, it will be ONLY be used witt
+              # the first associated non-privileged user because due the reasoning above
+              # that the installation logic adheres to, between FPM and Apache,
+              # FPM will be the one to use.
+              #
+              echo "$nonpriv_user" >> {{.TMP_INSTALL_DIR}}/nonpriv_users.txt
+            fi
+          done
+
 
     install_packages:
       cmds:
@@ -53,13 +114,6 @@ install:
           fi
           DEBIAN_FRONTEND=noninteractive sudo apt update
           DEBIAN_FRONTEND=noninteractive apt -y install newrelic-php5
-
-    create_shared:
-      cmds:
-        - rm -rf /tmp/php-agent-install
-        - mkdir -p /tmp/php-agent-install
-        - echo "Created temporary directory used for installation."
-
     config_newrelic_ini:
       cmds:
         - echo "TODO: configure newrelic.ini"
@@ -71,10 +125,16 @@ install:
 
     restart_services:
       cmds:
+        - echo "Restarting the services as needed to pick up newrelic.ini information."
         - |
-          if [ -z "{{.NR_PHP_RESTART}}" ]; then
-            echo "Restarting php-fpm"
-            sudo service php-fpm restart
+          if [ "{{.NR_PHP_RESTART}}" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+            cd {{.TMP_INSTALL_DIR}}
+            while read -r process user_name; do
+              echo "Restarting $process as privileged user $user_name"
+              sudo -u $user_name $process restart
+              echo "Sleeping for 10 seconds to give process time to recover."
+              sleep 10
+            done < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
           else
             echo "You will need to restart your PHP application in order for instrumentation to be enabled."
           fi
@@ -83,23 +143,44 @@ install:
       cmds:
         - echo "Send queryable transactions."
         - |
-          TMP_INSTALL_DIR="/tmp/php-agent-install"
-          cd $TMP_INSTALL_DIR
+          cd {{.TMP_INSTALL_DIR}}
           #
           # Expand the log files from the most recent installation attempt,
           # and get the name of the most recent log file.
           #
-          tar -xvf $(ls -t nrinstall*.tar | head -1)
-          NR_INSTALL_LOG=$(ls -t nrinstall*.log | head -1)
-          #
-          # Get the web server PHP INI directories that the most recent 
-          # installation attempt used.
-          #
-          WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
-          WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
-          if [ -z "${WEB_PHP_INI_DIR}" ]; then
-              WEB_PHP_INI_DIR=$WEB_NR_INI_DIR
+
+          tar_file=$(ls -t nrinstall*.tar | head -1)
+          if [ -f $tar_file ]; then
+            tar xvf $tar_file
+            log_file=$(ls -t nrinstall*.log | head -1)
+            if  [ -f $log_file ]; then
+              NR_INSTALL_LOG=$(ls -t nrinstall*.log | head -1)
+
+              #
+              # Get the web server PHP INI directories that the most recent installation attempt used.
+              #
+              WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
+              WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
+              if [ -z "${WEB_PHP_INI_DIR}" ]; then
+                WEB_PHP_INI_DIR=$WEB_NR_INI_DIR
+              fi
+            fi
+          else
+            #
+            # If tar file doesn't exist, something went wrong with installation.
+            # Exit with Agent install failure code exit(16)
+            exit 16
           fi
+
+          #
+          # Get the non-privileged user that was previously stored.
+          #
+          if [ -f {{.TMP_INSTALL_DIR}}/nonpriv_users.txt ]; then
+          nonpriv_user=$(head -1 {{.TMP_INSTALL_DIR}}/nonpriv_users.txt)
+          else
+            nonpriv_user=$(whoami)
+          fi
+
           #
           # The first transaction initializes the app.
           # The second transaction is for luck.
@@ -110,12 +191,12 @@ install:
           # Web server was detected. Send transaction associated with the webserver php.ini
           # and the newrelic.ini file associated with that web server.
           #
-             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
-             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
-             php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
+             sudo -u ${nonpriv_user} php -c "${WEB_PHP_INI_DIR}/php.ini" -c "${WEB_NR_INI_DIR}/newrelic.ini" -n --ini &>/dev/null
           else
           #
-          # No web server detected, this was a pure PHP CLI php agent installation.
+          # No web server detected, pure PHP CLI.
           #
              php —-ini
              php —-ini
@@ -125,6 +206,7 @@ install:
 
     delete_shared:
       ignore_error: true
+      label: "Cleaning up"
       cmds:
-        - rm -rf /tmp/php-agent-install
+        - rm -rf {{.TMP_INSTALL_DIR}}
         - echo "Removed temporary directory used for installation."


### PR DESCRIPTION
Added additional tasks:
* `send_transaction`
* `create_shared`
* `delete_shared`
* `detect_services`

updated `restart_services`

Original below:
Goal is to make minimal changes to the user’s environment and to reduce the amount of questions/interactions.

The php agent needs one transaction to initialize the agent then subsequent transactions are sent to NR1.  Normally, calling `php --ini` will always use the CLI `php.ini` and the associated `newrelic.ini`.

However, by calling something like `php -c /etc/php/7.2/apache2/php.ini -c /etc/php/7.2/apache2/conf.d/newrelic.ini -n --ini`, we force the command to use ONLY the ini files used by the web server (it is forced to ignore all other INIs) and can thereby verify the data flowing pipeline without other disadvantages.

This has the advantages of:
1) Verifies the data pipeline with the `php.ini` and `newrelic.ini` files that the web server will use by verifying the interoperability of those two `ini` files.
2) Doesn’t require the user to send data.
3) Doesn’t ask the user for the website URL in non-silent mode.
4) Doesn’t make us guess about URLs or detected ip/port pairs that may or may not be correct.
5) Curl doesn’t always trigger PHP scripts so we could curl to a valid page and still not get anything (for instance, Wordpress plugins aren’t triggered).
6) We don’t have to make a test.php to run on the user’s website.

To test:
1) deployed:
```
docker run -it \
-v <<local dir>>/demo-deployer/configs/:/mnt/deployer/configs/ \
-v <<local dir>>/open-install-library/test/:/mnt/deployer/test/ \
-v <<local dir>>/open-install-library/:/mnt/open-install-library \
--entrypoint ruby ghcr.io/newrelic/deployer:latest main.rb \
-c /mnt/deployer/configs/mycreds.credentials.local.json \
-d "test/manual/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json" -l debug
```

2) installed `9.17.1.301` php agent 
3) `sudo NEW_RELIC_REGION=STAGING NEW_RELIC_CLI_PRERELEASEFEATURES=ALLOW NEW_RELIC_API_KEY=<<add api key>> NEW_RELIC_ACCOUNT_ID=<<add account id>> /usr/local/bin/newrelic install -c <<add path to this recipe>>`

One caveat, it assumes the installation step uses the following temporary directory:
`TMP_INSTALL_DIR="/tmp/php-agent-install”` which is then deleted as the last step of the recipe.
@kneitinger , please let me know if this can be integrated into your install script logic.

Note, while the `send_transaction` section is intended to be run immediately after the installation and that task will only generate web server `ini` related transactions, if the agent is already installed and the recipe is run again on the same machine, it will currently generate some additional cli transactions as well just by nature of the other tasks that are run.
