### PR TITLE
Add apache fpm deploy config

### DIFF
--- a/test/deploy/linux/php/apache-fpm-wordpress/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/php/apache-fpm-wordpress/debian/roles/configure/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- debug:
+    msg: Install PHP
+
+- name: install PHP and pre-reqs
+  apt:
+    pkg:
+      - apache2
+      - php-fpm
+      - mysql-server
+      - mysql-client
+      - php-mysql
+    update_cache: yes
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../../../templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/deploy/linux/php/templates/install-wordpress.sh
+++ b/test/deploy/linux/php/templates/install-wordpress.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Install wp-cli
 curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -56,12 +56,20 @@ if [ $(which nginx) ]; then
 fi
 
 if [ $(which apache2) ]; then
-	if [ ! -f /etc/apache2/sites-available/wordpress-site ]; then
+	SITE="wordpress"
+	if [[ $(dpkg -l php-fpm) ]]; then
+		echo "Using PHP FPM variant of apache2 site config."
+		SITE="wordpress-fpm"
+
+		echo Enabling proxy_fcgi.
+		a2enmod proxy_fcgi
+	fi
+	if [ ! -f /etc/apache2/sites-available/$SITE.conf ]; then
 		echo Creating apache2 wordpress site config.
-		cp ~/templates/wordpress.conf /etc/apache2/sites-available
+		cp ~/templates/$SITE.conf /etc/apache2/sites-available
 	fi
 	echo Enabling apache2 wordpress site.
-	a2ensite wordpress
+	a2ensite $SITE
 
 	echo Disabling apache2 default site.
 	a2dissite 000-default

--- a/test/deploy/linux/php/templates/wordpress-fpm.conf
+++ b/test/deploy/linux/php/templates/wordpress-fpm.conf
@@ -1,0 +1,47 @@
+<VirtualHost *:80>
+    # The ServerName directive sets the request scheme, hostname and port that
+    # the server uses to identify itself. This is used when creating
+    # redirection URLs. In the context of virtual hosts, the ServerName
+    # specifies what hostname must appear in the request's Host: header to
+    # match this virtual host. For the default virtual host (this file) this
+    # value is not decisive as it is used as a last resort host regardless.
+    # However, you must set it for any further virtual host explicitly.
+    #ServerName www.example.com
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /wordpress
+
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+    <FilesMatch \.php>
+        SetHandler proxy:unix:/var/run/php/php7.2-fpm.sock|fcgi://localhost;
+    </FilesMatch>    
+</VirtualHost>
+
+<Directory /wordpress>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Order allow,deny
+    Require all granted
+    Allow from all
+</Directory>
+<Directory /wordpress/wp-content>
+    Options FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -1,0 +1,29 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+        "id": "php-a-f-w-u18",
+        "display_name": "PHP Apache FPM Wordpress",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????.1",
+        "user_name": "ubuntu"
+    }],
+
+    "services": [
+        {
+          "id": "wordpress",
+          "display_name": "Debian PHP Apache FPM Wordpress",
+          "local_source_path": "/mnt/open-install-library",
+          "deploy_script_path": "test/deploy/linux/php/apache-fpm-wordpress/debian/roles",
+          "port": 80,
+          "destinations": ["php-a-f-w-u18"]
+        }
+    ]
+}


### PR DESCRIPTION
Since I neglected to open a PR for some of my recent changes, here is a summary of the approach being used.

Both the deploy config (json file) and the ansible play (yaml file) are kept as minimal as possible.

The deploy config's job is to create the EC2 instance of the needed OS and to specify the ansible play that needs to run to install the needed services (wordpress in this case).

The ansible play's job is to install the prerequisite OS packages, copy over the template files, and run a single shell script (install-wordpress.sh). The presence or absence of OS packages or specific binaries installed by those packages are used by the install script to determine which steps to perform on the target EC2 instance.

The install script is based on our wordpress setup script in our test-apps repo. It downloads wordpress using the wp-cli, sets up the site, and configures the web server based on which one has been installed.

This PR adds a new deploy config for an Apache FPM Wordpress setup. The install script has been updated to detect the presence of FPM in an Apache setup. In this scenario, an additional apache module is enabled and we use a slight variation of the previous wordpress site config that sends PHP files through a fast cgi proxy. (I was unable to use a single apache site config for both apache setups as it doesn't look like ansible templates allow setting arbitrary jinja template properties).