### PR TITLE
fix: use sudo when modifying the agent config

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux.yml
@@ -88,10 +88,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -90,10 +90,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -104,10 +104,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -121,10 +121,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -99,10 +99,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -107,10 +107,10 @@ install:
       cmds:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
-            sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sudo sed -i "/^staging/d" /etc/newrelic-infra.yml
 
-            sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
-            sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(license_key: \).*/\1{{.NEW_RELIC_LICENSE_KEY}}/" /etc/newrelic-infra.yml
+            sudo sed -i "s/^\(enable_process_metrics: \).*/\1true/" /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
             sudo cat > /etc/newrelic-infra.yml <<EOT


### PR DESCRIPTION
Some customers receive an error because sed doesn't have permission to
modify the infra agent configuration. Add sudo in the command to fix it.