### PR TITLE
Install gnupg in ubuntu and debian

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -34,7 +34,7 @@ install:
         - task: assert_pre_req
         - task: setup_license
         - task: update_apt
-        - task: add_gnupg2_if_required
+        - task: install_gnupg
         - task: add_gpg_key
         - task: add_nr_source
         - task: update_apt_nr_source
@@ -145,15 +145,15 @@ install:
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 
-    add_gnupg2_if_required:
+    install_gnupg:
       cmds:
         - |
-          if [ $(({{.DEBIAN_VERSION}})) -ge 10 ]; then
+          if [ {{.HAS_GPG}} -eq 0 ] ; then
             sudo apt-get install gnupg2 -y
           fi
       vars:
-        DEBIAN_VERSION:
-          sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release
+        HAS_GPG:
+          sh: command -v gpg | wc -l
 
     add_gpg_key:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -36,6 +36,7 @@ install:
         - task: assert_pre_req
         - task: setup_license
         - task: update_apt
+        - task: install_gnupg
         - task: add_gpg_key
         - task: add_nr_source
         - task: update_apt_nr_source
@@ -130,6 +131,16 @@ install:
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
+
+    install_gnupg:
+      cmds:
+        - |
+          if [ {{.HAS_GPG}} -eq 0 ] ; then
+            sudo apt-get install gnupg2 -y
+          fi
+      vars:
+        HAS_GPG:
+          sh: command -v gpg | wc -l
 
     add_gpg_key:
       cmds:


### PR DESCRIPTION
I noticed that on some versions of ubuntu, gpg is not installed, which results in an error when adding the gpg key for the infra agent.

We're currently installing gpg on some versions of debian. I modified the recipe to install only when it's not already installed, which seems more robust. Let me know what you think.