### PR TITLE
fix(ohi): remove redirect URL filter for due to avoid redirect to blank page

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -40,7 +40,6 @@ validationNrql: "SELECT count(*) from CassandraSample where hostname like '{{.HO
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''CASSANDRANODE''"'
   
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -44,7 +44,6 @@ validationNrql: "SELECT count(*) from CassandraSample where hostname like '{{.HO
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''CASSANDRANODE''"'
   
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -34,7 +34,6 @@ validationNrql: "SELECT count(*) from ElasticsearchClusterSample where hostname 
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''ELASTICSEARCHNODE''"'
 
 inputVars:
   - name: "NR_CLI_API_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -37,7 +37,6 @@ validationNrql: "SELECT count(*) from ElasticsearchClusterSample where hostname 
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''ELASTICSEARCHNODE''"'
 
 inputVars:
   - name: "NR_CLI_API_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -31,7 +31,6 @@ validationNrql: "SELECT count(*) from ElasticsearchClusterSample where hostname 
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''ELASTICSEARCHNODE''"'
 
 inputVars:
   - name: "NR_CLI_API_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -43,7 +43,6 @@ validationNrql: "SELECT count(*) from MysqlSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''MYSQLNODE''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -43,7 +43,6 @@ validationNrql: "SELECT count(*) from MysqlSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''MYSQLNODE''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -40,7 +40,6 @@ validationNrql: "SELECT count(*) from MysqlSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''MYSQLNODE''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -39,7 +39,6 @@ validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''NGINXSERVER''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -43,7 +43,6 @@ validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''NGINXSERVER''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -36,7 +36,6 @@ validationNrql: "SELECT count(*) from NginxSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''NGINXSERVER''"'
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -33,7 +33,6 @@ validationNrql: "SELECT count(*) from PostgresqlDatabaseSample where hostname li
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''POSTGRESQLINSTANCE''"'
   
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -37,7 +37,6 @@ validationNrql: "SELECT count(*) from PostgresqlDatabaseSample where hostname li
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''POSTGRESQLINSTANCE''"'
   
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -39,7 +39,6 @@ validationNrql: "SELECT count(*) from RedisSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''REDISINSTANCE''"'
     
 # Prompts for input from the user. These variables then become
 # available to go-task in the form of {{.VAR_NAME}}

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -43,7 +43,6 @@ validationNrql: "SELECT count(*) from RedisSample where hostname like '{{.HOSTNA
 
 successLinkConfig:
   type: EXPLORER
-  filter: '"type = ''REDISINSTANCE''"'
 
 # Prompts for input from the user. These variables then become
 # available to go-task in the form of {{.VAR_NAME}}


### PR DESCRIPTION
Most entities seem to have a bit of a delay before they show up in the UI, so instead of redirecting users to a blank page by filtering to a specific type of entity, it's better to have them redirected to the main explore page so they at least see their Infra host entity at the very least. 