### PR TITLE
Check for PHP pre-reqs

### DIFF
--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -39,6 +39,7 @@ install:
   tasks:
     default:
       cmds:
+        - task: assert_pre_req
         - task: create_shared
         - task: detect_services
           #- task: install_packages
@@ -47,6 +48,34 @@ install:
         - task: restart_services
         - task: send_transaction
         - task: delete_shared
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ -z "$SUDO_USER" ]; then
+            echo "This installation recipe for the New Relic PHP agent must be run under sudo." >> /dev/stderr
+            exit 20
+          fi
+        - |
+          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+          then
+            echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'." >> /dev/stderr
+            exit 20
+          fi
+        - |
+          # Map of tool names to the associated error code
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:13 curl:14"
+          for tuple in $required_tools_and_error_codes; do
+            tool=$(echo ${tuple} |cut -d':' -f1)
+            code=$(echo ${tuple} |cut -d':' -f2)
+            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+            then
+              echo "This installation recipe for the New Relic PHP agent requires '${tool}' to be installed." >> /dev/stderr
+              exit ${code}
+            fi
+          done
 
     create_shared:
       cmds:

--- a/recipes/newrelic/apm/php-agent/php.yml
+++ b/recipes/newrelic/apm/php-agent/php.yml
@@ -54,7 +54,7 @@ install:
         - |
           if [ -z "$SUDO_USER" ]; then
             echo "This installation recipe for the New Relic PHP agent must be run under sudo." >> /dev/stderr
-            exit 20
+            exit 22
           fi
         - |
           IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
@@ -65,7 +65,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:13 curl:14"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22"
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
             code=$(echo ${tuple} |cut -d':' -f2)


### PR DESCRIPTION
Note: This is based on Amber's PR (#359) and will need to be rebased once that is merged.

This PR adds an `assert_pre_req` step that checks the following:
* The recipe is being run via sudo.
* The target host has systemd installed.
* grep, egrep, sed, awk, and curl are installed.

The bulk of the code for this step was taken from the [.NET recipe](https://github.com/newrelic/open-install-library/blob/e7347282f607e079f528d8199b678f29dbeb4fcb/recipes/newrelic/apm/dotNet/linux-systemd.yml#L102).