### PR TITLE
PHP RedHat deploy configs

### DIFF
--- a/test/deploy/linux/php/apache-fpm-wordpress/redhat/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/php/apache-fpm-wordpress/redhat/roles/configure/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- debug:
+    msg: Install PHP
+
+- name: install PHP
+  shell: "amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2"
+  become: yes
+
+- name: install other pre-reqs
+  yum:
+    pkg:
+      - httpd
+      - mariadb
+      - mariadb-server
+    state: present
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../../../templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/deploy/linux/php/apache-wordpress/redhat/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/php/apache-wordpress/redhat/roles/configure/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- debug:
+    msg: Install PHP
+
+- name: install PHP
+  shell: "amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2"
+  become: yes
+
+- name: install other pre-reqs
+  yum:
+    pkg:
+      - php
+      - httpd
+      - mariadb
+      - mariadb-server
+    state: present
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../../../templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/deploy/linux/php/nginx-fpm-wordpress/redhat/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/php/nginx-fpm-wordpress/redhat/roles/configure/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- debug:
+    msg: Install PHP
+
+- name: install PHP and nginx
+  shell: "amazon-linux-extras install -y nginx1 lamp-mariadb10.2-php7.2 php7.2"
+  become: yes
+
+- name: install other pre-reqs
+  yum:
+    pkg:
+      - mariadb
+      - mariadb-server
+    state: present
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - "../../../../../templates/*"
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/deploy/linux/php/templates/wordpress-httpd.conf
+++ b/test/deploy/linux/php/templates/wordpress-httpd.conf
@@ -1,0 +1,14 @@
+<Directory /wordpress>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Order allow,deny
+    Require all granted
+    Allow from all
+</Directory>
+<Directory /wordpress/wp-content>
+    Options FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
@@ -1,0 +1,29 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+      "id": "php-a-f-w-l2",
+      "display_name": "PHP Apache FPM Wordpress",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3a.micro",
+      "ami_name": "amazonlinux-2-base*",
+      "user_name": "ec2-user"
+    }],
+
+    "services": [
+        {
+          "id": "wordpress",
+          "display_name": "RedHat PHP Apache FPM Wordpress",
+          "local_source_path": "/mnt/open-install-library",
+          "deploy_script_path": "test/deploy/linux/php/apache-fpm-wordpress/redhat/roles",
+          "port": 80,
+          "destinations": ["php-a-f-w-l2"]
+        }
+    ]
+}

--- a/test/manual/definitions/apm/php-agent/php-apache-wordpress-linux2.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-wordpress-linux2.json
@@ -1,0 +1,29 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+      "id": "php-a-w-l2",
+      "display_name": "PHP Apache Wordpress",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3a.micro",
+      "ami_name": "amazonlinux-2-base*",
+      "user_name": "ec2-user"
+    }],
+
+    "services": [
+        {
+          "id": "wordpress",
+          "display_name": "RedHat PHP Apache Wordpress",
+          "local_source_path": "/mnt/open-install-library",
+          "deploy_script_path": "test/deploy/linux/php/apache-wordpress/redhat/roles",
+          "port": 80,
+          "destinations": ["php-a-w-l2"]
+        }
+    ]
+}

--- a/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
+++ b/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
@@ -1,0 +1,29 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+      "id": "php-n-f-w-l2",
+      "display_name": "PHP nginx FPM Wordpress",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3a.micro",
+      "ami_name": "amazonlinux-2-base*",
+      "user_name": "ec2-user"
+    }],
+
+    "services": [
+        {
+          "id": "wordpress",
+          "display_name": "RedHat PHP nginx FPM Wordpress",
+          "local_source_path": "/mnt/open-install-library",
+          "deploy_script_path": "test/deploy/linux/php/nginx-fpm-wordpress/redhat/roles",
+          "port": 80,
+          "destinations": ["php-n-f-w-l2"]
+        }
+    ]
+}


### PR DESCRIPTION
This PR creates PHP deploy configs for Amazon Linux 2 (a RedHat derivative). It mirrors what was done for Debian by creating a Wordpress install for Apache, Apache + FPM, and nginx + FPM.