### PR TITLE
feat: Nginx Check if user has stub_status enabled and change error codes

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -45,7 +45,7 @@ preInstall:
       To capture data from the NGINX integration, you'll first need to enable
       and configure the applicable extension module:
       - For NGINX Open Source: HTTP stub status module 
-      - For NGINX Plus: HTTP status module and HTTP API module
+      - For NGINX Plus: HTTP status module or HTTP API module
       - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info.
 
 install:
@@ -93,10 +93,13 @@ install:
               ((tries++))
               echo "The status url provided $input couldn't be reached. Try again"
               if [ ! $tries -lt {{.MAX_RETRIES}} ]; then
-                echo "NGINX HTTP status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                if [ $(sudo nginx -V 2>&1 | grep -o "with-http_stub_status_module" | wc -l) -eq 0 ] ; then
+                  echo "with-http_stub_status_module should be enabled in order to monitor NGINX \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                  exit 4
+                fi
+                echo "NGINX HTTP status page should be set up with a locally accessible URL in the conf server block. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
                 exit 2
               fi
-              echo "Try again"
             done
           fi
 
@@ -108,8 +111,8 @@ install:
           elif [ ! $(echo $STATUS_RESPONSE | grep '"nginx"' | wc -l) -eq 0 ] ; then
             NR_CLI_STATUS_MODULE="ngx_http_api_module"
           else
-            echo "NGINX status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
-            exit 2
+            echo "The endpoint provided is not an NGINX status endpoint. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+            exit 3
           fi
           printf "\n[OK] All checks passed. Installing Nginx Integration...\n\n"
 

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -49,7 +49,7 @@ preInstall:
       To capture data from the NGINX integration, you'll first need to enable
       and configure the applicable extension module:
       - For NGINX Open Source: HTTP stub status module 
-      - For NGINX Plus: HTTP status module and HTTP API module
+      - For NGINX Plus: HTTP status module or HTTP API module
       - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info.
 
 install:
@@ -97,10 +97,13 @@ install:
               ((tries++))
               echo "The status url provided $input couldn't be reached. Try again"
               if [ ! $tries -lt {{.MAX_RETRIES}} ]; then
-                echo "NGINX HTTP status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                if [ $(sudo nginx -V 2>&1 | grep -o "with-http_stub_status_module" | wc -l) -eq 0 ] ; then
+                  echo "with-http_stub_status_module should be enabled in order to monitor NGINX \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                  exit 4
+                fi
+                echo "NGINX HTTP status page should be set up with a locally accessible URL in the conf server block. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
                 exit 2
               fi
-              echo "Try again"
             done
           fi
 
@@ -112,8 +115,8 @@ install:
           elif [ ! $(echo $STATUS_RESPONSE | grep '"nginx"' | wc -l) -eq 0 ] ; then
             NR_CLI_STATUS_MODULE="ngx_http_api_module"
           else
-            echo "NGINX status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
-            exit 2
+            echo "The endpoint provided is not an NGINX status endpoint. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+            exit 3
           fi
           printf "\n[OK] All checks passed. Installing Nginx Integration...\n\n"
 

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -42,7 +42,7 @@ preInstall:
       To capture data from the NGINX integration, you'll first need to enable
       and configure the applicable extension module:
       - For NGINX Open Source: HTTP stub status module 
-      - For NGINX Plus: HTTP status module and HTTP API module
+      - For NGINX Plus: HTTP status module or HTTP API module
       - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info.
 
 install:
@@ -90,10 +90,13 @@ install:
               ((tries++))
               echo "The status url provided $input couldn't be reached. Try again"
               if [ ! $tries -lt {{.MAX_RETRIES}} ]; then
-                echo "NGINX HTTP status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                if [ $(sudo nginx -V 2>&1 | grep -o "with-http_stub_status_module" | wc -l) -eq 0 ] ; then
+                  echo "with-http_stub_status_module should be enabled in order to monitor NGINX \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+                  exit 4
+                fi
+                echo "NGINX HTTP status page should be set up with a locally accessible URL in the conf server block. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
                 exit 2
               fi
-              echo "Try again"
             done
           fi
 
@@ -105,8 +108,8 @@ install:
           elif [ ! $(echo $STATUS_RESPONSE | grep '"nginx"' | wc -l) -eq 0 ] ; then
             NR_CLI_STATUS_MODULE="ngx_http_api_module"
           else
-            echo "NGINX status must be configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
-            exit 2
+            echo "The endpoint provided is not an NGINX status endpoint. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config for more info." >> /dev/stderr
+            exit 3
           fi
           printf "\n[OK] All checks passed. Installing Nginx Integration...\n\n"
 


### PR DESCRIPTION
- Add check to control if user has "with-http_stub_status_module" enabled, as it's required by NGINX in order to be monitored.
- If "with-http_stub_status_module" is detected but the url failed, inform the user that also the status endpoint should be set up and point him to our documentation in order to correctly set it up.