### PR TITLE
Improving Tomcat autodetection for CLI

### DIFF
--- a/recipes/newrelic/apm/java/linux.yml
+++ b/recipes/newrelic/apm/java/linux.yml
@@ -15,7 +15,7 @@ keywords:
   - java
 
 processMatch:
-  - java.*catalina
+  - java.*org.apache.catalina.startup.Bootstrap
 
 validationNrql: "SELECT count(*) FROM ApplicationAgentContext WHERE host LIKE '{{.HOSTNAME}}%' SINCE 10 minutes AGO"
 


### PR DESCRIPTION
Instead of simply matching for `catalina`, will match for the whole class that starts Tomcat.
This can prevent mismatching in case they are running another Java process which has `catalina` as part of a parameter.