### PR TITLE
Added exit 130 - missing env vars

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -66,6 +66,7 @@ install:
         - task: input_assert
           vars:
             MAX_RETRIES: 3
+            EXIT130: ""
         - task: restart
 
     assert_infra:
@@ -92,8 +93,6 @@ install:
           # Set Defaults
           NR_CLI_DB_HOSTNAME=${NR_CLI_DB_HOSTNAME:-localhost}
           NR_CLI_DB_PORT=${NR_CLI_DB_PORT:-3306}
-          NR_CLI_DB_USERNAME=${NR_CLI_DB_USERNAME:-''}
-          NR_CLI_DB_PASSWORD=${NR_CLI_DB_PASSWORD:-''}
 
           if [[ "$NEW_RELIC_ASSUME_YES" != "true" ]]; then
             while [ $TRIES -lt {{.MAX_RETRIES}} ]; do
@@ -159,7 +158,20 @@ install:
               fi
           done
           fi
-          printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+
+          if [ "$NR_CLI_DB_USERNAME" == "" ]; then
+            EXIT130=" - NR_CLI_DB_USERNAME=<mysql_username>\n"
+          fi
+          if [ "$NR_CLI_DB_PASSWORD" == "" ]; then
+            EXIT130="$EXIT130 - NR_CLI_DB_PASSWORD=<mysql_password>\n"
+          fi
+
+          if [ "$EXIT130" != "" ]; then
+            printf "You did not provide all the required environment variables. Please set the following variable(s) and try again:\n\n$EXIT130\n"
+            exit 130
+          else
+            printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+          fi
 
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -66,6 +66,7 @@ install:
         - task: input_assert
           vars:
             MAX_RETRIES: 3
+            EXIT130: ""
         - task: restart
 
     assert_infra:
@@ -159,7 +160,20 @@ install:
               fi
           done
           fi
-          printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+
+          if [ "$NR_CLI_DB_USERNAME" == "" ]; then
+            EXIT130=" - NR_CLI_DB_USERNAME=<mysql_username>\n"
+          fi
+          if [ "$NR_CLI_DB_PASSWORD" == "" ]; then
+            EXIT130="$EXIT130 - NR_CLI_DB_PASSWORD=<mysql_password>\n"
+          fi
+
+          if [ "$EXIT130" != "" ]; then
+            printf "You did not provide all the required environment variables. Please set the following variable(s) and try again:\n\n$EXIT130\n"
+            exit 130
+          else
+            printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+          fi
 
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -87,8 +87,6 @@ install:
           NEW_RELIC_ASSUME_YES="{{.NEW_RELIC_ASSUME_YES}}"
           NR_CLI_DB_HOSTNAME="{{.NR_CLI_DB_HOSTNAME}}"
           NR_CLI_DB_PORT="{{.NR_CLI_DB_PORT}}"
-          NR_CLI_DB_USERNAME="{{.NR_CLI_DB_USERNAME}}"
-          NR_CLI_DB_PASSWORD="{{.NR_CLI_DB_PASSWORD}}"
 
           # Set Defaults
           NR_CLI_DB_HOSTNAME=${NR_CLI_DB_HOSTNAME:-localhost}

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -90,8 +90,6 @@ install:
           # Set Defaults
           NR_CLI_DB_HOSTNAME=${NR_CLI_DB_HOSTNAME:-localhost}
           NR_CLI_DB_PORT=${NR_CLI_DB_PORT:-3306}
-          NR_CLI_DB_USERNAME=${NR_CLI_DB_USERNAME:-''}
-          NR_CLI_DB_PASSWORD=${NR_CLI_DB_PASSWORD:-''}
 
           if [[ "$NEW_RELIC_ASSUME_YES" != "true" ]]; then
             while [ $TRIES -lt {{.MAX_RETRIES}} ]; do

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -63,6 +63,7 @@ install:
         - task: input_assert
           vars:
             MAX_RETRIES: 3
+            EXIT130: ""
         - task: restart
 
     assert_infra:
@@ -156,7 +157,20 @@ install:
               fi
           done
           fi
-          printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+
+          if [ "$NR_CLI_DB_USERNAME" == "" ]; then
+            EXIT130=" - NR_CLI_DB_USERNAME=<mysql_username>\n"
+          fi
+          if [ "$NR_CLI_DB_PASSWORD" == "" ]; then
+            EXIT130="$EXIT130 - NR_CLI_DB_PASSWORD=<mysql_password>\n"
+          fi
+
+          if [ "$EXIT130" != "" ]; then
+            printf "You did not provide all the required environment variables. Please set the following variable(s) and try again:\n\n$EXIT130\n"
+            exit 130
+          else
+            printf "\n[OK] All checks passed. Installing MySQL Integration...\n\n"
+          fi
 
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"


### PR DESCRIPTION
Added exit status 130 if required env vars are not supplied when running in -y mode