### PR TITLE
Dotnet linux preinstall

### DIFF
--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -21,21 +21,19 @@ processMatch: []
 preInstall:
   requireAtDiscovery:
     - |
-      rm -rf /tmp/dotnet-introspector >/dev/null
-      curl -s https://virtuoso-testing.s3-us-west-2.amazonaws.com/dotnet-is-linux-x64.gz -o /tmp/dotnet-is-linux-x64.gz >/dev/null
-      mkdir -p /tmp/dotnet-introspector >/dev/null
-      zcat /tmp/dotnet-is-linux-x64.gz > /tmp/dotnet-introspector/nri-lsi-dotnet
-      rm -f /tmp/dotnet-is-linux-x64.gz >/dev/null
-      chmod -R 777 /tmp/dotnet-introspector >/dev/null
-      processCount=$(/tmp/dotnet-introspector/nri-lsi-dotnet -c | tr -d '[]' | tr ',' '\n' | wc -w)
+      TMP_DIR=$(mktemp -dq /tmp/newrelic.XXXXXX)
+      curl -s https://virtuoso-testing.s3-us-west-2.amazonaws.com/dotnet-is-linux-x64.gz -o ${TMP_DIR}/dotnet-is-linux-x64.gz >/dev/null
+      zcat ${TMP_DIR}/dotnet-is-linux-x64.gz > ${TMP_DIR}/nri-lsi-dotnet
+      chmod u+x $TMP_DIR/nri-lsi-dotnet >/dev/null
+      processCount=$(${TMP_DIR}/nri-lsi-dotnet -c | tr -d '[]' | tr ',' '\n' | wc -w)
       if [[ "$processCount" -ne 0 ]]; then
         # Found .NET processes - return 0
-        rm -rf /tmp/dotnet-introspector >/dev/null
+        rm -rf $TMP_DIR >/dev/null
         exit 0
       fi
 
       # No .NET processes - return 3 (No processes found to monitor)
-      rm -rf /tmp/dotnet-introspector >/dev/null
+      rm -rf $TMP_DIR >/dev/null
       exit 3
 
 validationNrql: "SELECT count(*) FROM NrIntegrationError WHERE purpose = 'New Relic CLI configuration validation' AND hostname like '{{.HOSTNAME}}%' since 10 minutes ago"

--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -18,6 +18,26 @@ keywords:
 
 processMatch: []
 
+preInstall:
+  requireAtDiscovery:
+    - |
+      rm -rf /tmp/dotnet-introspector
+      curl -s https://virtuoso-testing.s3-us-west-2.amazonaws.com/dotnet-is-linux-x64.gz -o /tmp/dotnet-is-linux-x64.gz
+      mkdir -p /tmp/dotnet-introspector
+      zcat /tmp/dotnet-is-linux-x64.gz > /tmp/dotnet-introspector/nri-lsi-dotnet
+      rm -f /tmp/dotnet-is-linux-x64.gz
+      chmod -R 777 /tmp/dotnet-introspector
+      processCount=$(/tmp/dotnet-introspector/nri-lsi-dotnet -c | tr -d '[]' | tr ',' '\n' | wc -w)
+      if [[ "$processCount" -ne 0 ]]; then
+        # Found .NET processes
+        rm -rf /tmp/dotnet-introspector
+        exit 0
+      fi
+
+      # No .NET processes
+      rm -rf /tmp/dotnet-introspector
+      exit 2
+
 validationNrql: "SELECT count(*) FROM NrIntegrationError WHERE purpose = 'New Relic CLI configuration validation' AND hostname like '{{.HOSTNAME}}%' since 10 minutes ago"
 
 successLinkConfig:

--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -21,22 +21,22 @@ processMatch: []
 preInstall:
   requireAtDiscovery:
     - |
-      rm -rf /tmp/dotnet-introspector
-      curl -s https://virtuoso-testing.s3-us-west-2.amazonaws.com/dotnet-is-linux-x64.gz -o /tmp/dotnet-is-linux-x64.gz
-      mkdir -p /tmp/dotnet-introspector
+      rm -rf /tmp/dotnet-introspector >/dev/null
+      curl -s https://virtuoso-testing.s3-us-west-2.amazonaws.com/dotnet-is-linux-x64.gz -o /tmp/dotnet-is-linux-x64.gz >/dev/null
+      mkdir -p /tmp/dotnet-introspector >/dev/null
       zcat /tmp/dotnet-is-linux-x64.gz > /tmp/dotnet-introspector/nri-lsi-dotnet
-      rm -f /tmp/dotnet-is-linux-x64.gz
-      chmod -R 777 /tmp/dotnet-introspector
+      rm -f /tmp/dotnet-is-linux-x64.gz >/dev/null
+      chmod -R 777 /tmp/dotnet-introspector >/dev/null
       processCount=$(/tmp/dotnet-introspector/nri-lsi-dotnet -c | tr -d '[]' | tr ',' '\n' | wc -w)
       if [[ "$processCount" -ne 0 ]]; then
-        # Found .NET processes
-        rm -rf /tmp/dotnet-introspector
+        # Found .NET processes - return 0
+        rm -rf /tmp/dotnet-introspector >/dev/null
         exit 0
       fi
 
-      # No .NET processes
-      rm -rf /tmp/dotnet-introspector
-      exit 2
+      # No .NET processes - return 3 (No processes found to monitor)
+      rm -rf /tmp/dotnet-introspector >/dev/null
+      exit 3
 
 validationNrql: "SELECT count(*) FROM NrIntegrationError WHERE purpose = 'New Relic CLI configuration validation' AND hostname like '{{.HOSTNAME}}%' since 10 minutes ago"
 


### PR DESCRIPTION
Adds a preinstall script to detect if a recipe should be executed.  This is based on our existing introspector task in the recipe and uses the .NET introspector to gather a list of process that are running .NET Core  or .NET 5+.  All steps that can be sent to dev/null are to prevent any extra output.

Workflow:
1. Attempts to delete the folder we use to temporarily hold the introspector - `/tmp/dotnet-introspector` (same one from the introspector task)
2. Downloads the Linux x64 introspector zip to `/tmp`
3. Creates the `/tmp/dotnet-introspector` directory for the extracted introspector
4. Extracts the intospector using zcat (no dependencies)
5. Removes the zip file from `/tmp`
6. Uses chmod to set the `/tmp/dotnet-introspector` to 777 to allow the tool to run properly
7. Runs the instrospector, converts the json list of PIDs into a simple list, counts the number of lines, and puts that value in a variable
8. Checks if the value from step 7 not equal to 0, if it is then we found .NET process and exit with a 0.   If we did get back 0 then we did not find any running .NET process exit with a 3 - the error for for "No processes found to monitor".