### PR TITLE
PHP: use curl instead of wget

### DIFF
--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -220,7 +220,7 @@ install:
         - |
           echo -e "{{.ARROW}}Installing New Relic PHP Agent package{{.GRAY}}"
           echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
-          wget -q -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
+          curl -s https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install newrelic-php5 -y -qq
 


### PR DESCRIPTION
This PR reduces the number of dependencies required to run the recipe by replacing the one usage of wget with curl.