### PR TITLE
PHP: Add assert_pre_req and cleanup on exit

### DIFF
--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -88,6 +88,7 @@ install:
               fi
               if [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
                 echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
+                rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
                 exit 130
               fi
               if [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
@@ -100,8 +101,22 @@ install:
     assert_pre_req:
       cmds:
         - |
+          if [ -z "$SUDO_USER" ]; then
+            echo "This installation recipe for the New Relic PHP agent must be run under sudo." >> /dev/stderr
+            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
+            exit 7
+          fi
+        - |
+          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+          then
+            echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'." >> /dev/stderr
+            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
+            exit 20
+          fi
+        - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
@@ -111,6 +126,7 @@ install:
             if [ "$IS_TOOL_INSTALLED" -eq 0 ]
             then
               echo "This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed." >> /dev/stderr
+              rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
               exit ${code}
             fi
           done
@@ -246,6 +262,7 @@ install:
               # We really shouldn't get here if we found the tar file.
               # Exit with Agent install failure code exit(16)
               echo -e "{{.RED}}Unable to find agent install log.{{.NOCOLOR}}"
+              rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
               exit 16
             fi
           else
@@ -253,6 +270,7 @@ install:
             # If tar file doesn't exist, something went wrong with installation.
             # Exit with Agent install failure code exit(16)
             echo -e "{{.RED}}Unable to find agent install log tarfile.{{.NOCOLOR}}"
+            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
             exit 16
           fi
           WEB_CONFD=$(grep 'final pi_inidir_dso' "$NR_INSTALL_LOG" | cut -d'=' -f2)

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -88,7 +88,6 @@ install:
               fi
               if [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
                 echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
-                rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
                 exit 130
               fi
               if [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
@@ -103,7 +102,6 @@ install:
         - |
           if [ -z "$SUDO_USER" ]; then
             echo "This installation recipe for the New Relic PHP agent must be run under sudo." >> /dev/stderr
-            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
             exit 7
           fi
         - |
@@ -111,7 +109,6 @@ install:
           if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
           then
             echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'." >> /dev/stderr
-            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
             exit 20
           fi
         - |
@@ -126,7 +123,6 @@ install:
             if [ "$IS_TOOL_INSTALLED" -eq 0 ]
             then
               echo "This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed." >> /dev/stderr
-              rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
               exit ${code}
             fi
           done
@@ -262,7 +258,6 @@ install:
               # We really shouldn't get here if we found the tar file.
               # Exit with Agent install failure code exit(16)
               echo -e "{{.RED}}Unable to find agent install log.{{.NOCOLOR}}"
-              rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
               exit 16
             fi
           else
@@ -270,7 +265,6 @@ install:
             # If tar file doesn't exist, something went wrong with installation.
             # Exit with Agent install failure code exit(16)
             echo -e "{{.RED}}Unable to find agent install log tarfile.{{.NOCOLOR}}"
-            rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
             exit 16
           fi
           WEB_CONFD=$(grep 'final pi_inidir_dso' "$NR_INSTALL_LOG" | cut -d'=' -f2)


### PR DESCRIPTION
Expands the `assert_pre_req` and completes [166](https://github.com/newrelic/newrelic-php-agent/issues/166).

~I couldn't find a way to call a task from another task from the docs (unless it's there and I totally missed it 🙃. Otherwise, the easy thing to do is to just call the `cleanup_temp_files` task on exit.~

Confirmed that this is not possible, so I removed the cleanup. A successful run should do the necessary cleanup.