### PR TITLE
Fix for when the recipe name contains a keyword we search for

### DIFF
--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -152,11 +152,11 @@ install:
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do
-            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
-            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $11}')
+            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
+            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $11}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
-              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $14}')
+              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
               fpm_ver=$(echo "${fpm_process_loc}" | sed -n 's/.*\/php\/\([578].[0-9]\)\/.*/\1/p')
               if [ -n "${fpm_ver}" ]; then
                 # It's fpm.
@@ -170,7 +170,7 @@ install:
             fi
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
-              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v $priv_user | head -n1 | awk '{print $1}')
+              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
             fi
             if [ -n "${process_name}" ]; then
               if [ -z "${nonpriv_user}" ]; then

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -148,7 +148,7 @@ install:
           # while there are many ways to end up with libapache2-mod-php5 installed,
           # it's unlikely php5-fpm will be installed unless FPM is actually in use.
           #
-          declare -a guided_support=("(fpm)" "(httpd|apache2|apache)" "(nginx)")
+          declare -a guided_support=("(php-fpm)" "(httpd|apache2|apache)" "(nginx)")
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -149,11 +149,11 @@ install:
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do
-            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $1}')
-            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $11}')
+            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
+            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $11}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
-              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | head -n1 | awk '{print $14}')
+              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
               fpm_ver=$(echo "${fpm_process_loc}" | sed -n 's/.*\/php\/\([578].[0-9]\)\/.*/\1/p')
               if [ -n "${fpm_ver}" ]; then
                 # It's fpm.
@@ -167,7 +167,7 @@ install:
             fi
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
-              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v $priv_user | head -n1 | awk '{print $1}')
+              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
             fi
             if [ -n "${process_name}" ]; then
               if [ -z "${nonpriv_user}" ]; then

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -145,7 +145,7 @@ install:
           # while there are many ways to end up with libapache2-mod-php5 installed,
           # it's unlikely php5-fpm will be installed unless FPM is actually in use.
           #
-          declare -a guided_support=("(fpm)" "(httpd|apache2|apache)" "(nginx)")
+          declare -a guided_support=("(php-fpm)" "(httpd|apache2|apache)" "(nginx)")
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do


### PR DESCRIPTION
The `fpm` grep was getting triggered by the process that called a recipe containing the keyword `fpm`.

Fixed this in two ways:
1) Narrowed the keyword we search for to `php-fpm`.
2) Added `grep` clause to ignore items containing `yml` so that if a future recipe name contains the keywords we are looking for, we won't grab the line containing the call to run that recipe.
This could have been an issue with apache as well if for instance there were a recipe named `debian-apache2.yml`.