### PR TITLE
Fix python regex to show recommendet nerdlet

### DIFF
--- a/recipes/newrelic/apm/python/linux.yml
+++ b/recipes/newrelic/apm/python/linux.yml
@@ -14,7 +14,7 @@ keywords:
   - python
 
 processMatch:
-  - python(?!.*\/usr\/share)
+  - (.python.)(.\/usr\/local\/bin\/.|.\/home\/.)
 
 install:
 


### PR DESCRIPTION
Verified the regex is now working properly by running `newrelic install --trace`, there is no longer an error when evaluating python regex.
