### PR TITLE
PHP Virtuoso: ubuntu and redhat updates

### DIFF
--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -72,7 +72,7 @@ install:
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation will not automatically restart the php-fpm or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
           fi
           echo -e "{{.GRAY}}
-          Note: If you are hosting your PHP application on something other than nginx or php-fpm, please select 'n' and check out our other installation options:
+          Note: If you are hosting your PHP application on something other than apache, nginx, or php-fpm, please select 'n' and check out our other installation options:
           https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-overview/{{.NOCOLOR}}
           "
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -150,11 +150,17 @@ install:
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do
-            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
-            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $11}')
+            #
+            # First look for the full process name with a minimal set of other values so
+            # that there is no chance of filtering off of those (for instance, when the
+            # username is `apache` or something similar to the filters.  Then use the name
+            # for other searches.
+            #
+            full_process_name=$(ps xf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $5}')
+            priv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
-              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
+              fpm_process_loc=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
               fpm_ver=$(echo "${fpm_process_loc}" | sed -n 's/.*\/php\/\([578].[0-9]\)\/.*/\1/p')
               if [ -n "${fpm_ver}" ]; then
                 # It's fpm.
@@ -168,7 +174,7 @@ install:
             fi
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
-              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
+              nonpriv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
             fi
             if [ -n "${process_name}" ]; then
               if [ -z "${nonpriv_user}" ]; then
@@ -318,11 +324,27 @@ install:
               read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
               echo -e "{{.RED}}Please restart $process as privileged user $user_name for instrumentation to be enabled.{{.NOCOLOR}}"
             else
-              echo -e "{{.RED}}You will need to restart your PHP web server in order for web instrumentation to be enabled.{{.NOCOLOR}}"
-              if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-                echo -n "Press enter to continue once this has been done."
+              echo -e "{{.RED}}You will need to restart your PHP web server in order for web instrumentation to be enabled.{{.NOCOLORi}}"
+            fi
+            if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
+              while :; do
+                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
                 read answer
-              fi
+                echo ""
+                NEW_RELIC_RESTARTED=$(echo "${answer^^}" | cut -c1-1)
+                if [[ -z "$NEW_RELIC_RESTARTED" ]]; then
+                  NEW_RELIC_RESTARTED="Y"
+                fi
+                if [[ "$NEW_RELIC_RESTARTED" == "N" ] || [ "$NEW_RELIC_RESTARTED" == "n" ]]; then
+                  echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
+		  #exit 23: User declined to accept recipe terms
+                  exit 23
+                fi
+                if [[ "$NEW_RELIC_RESTARTED" == "Y" ] || [ "$NEW_RELIC_RESTARTED" == "y" ]]; then
+                  break
+                fi
+                echo -e "{{.WHITE}}Please type Y or N only.{{.NOCOLOR}}"
+              done
             fi
           fi
 

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -28,7 +28,7 @@ inputVars:
     prompt: "What is the name of your PHP application?"
     default: "PHP Application"
   - name: "NR_PHP_RESTART"
-    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm or nginx depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
     default: "y"
 
 install:
@@ -328,7 +328,7 @@ install:
             fi
             if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
               while :; do
-                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
+                echo -n -e "{{.YELLOW}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
                 read answer
                 echo ""
                 NEW_RELIC_RESTARTED=$(echo "${answer^^}" | cut -c1-1)

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -28,7 +28,7 @@ inputVars:
     prompt: "What is the name of your PHP application?"
     default: "PHP Application"
   - name: "NR_PHP_RESTART"
-    prompt: "Restart the PHP application after installation? (y/n)"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm or nginx depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
     default: "y"
 
 install:
@@ -64,15 +64,15 @@ install:
     verify_continue:
       cmds:
         - |
+          echo -e "{{.YELLOW}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
+          echo -e "* The following application name was selected: {{.NR_PHP_APPLICATION}}"
           if [ "{{.NR_PHP_RESTART}}" = "y" ]; then
-            echo -e "{{.YELLOW}}Confirmation:
-            This installation will restart php-fpm or nginx depending on the application
-            architecture detected. If you would prefer to run this step manually, enter 'n'
-            at the following prompt to exit the installer, and enter 'n' at the previous restart prompt.{{.NOCOLOR}}"
+            echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation will restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
+          else
+            echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation will not automatically restart the php-fpm or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
           fi
-
           echo -e "{{.GRAY}}
-          Note: If you are hosting your PHP application differently, check out our other installation options:
+          Note: If you are hosting your PHP application on something other than nginx or php-fpm, please select 'n' and check out our other installation options:
           https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-overview/{{.NOCOLOR}}
           "
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
@@ -84,11 +84,11 @@ install:
               if [[ -z "$NEW_RELIC_CONTINUE" ]]; then
                 NEW_RELIC_CONTINUE="Y"
               fi
-              if [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
+              if [[ "$NEW_RELIC_CONTINUE" == "n" ]] || [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
                 echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
                 exit 130
               fi
-              if [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
+              if [[ "$NEW_RELIC_CONTINUE" == "y" ]] || [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
                 break
               fi
               echo -e "{{.WHITE}}Please type Y or N only.{{.NOCOLOR}}"
@@ -328,19 +328,19 @@ install:
             fi
             if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
               while :; do
-                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
+                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
                 read answer
                 echo ""
                 NEW_RELIC_RESTARTED=$(echo "${answer^^}" | cut -c1-1)
                 if [[ -z "$NEW_RELIC_RESTARTED" ]]; then
                   NEW_RELIC_RESTARTED="Y"
                 fi
-                if [[ "$NEW_RELIC_RESTARTED" == "N" ] || [ "$NEW_RELIC_RESTARTED" == "n" ]]; then
+                if [[ "$NEW_RELIC_RESTARTED" == "N" ]] || [[ "$NEW_RELIC_RESTARTED" == "n" ]]; then
                   echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
-		  #exit 23: User declined to accept recipe terms
-                  exit 23
+		  # exit 130: Installation was cancelled either using Ctrl+C or by selecting not to continue the installation
+                  exit 130
                 fi
-                if [[ "$NEW_RELIC_RESTARTED" == "Y" ] || [ "$NEW_RELIC_RESTARTED" == "y" ]]; then
+                if [[ "$NEW_RELIC_RESTARTED" == "Y" ]] || [[ "$NEW_RELIC_RESTARTED" == "y" ]]; then
                   break
                 fi
                 echo -e "{{.WHITE}}Please type Y or N only.{{.NOCOLOR}}"

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -337,7 +337,7 @@ install:
                 fi
                 if [[ "$NEW_RELIC_RESTARTED" == "N" ]] || [[ "$NEW_RELIC_RESTARTED" == "n" ]]; then
                   echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
-		  # exit 130: Installation was cancelled either using Ctrl+C or by selecting not to continue the installation
+                  # exit 130: Installation was cancelled either using Ctrl+C or by selecting not to continue the installation
                   exit 130
                 fi
                 if [[ "$NEW_RELIC_RESTARTED" == "Y" ]] || [[ "$NEW_RELIC_RESTARTED" == "y" ]]; then

--- a/recipes/newrelic/apm/php/debian-fpm.yml
+++ b/recipes/newrelic/apm/php/debian-fpm.yml
@@ -64,7 +64,7 @@ install:
     verify_continue:
       cmds:
         - |
-          echo -e "{{.YELLOW}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
+          echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
           echo -e "* The following application name was selected: {{.NR_PHP_APPLICATION}}"
           if [ "{{.NR_PHP_RESTART}}" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation will restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -66,7 +66,7 @@ install:
           if [ "{{.NR_PHP_RESTART}}" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation WILL restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
           else
-            echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the php-fpm or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
+            echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the php-fpm, apache, or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
           fi
           echo -e "{{.GRAY}}
           Note: If you are hosting your PHP application on something other than apache, nginx, or php-fpm, please select 'n' and check out our other installation options:

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -341,14 +341,14 @@ install:
           echo -e "{{.ARROW}}Send queryable transactions{{.GRAY}}"
           cd {{.TMP_INSTALL_DIR}}
           NR_INSTALL_LOG={{.TMP_INSTALL_DIR}}/nrinstall.log
-          WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
+          WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\)\/php.d/\1/p' $NR_INSTALL_LOG)
           WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_dso=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
           if [ -z "${WEB_PHP_INI_DIR}" ]; then
             WEB_PHP_INI_DIR=$WEB_NR_INI_DIR
           fi
           # Fallback to cli ini dir if there is no web specific ini dir
           if [ -z "${WEB_PHP_INI_DIR}" ]; then
-            WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_cli=\(.*\)\/conf.d/\1/p' $NR_INSTALL_LOG)
+            WEB_PHP_INI_DIR=$(sed -n 's/.*pi_inidir_cli=\(.*\)\/php.d/\1/p' $NR_INSTALL_LOG)
             WEB_NR_INI_DIR=$(sed -n 's/.*pi_inidir_cli=\(.*\/\)/\1/p' $NR_INSTALL_LOG)
             if [ -z "${WEB_PHP_INI_DIR}" ]; then
               WEB_PHP_INI_DIR=$WEB_NR_INI_DIR

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -149,11 +149,17 @@ install:
           current_user=$SUDO_USER
           for PROCESS in ${guided_support[@]}
           do
-            priv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
-            full_process_name=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $11}')
+            #
+            # First look for the full process name with a minimal set of other values so
+            # that there is no chance of filtering off of those (for instance, when the
+            # username is `apache` or something similar to the filters.  Then use the name
+            # for other searches.
+            #
+            full_process_name=$(ps xf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $5}')
+            priv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
-              fpm_process_loc=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
+              fpm_process_loc=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $14}')
               fpm_ver=$(echo "${fpm_process_loc}" | sed -n 's/.*\/php\/\([578].[0-9]\)\/.*/\1/p')
               if [ -n "${fpm_ver}" ]; then
                 # It's fpm.
@@ -167,7 +173,7 @@ install:
             fi
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
-              nonpriv_user=$(ps auxf | egrep $PROCESS | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
+              nonpriv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')
             fi
             if [ -n "${process_name}" ]; then
               if [ -z "${nonpriv_user}" ]; then

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -61,7 +61,7 @@ install:
     verify_continue:
       cmds:
         - |
-          echo -e "{{.YELLOW}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
+          echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
           echo -e "* The following application name was selected: {{.NR_PHP_APPLICATION}}"
           if [ "{{.NR_PHP_RESTART}}" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation WILL restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -69,7 +69,7 @@ install:
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the php-fpm or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
           fi
           echo -e "{{.GRAY}}
-          Note: If you are hosting your PHP application on something other than nginx or php-fpm, please select 'n' and check out our other installation options:
+          Note: If you are hosting your PHP application on something other than apache, nginx, or php-fpm, please select 'n' and check out our other installation options:
           https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-overview/{{.NOCOLOR}}
           "
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -25,7 +25,7 @@ inputVars:
     prompt: "What is the name of your PHP application?"
     default: "PHP Application"
   - name: "NR_PHP_RESTART"
-    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm or nginx depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
     default: "y"
 
 install:
@@ -231,13 +231,13 @@ install:
     install_rpm:
       cmds:
         - |
-          echo -e "{{.ARROW}}Installing the New Relic PHP Agent RPM{{.GRAY}}"
+          echo -e "{{.ARROW}}Adding the New Relic PHP Agent repository{{.GRAY}}"
           # The repo install command returns a non-zero return code if it is already installed
           # Only attempt an install if it is needed
           if rpm -q newrelic-repo-5-3.noarch > /dev/null; then
-            echo -e "The New Relic PHP Agent RPM is already installed."
+            echo -e "The New Relic repository is already installed."
           else
-            echo -e "Installing the New Relic PHP Agent RPM."
+            echo -e "Adding the New Relic PHP Agent repository."
             sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
           fi
           sudo yum install -y newrelic-php5
@@ -315,7 +315,7 @@ install:
             fi
             if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
               while :; do
-                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
+                echo -n -e "{{.YELLOW}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
                 read answer
                 echo ""
                 NEW_RELIC_RESTARTED=$(echo "${answer^^}" | cut -c1-1)

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -1,7 +1,7 @@
 # Visit our schema definition for additional information on this file format
 # https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
 
-name: php-agent-debian-fpm-installer
+name: php-agent-redhat-fpm-installer
 displayName: PHP Agent Installer for RedHat + FPM
 description: New Relic install recipe for instrumenting PHP applications on Redhat systems with FPM
 repository: https://github.com/newrelic/newrelic-php-agent
@@ -227,10 +227,13 @@ install:
     install_rpm:
       cmds:
         - |
+          echo -e "{{.ARROW}}Installing the New Relic PHP Agent RPM{{.GRAY}}"
           # The repo install command returns a non-zero return code if it is already installed
           # Only attempt an install if it is needed
-          sudo rpm -q newrelic-repo-5-3.noarch > /dev/null
-          if [ $? -ne 0 ]; then
+          if rpm -q newrelic-repo-5-3.noarch > /dev/null; then
+            echo -e "The New Relic PHP Agent RPM is already installed."
+          else
+            echo -e "Installing the New Relic PHP Agent RPM."
             sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
           fi
           sudo yum install -y newrelic-php5

--- a/recipes/newrelic/apm/php/redhat-fpm.yml
+++ b/recipes/newrelic/apm/php/redhat-fpm.yml
@@ -25,7 +25,7 @@ inputVars:
     prompt: "What is the name of your PHP application?"
     default: "PHP Application"
   - name: "NR_PHP_RESTART"
-    prompt: "Restart the PHP application after installation? (y/n)"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm or nginx depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
     default: "y"
 
 install:
@@ -37,7 +37,8 @@ install:
       sh: mktemp -d /tmp/newrelic-php-agent.XXXXXX
     WHITE: '\033[0;97m'
     RED: '\033[0;31m'
-    GRAY: '\033[38;5;240m'
+    GRAY: '\033[38;5;248m'
+    CYAN: '\033[0;36m'
     NOCOLOR: '\033[0m'
     YELLOW: '\033[0;33m'
     ARROW: '\033[0;36m===> \033[0;97m'
@@ -60,19 +61,16 @@ install:
     verify_continue:
       cmds:
         - |
-          echo -e "{{.YELLOW}}
-          ================================================================================
-          =                                                                              =
-          =                                   Warning                                    =
-          =                                                                              =
-          =               This installation will automatically reload your               =
-          =                          nginx and/or FPM services                           =
-          =                                                                              =
-          ================================================================================
-          {{.NOCOLOR}}"
-          echo "
-          If you are hosting your PHP application differently then check out our other installation options:
-          https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-overview/
+          echo -e "{{.YELLOW}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
+          echo -e "* The following application name was selected: {{.NR_PHP_APPLICATION}}"
+          if [ "{{.NR_PHP_RESTART}}" = "y" ]; then
+            echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation WILL restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
+          else
+            echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the php-fpm or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
+          fi
+          echo -e "{{.GRAY}}
+          Note: If you are hosting your PHP application on something other than nginx or php-fpm, please select 'n' and check out our other installation options:
+          https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-overview/{{.NOCOLOR}}
           "
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
             while :; do
@@ -83,11 +81,11 @@ install:
               if [[ -z "$NEW_RELIC_CONTINUE" ]]; then
                 NEW_RELIC_CONTINUE="Y"
               fi
-              if [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
+              if [[ "$NEW_RELIC_CONTINUE" == "n" ]] || [[ "$NEW_RELIC_CONTINUE" == "N" ]]; then
                 echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
                 exit 130
               fi
-              if [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
+              if [[ "$NEW_RELIC_CONTINUE" == "y" ]] || [[ "$NEW_RELIC_CONTINUE" == "Y" ]]; then
                 break
               fi
               echo -e "{{.WHITE}}Please type Y or N only.{{.NOCOLOR}}"
@@ -314,10 +312,26 @@ install:
               echo -e "{{.RED}}Please restart $process as privileged user $user_name for instrumentation to be enabled.{{.NOCOLOR}}"
             else
               echo -e "{{.RED}}You will need to restart your PHP web server in order for web instrumentation to be enabled.{{.NOCOLOR}}"
-              if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-                echo -n "Press enter to continue once this has been done."
+            fi
+            if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
+              while :; do
+                echo -n -e "{{.WHITE}}Press Y if you successfully restarted your web server.  Press N if you are unable to restart your web server at this time, and you wish to exit the installation. (default: Y)? {{.NOCOLOR}}"
                 read answer
-              fi
+                echo ""
+                NEW_RELIC_RESTARTED=$(echo "${answer^^}" | cut -c1-1)
+                if [[ -z "$NEW_RELIC_RESTARTED" ]]; then
+                  NEW_RELIC_RESTARTED="Y"
+                fi
+                if [[ "$NEW_RELIC_RESTARTED" == "N" ]] || [[ "$NEW_RELIC_RESTARTED" == "n" ]]; then
+                  echo -e "{{.WHITE}}Exiting the installation{{.NOCOLOR}}"
+                  #exit 130: Installation was cancelled either using Ctrl+C or by selecting not to continue the installation
+                  exit 130
+                fi
+                if [[ "$NEW_RELIC_RESTARTED" == "Y" ]] || [[ "$NEW_RELIC_RESTARTED" == "y" ]]; then
+                  break
+                fi
+                echo -e "{{.WHITE}}Please type Y or N only.{{.NOCOLOR}}"
+              done
             fi
           fi
 


### PR DESCRIPTION
1) redhat recipe: Changed debian reference to redhat.
2) redhat recipe: The RPM detection logic wasn't working for redhat.
3) both recipes: The local user on `php-apache-wordpress-linux2.json` is apache, so it's getting caught in our filter.
4) both recipes: When the user declines to accept auto service restart, ask them if they have restarted; else exit. 
5) redhat recipe: Pull over text/format/color changes from Debian to redhat.
6) both recipes: User instruction clarifications.

The redhat recipe is still not consistently running.  Putting this PR up to get the debian recipe changes incorporated.  The remaining redhat recipe changes will go in another PR after this is merged.