### PR TITLE
Migrate windows from processMatch to preinstall scripts and fixes some other issues

### DIFF
--- a/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
@@ -21,8 +21,20 @@ keywords:
   - aspnet
   - core
 
-processMatch:
-  - w3wp.exe
+processMatch: []
+
+preInstall:
+  requireAtDiscovery: |
+    powershell -command '
+    $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
+    if ($iisEnabled.State -ne "Enabled") {
+      # IIS is not installed
+      exit 3
+    }
+
+    # IIS is installed
+    exit 0
+    '
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -116,7 +116,20 @@ install:
       cmds:
         - |
           powershell -command '
-          iisreset /stop | Out-Null
+          function Stop-IIS {
+            try {
+              iisreset /stop | Out-Null
+              return $true
+            }
+            catch { return $false }
+          }
+          
+          $DidIisStop = (Stop-IIS)       
+          if (-not $DidIisStop) {
+              # Try to stop IIS a second time.
+              # Based on past experience, the second attempt almost always works.
+              Stop-IIS | Out-Null
+          }
           '
 
     remove_any_previous:

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -17,9 +17,21 @@ keywords:
   - aspnet
   - core
 
-processMatch:
-  - w3wp.exe
+processMatch: []
 
+preInstall:
+  requireAtDiscovery: |
+    powershell -command '
+    $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
+    if ($iisEnabled.State -ne "Enabled") {
+      # IIS is not installed
+      exit 3
+    }
+
+    # IIS is installed
+    exit 0
+    '
+    
 validationNrql: "SELECT count(*) FROM NrIntegrationError WHERE purpose = 'New Relic CLI configuration validation' AND hostname like '{{.HOSTNAME}}%' since 10 minutes ago"
 
 successLinkConfig:
@@ -35,7 +47,6 @@ install:
       cmds:
         - task: verify_continue
         - task: assert_admin_perms
-        - task: assert_pre_req
         - task: stop
         - task: remove_any_previous
         - task: install
@@ -92,23 +103,6 @@ install:
           if (! $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
             Write-Host -ForegroundColor Red "The installation recipe for the .NET Agent on Windows must be run with Administrator permissions."
             exit 7
-          }
-          '
-
-    assert_pre_req:
-      cmds:
-        - |
-          powershell -command '
-          $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
-          if ($iisEnabled.State -ne "Enabled") {
-            Write-Host -ForegroundColor Red "IIS is not installed."
-            exit 5
-          }
-
-          $aspNet45Enabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-ASPNET45 | select State
-          if ($aspNet45Enabled.State -ne "Enabled") {
-            Write-Host -ForegroundColor Red "ASP.NET is not installed."
-            exit 6
           }
           '
 


### PR DESCRIPTION
Migrates both windows-iis-unsupported.yml and windows-iis.yml to use a preInstall script.
Uses the existing assert_pre_req task script to perform the check.
Removed the assert_pre_req task entirely since we don't need to check for IIS and we want to install even if ASP.NET is not installed to support .NET Core/.NET 5+
