### PR TITLE
fix/infra: don't remove the entire db directory

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux.yml
@@ -90,7 +90,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -93,7 +93,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -106,7 +106,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -123,7 +123,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -101,7 +101,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -110,7 +110,7 @@ install:
     cleanup:
       cmds:
         - |
-          sudo rm -rf /var/db/newrelic-infra
+          sudo rm -rf /var/db/newrelic-infra/data
 
     setup_license:
       cmds:


### PR DESCRIPTION
Removing /var/db/newrelic-infra also removes the installed integrations
and makes logging fails on reinstall. Only removing the data subdirectory
should be enough.