### PR TITLE
PHP: update recipe paths in automated deploy configs

### DIFF
--- a/test/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-apache-wordpress-linux2.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -37,7 +37,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian-fpm.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }


### PR DESCRIPTION
We recently renamed the two PHP recipes to remove the `-fpm` suffix. This PR updates the paths to the PHP recipes embedded in the automated deploy configs.