### PR TITLE
feat: infrastructure agent amazon linux 2 repository new path

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -134,7 +134,7 @@ install:
       cmds:
         - |
           ARCH=$(uname -m)
-          REPO_URL=$(echo -n "https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/$ARCH/newrelic-infra.repo")
+          REPO_URL=$(echo -n "https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/$ARCH/newrelic-infra.repo")
           IS_NEWRELIC_AVAILABLE=$(curl -Ls $REPO_URL | grep "\[newrelic-infra\]" | wc -l)
           if [ $IS_NEWRELIC_AVAILABLE -eq 0 ] ; then
             echo "newrelic infrastructure agent is not available for this architecture "$ARCH". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2


### PR DESCRIPTION
As part of the epic to install fluent-bit package as an infrastructure-agent dependency, the Amazon Linux 2 repository location is being changed.