### PR TITLE
fix: disable the status check in the infra recipe

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux.yml
@@ -34,7 +34,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -37,7 +37,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -40,7 +40,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -43,7 +43,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -36,7 +36,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -45,7 +45,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -31,7 +31,7 @@ install:
         - task: install_infra
         - task: start_infra
         - task: assert_agent_started
-        - task: assert_agent_status_ok
+        # - task: assert_agent_status_ok
 
     remove_any_previous:
       ignore_error: true


### PR DESCRIPTION
There is a regression on release 1.19 of the agent causing the wrong
port to be used. Disabling the status check for now.