### PR TITLE
PHP Virtuoso: Adherence to naming conventions.

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -1,7 +1,7 @@
 # Visit our schema definition for additional information on this file format
 # https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
 
-name: php-agent-debian-installer
+name: php-agent-installer
 displayName: PHP Agent Installer for Debian
 description: New Relic install recipe for instrumenting PHP applications on Debian systems with php-fpm, nginx, or apache.
 repository: https://github.com/newrelic/newrelic-php-agent

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -1,7 +1,7 @@
 # Visit our schema definition for additional information on this file format
 # https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
 
-name: php-agent-redhat-installer
+name: php-agent-installer
 displayName: PHP Agent Installer for RedHat
 description: New Relic install recipe for instrumenting PHP applications on Redhat systems with php-fpm, nginx, or apache.
 repository: https://github.com/newrelic/newrelic-php-agent


### PR DESCRIPTION
Changed the name of the recipes to be 'php-agent-installer'. The dashboards are all build around tracking the recipes as whole.  We capture the platform as a field in the NRDB so we can always resolve which recipes was run by that piece of data.