### PR TITLE
PHP: fix dup inis and other changes

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -40,7 +40,7 @@ install:
       sh: mktemp -d /tmp/newrelic-php-agent.XXXXXX
     WHITE: '\033[0;97m'
     RED: '\033[0;31m'
-    GRAY: '\033[38;5;248m'
+    GRAY: '\033[38;5;240m'
     CYAN: '\033[0;36m'
     NOCOLOR: '\033[0m'
     YELLOW: '\033[0;33m'
@@ -135,7 +135,7 @@ install:
     detect_services:
       cmds:
         - |
-          echo -e "{{.ARROW}}Detecting services{{.NOCOLOR}}"
+          echo -e "{{.ARROW}}Detecting services{{.GRAY}}"
           cd {{.TMP_INSTALL_DIR}}
           rm -f {{.TMP_INSTALL_DIR}}/nonpriv_users.txt 2>/dev/null
           rm -f {{.TMP_INSTALL_DIR}}/processes_to_restart.txt 2>/dev/null
@@ -226,7 +226,7 @@ install:
           # for treating directory as an HTML directory listing
           RELEASE_URL='https://download.newrelic.com/php_agent/release/'
           AGENT_VERSION="$(curl -s "$RELEASE_URL" | grep --only-match "$VERSION_REGEX" | head -n1)"
-          echo -e "{{.RED}}AGENT VERSION: $AGENT_VERSION{{.NOCOLOR}}"
+          echo -e "{{.GRAY}}AGENT VERSION: $AGENT_VERSION{{.NOCOLOR}}"
           if [ -z "${AGENT_VERSION}" ]; then
             echo -e "{{.RED}}Unable to determine current PHP Agent version from New Relic's downloads site.{{.NOCOLOR}}"
             # Exit with Agent install failure code exit(16)
@@ -305,6 +305,19 @@ install:
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
             fi
+            target_ini_dir="/etc/php5/conf.d/"
+            if [ -x /usr/sbin/phpquery ]; then
+              target_ini_dir="${ini}/../../mods-available/"
+            elif [ -x /usr/sbin/php5endmod ]; then
+              target_ini_dir="/etc/php5/mods-available/"
+            fi
+            if [ ! -d $target_ini_dir ]; then
+              echo -e "{{.RED}}Warning: Unable to move ${ini_full_name} to ${target_ini_dir}{{.GRAY}}"
+              continue
+            fi
+            # Move newrelic.ini created by tarball to the name that the installer will use.
+            mv ${ini_full_name} ${target_ini_dir}
+            # We rely on the package installer to enable the newrelic module.
           done;
 
     restart_services:


### PR DESCRIPTION
This PR makes the following changes:
* Add logic to move the ini files created by the tarball installer to the location that will be used by the package installer.
* Display the detected agent version in gray instead of red. It isn't an error condition and we display the version we are using in brighter colors a little later on so it is a detail that the user can safely ignore in most cases.
* Set the color to gray when detecting services. This reduces the attention drawn to any shell output. (Aside: I'm seeing a usage message from grep displayed at this step. Not sure why, but it does not appear to be related to my changes).

**Design considerations:**
There's a question about what to do if the target ini directory doesn't exist. We could fail the install right there, but since there may be more than one PHP install, there's a chance another will succeed where this fails.

The approach chosen is to just warn if the target destination does not exist. This essentially results in the same behavior as before these changes were made. It results in multiple ini files which may cause problems later down the road.

The alternative is to fail the first time we are unable to find a target ini dir, but this may leave the system in a partially installed state with some ini files in the correct location and some in the SAPI specific directories. We could write clean up logic to attempt to remove them all, but that adds additional complexity to the recipe.

Should the ini file move succeed, there is a chance that the module does not get enabled. The changes purposefully do not manually call `phpenmod` to enable the module as there is logic in the installer to do that. This avoids the complication of having to determine which version of `phpenmod`, if any, needs to be called and also reduces the duplication between the recipe and the agent installers.

Note that the recipe has been failing more often than not for me today, but it doesn't seem to be related to my changes as it seems to pass if I run it enough. I also noticed that the recipe installer no longer seems to check the connection to New Relic before installing the recipe so I'm not sure if the problem is on the NR side or not.