### PR TITLE
PHP: Update PHP test definitions

### DIFF
--- a/test/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-apache-fpm-wordpress-linux2.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "RedHat PHP Apache FPM Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/apache-fpm-wordpress/redhat/roles",
           "port": 80,
           "destinations": ["php-a-f-w-l2"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-a-f-w-l2"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "Debian PHP Apache FPM Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/apache-fpm-wordpress/debian/roles",
           "port": 80,
           "destinations": ["php-a-f-w-u18"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-a-f-w-u18"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-apache-wordpress-linux2.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "RedHat PHP Apache Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/apache-wordpress/redhat/roles",
           "port": 80,
           "destinations": ["php-a-w-l2"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-a-w-l2"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "Debian PHP Apache Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/apache-wordpress/debian/roles",
           "port": 80,
           "destinations": ["php-a-w-u18"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-a-w-u18"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "RedHat PHP nginx FPM Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/nginx-fpm-wordpress/redhat/roles",
           "port": 80,
           "destinations": ["php-n-f-w-l2"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-n-f-w-l2"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/redhat.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml"
             ]
           }
         }

--- a/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -20,7 +20,7 @@
         {
           "id": "wordpress",
           "display_name": "Debian PHP nginx FPM Wordpress",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/php/nginx-fpm-wordpress/debian/roles",
           "port": 80,
           "destinations": ["php-n-f-w-u18"]
@@ -33,11 +33,11 @@
           "id": "instrumentation1",
           "resource_ids": ["php-n-f-w-u18"],
           "provider": "newrelic",
-          "local_source_path": "/mnt/open-install-library",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": [
-              "https://raw.githubusercontent.com/newrelic/open-install-library/feat/php-agent/recipes/newrelic/apm/php/debian.yml"
+              "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml"
             ]
           }
         }


### PR DESCRIPTION
This PR contains:
- Replaces `local_source_path` with `"source_repository": "https://github.com/newrelic/open-install-library.git",`
- The `recipe_content_url` now references the `main` branch instead of `feat/php-agent`