### PR TITLE
Retry starting IIS if first attempt fails in .net windows iis recipe

### DIFF
--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -120,11 +120,12 @@ install:
             catch { return $false }
           }
           
-          $DidIisStop = (Stop-IIS)       
-          if (-not $DidIisStop) {
-              # Try to stop IIS a second time.
-              # Based on past experience, the second attempt almost always works.
-              Stop-IIS | Out-Null
+          for ($tries = 0; $tries -lt 30; $tries++) {
+            if ((Stop-IIS)) {
+              break
+            }
+            # Try to stop IIS again after a delay
+            Start-Sleep -s 2
           }
           '
 
@@ -271,11 +272,12 @@ install:
             catch { return $false }
           }
           
-          $DidIisStart = (Start-IIS)       
-          if (-not $DidIisStart) {
-              # Try to start IIS a second time.
-              # Based on past experience, the second attempt almost always works.
-              Start-IIS | Out-Null
+          for ($tries = 0; $tries -lt 30; $tries++) {
+            if ((Start-IIS)) {
+              break
+            }
+            # Try to start IIS again after a delay
+            Start-Sleep -s 2
           }
           '
 

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -263,7 +263,20 @@ install:
       cmds:
         - |
           powershell -command '
-          iisreset /start | Out-Null
+          function Start-IIS {
+            try {
+              iisreset /start | Out-Null
+              return $true
+            }
+            catch { return $false }
+          }
+          
+          $DidIisStart = (Start-IIS)       
+          if (-not $DidIisStart) {
+              # Try to start IIS a second time.
+              # Based on past experience, the second attempt almost always works.
+              Start-IIS | Out-Null
+          }
           '
 
     cli_validate:


### PR DESCRIPTION
There have been error reports of IIS failing to start during the guided install process. We used to get similar reports for stopping IIS, but were able to resolve most of them by adding retry logic. This PR adds similar retry logic to the starting of IIS.

This should resolve: https://github.com/newrelic/newrelic-dotnet-agent/issues/656

Tested on Server 2019 and did not see any failures. The behavior of IIS failing to start is intermittent so is difficult to test for explicitly.