### PR TITLE
Disable support for Server 2008/2008 R2 in guided install

### DIFF
--- a/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
@@ -29,6 +29,8 @@ preInstall:
     $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
     if ($iisEnabled.State -ne "Enabled") {
       # IIS is not installed
+      Write-Host "Required dependency (IIS) is not installed. To enable run:"
+      Write-Host "Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer"
       exit 3
     }
 

--- a/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
@@ -39,8 +39,6 @@ preInstall:
     $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
     if ($iisEnabled.State -ne "Enabled") {
       # IIS is not installed
-      Write-Host "Required dependency (IIS) is not installed. To enable, run:"
-      Write-Host "Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer"
       exit 3
     }
 

--- a/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
@@ -7,13 +7,23 @@ description: New Relic install recipe for .NET application on Windows
 repository: https://github.com/newrelic/newrelic-dotnet-agent
 
 installTargets:
+  # Server 2008
+  - type: application
+    os: windows
+    platformVersion: "6.0.6003 Build 6003"
+  # Server 2008 R2
+  - type: application
+    os: windows
+    platformVersion: "6.1.7601 Build 7601"
+  # Server 2012
   - type: application
     os: windows
     platformVersion: "6.2.9200 Build 9200"
+  # Server 2012 R2
   - type: application
     os: windows
     platformVersion: "6.3.9600 Build 9600"
-
+  
 keywords:
   - Apm
   - .NET

--- a/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis-unsupported.yml
@@ -29,7 +29,7 @@ preInstall:
     $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
     if ($iisEnabled.State -ne "Enabled") {
       # IIS is not installed
-      Write-Host "Required dependency (IIS) is not installed. To enable run:"
+      Write-Host "Required dependency (IIS) is not installed. To enable, run:"
       Write-Host "Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer"
       exit 3
     }

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -25,8 +25,6 @@ preInstall:
     $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
     if ($iisEnabled.State -ne "Enabled") {
       # IIS is not installed
-      Write-Host "Required dependency (IIS) is not installed. To enable, run:"
-      Write-Host "Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer"
       exit 3
     }
 

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -25,6 +25,8 @@ preInstall:
     $iisEnabled = Get-WindowsOptionalFeature -Online -FeatureName IIS-WebServer | select State
     if ($iisEnabled.State -ne "Enabled") {
       # IIS is not installed
+      Write-Host "Required dependency (IIS) is not installed. To enable, run:"
+      Write-Host "Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer"
       exit 3
     }
 


### PR DESCRIPTION
Resolves: https://github.com/newrelic/newrelic-dotnet-agent/issues/657

There have been customer complaints/questions about whether we support guided install on Server 2008/2008 R2. We already have checks to flag 2012/2012 R2 as unsupported, but we didn't have similar rules for 2008/2008 R2.

It would be great if there was a way to programmatically set a minimum supported version and reject everything under that, but I am unfamiliar with if that is supported in our recipe YMLs. If there is an easy way to do this then let me know.

I am spinning up some server 2008 instances to test and will only merge if everything works properly.

I also added some helpful messages when IIS is not installed.