### PR TITLE
Virtuoso: PHP: redhat referencing global vs local var for tarball download

### DIFF
--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -245,7 +245,7 @@ install:
             echo -e "{{.WHITE}}Found agent version: {{.CYAN}}$AGENT_VERSION{{.GRAY}}"
           fi
 
-          AGENT="newrelic-php5-{{.AGENT_VERSION}}-linux"
+          AGENT="newrelic-php5-$AGENT_VERSION-linux"
           AGENT_TARBALL="$AGENT.tar.gz"
           # Lack of '/' is important. See above comment where $RELEASE_URL is
           # defined. An extraneous '/' here treats the URL as an HTML doc.


### PR DESCRIPTION
One line was still referencing a global default value vs the actual value we detect which then broke the tarball download logic when a new php agent was released.