### PR TITLE
Ohi v4 config

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -137,8 +137,8 @@ install:
           integrations:
             - name: nri-apache
               env:
-                metrics: true
-                status_url: $NR_CLI_STATUS_URL
+                METRICS: true
+                STATUS_URL: $NR_CLI_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -147,13 +147,13 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
               interval: 15
 
             - name: nri-apache
               env:
-                inventory: true
-                status_url: $NR_CLI_STATUS_URL
+                INVENTORY: true
+                STATUS_URL: $NR_CLI_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -162,7 +162,7 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
               inventory_source: config/apache
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -134,37 +134,37 @@ install:
           fi
           sudo cp /etc/newrelic-infra/integrations.d/apache-config.yml.sample /etc/newrelic-infra/integrations.d/apache-config.yml;
           sudo tee /etc/newrelic-infra/integrations.d/apache-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.apache
+          integrations:
+            - name: nri-apache
+              env:
+                metrics: true
+                status_url: $NR_CLI_STATUS_URL
 
-          instances:
-              - name: apache-server-metrics
-                command: metrics
-                arguments:
-                    status_url: $NR_CLI_STATUS_URL
+                # New users should leave this property as 'true', to identify the
+                # monitored entities as 'remote'. Setting this property to 'false' (the
+                # default value) is deprecated and will be removed soon, disallowing
+                # entities that are identified as 'local'.
+                # Please check the documentation to get more information about local
+                # versus remote entities:
+                # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
+                remote_monitoring: true
+              interval: 15
 
-                    # New users should leave this property as 'true', to identify the
-                    # monitored entities as 'remote'. Setting this property to 'false' (the
-                    # default value) is deprecated and will be removed soon, disallowing
-                    # entities that are identified as 'local'.
-                    # Please check the documentation to get more information about local
-                    # versus remote entities:
-                    # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                    remote_monitoring: true
+            - name: nri-apache
+              env:
+                inventory: true
+                status_url: $NR_CLI_STATUS_URL
 
-              - name: apache-server-inventory
-                command: inventory
-                arguments:
-                    status_url: $NR_CLI_STATUS_URL
-
-                    # New users should leave this property as 'true', to identify the
-                    # monitored entities as 'remote'. Setting this property to 'false' (the
-                    # default value) is deprecated and will be removed soon, disallowing
-                    # entities that are identified as 'local'.
-                    # Please check the documentation to get more information about local
-                    # versus remote entities:
-                    # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                    remote_monitoring: true
-
+                # New users should leave this property as 'true', to identify the
+                # monitored entities as 'remote'. Setting this property to 'false' (the
+                # default value) is deprecated and will be removed soon, disallowing
+                # entities that are identified as 'local'.
+                # Please check the documentation to get more information about local
+                # versus remote entities:
+                # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
+                remote_monitoring: true
+              inventory_source: config/apache
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -137,36 +137,37 @@ install:
           fi
           sudo cp /etc/newrelic-infra/integrations.d/apache-config.yml.sample /etc/newrelic-infra/integrations.d/apache-config.yml;
           sudo tee /etc/newrelic-infra/integrations.d/apache-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.apache
+          integrations:
+            - name: nri-apache
+              env:
+                metrics: true
+                status_url: $NR_CLI_STATUS_URL
 
-          instances:
-              - name: apache-server-metrics
-                command: metrics
-                arguments:
-                    status_url: $NR_CLI_STATUS_URL
+                # New users should leave this property as 'true', to identify the
+                # monitored entities as 'remote'. Setting this property to 'false' (the
+                # default value) is deprecated and will be removed soon, disallowing
+                # entities that are identified as 'local'.
+                # Please check the documentation to get more information about local
+                # versus remote entities:
+                # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
+                remote_monitoring: true
+              interval: 15
 
-                    # New users should leave this property as 'true', to identify the
-                    # monitored entities as 'remote'. Setting this property to 'false' (the
-                    # default value) is deprecated and will be removed soon, disallowing
-                    # entities that are identified as 'local'.
-                    # Please check the documentation to get more information about local
-                    # versus remote entities:
-                    # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                    remote_monitoring: true
+            - name: nri-apache
+              env:
+                inventory: true
+                status_url: $NR_CLI_STATUS_URL
 
-              - name: apache-server-inventory
-                command: inventory
-                arguments:
-                    status_url: $NR_CLI_STATUS_URL
-
-                    # New users should leave this property as 'true', to identify the
-                    # monitored entities as 'remote'. Setting this property to 'false' (the
-                    # default value) is deprecated and will be removed soon, disallowing
-                    # entities that are identified as 'local'.
-                    # Please check the documentation to get more information about local
-                    # versus remote entities:
-                    # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                    remote_monitoring: true
+                # New users should leave this property as 'true', to identify the
+                # monitored entities as 'remote'. Setting this property to 'false' (the
+                # default value) is deprecated and will be removed soon, disallowing
+                # entities that are identified as 'local'.
+                # Please check the documentation to get more information about local
+                # versus remote entities:
+                # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
+                remote_monitoring: true
+              inventory_source: config/apache
+              interval: 60
 
           EOT
 

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -140,8 +140,8 @@ install:
           integrations:
             - name: nri-apache
               env:
-                metrics: true
-                status_url: $NR_CLI_STATUS_URL
+                METRICS: true
+                STATUS_URL: $NR_CLI_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -150,13 +150,13 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
               interval: 15
 
             - name: nri-apache
               env:
-                inventory: true
-                status_url: $NR_CLI_STATUS_URL
+                INVENTORY: true
+                STATUS_URL: $NR_CLI_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -165,7 +165,7 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
               inventory_source: config/apache
               interval: 60
 

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -103,23 +103,24 @@ install:
 
         - |
           sudo tee /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.cassandra
-
-          instances: 
-            - name: cassandra-db-metrics
-              command: metrics
-              arguments:
+          integrations
+            - name: nri-cassandra
+              env:
+                metrics: true
                 hostname: {{.NR_CLI_DB_HOSTNAME}}
                 port: {{.NR_CLI_DB_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
                 password: {{.NR_CLI_DB_PASSWORD}}
                 remote_monitoring: true
-            - name: cassandra-db-inventory
-              command: inventory
-              arguments:
+              interval: 30
+            - name: nri-cassandra
+              env:
+                inventory: true
                 hostname: {{.NR_CLI_DB_HOSTNAME}}
                 config_path: /etc/cassandra/cassandra.yaml
                 remote_monitoring: true
+              inventory_source: config/redis
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -103,7 +103,7 @@ install:
 
         - |
           sudo tee /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
-          integrations
+          integrations:
             - name: nri-cassandra
               env:
                 metrics: true

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -106,19 +106,19 @@ install:
           integrations:
             - name: nri-cassandra
               env:
-                metrics: true
-                hostname: {{.NR_CLI_DB_HOSTNAME}}
-                port: {{.NR_CLI_DB_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                remote_monitoring: true
+                METRICS: true
+                HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
+                PORT: {{.NR_CLI_DB_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                REMOTE_MONITORING: true
               interval: 30
             - name: nri-cassandra
               env:
-                inventory: true
-                hostname: {{.NR_CLI_DB_HOSTNAME}}
-                config_path: /etc/cassandra/cassandra.yaml
-                remote_monitoring: true
+                INVENTORY: true
+                HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
+                CONFIG_PATH: /etc/cassandra/cassandra.yaml
+                REMOTE_MONITORING: true
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -106,7 +106,7 @@ install:
 
         - |
           sudo tee -a /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
-          integrations
+          integrations:
             - name: nri-cassandra
               env:
                 metrics: true

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -106,23 +106,24 @@ install:
 
         - |
           sudo tee -a /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.cassandra
-
-          instances: 
-            - name: cassandra-db-metrics
-              command: metrics
-              arguments:
+          integrations
+            - name: nri-cassandra
+              env:
+                metrics: true
                 hostname: {{.NR_CLI_DB_HOSTNAME}}
                 port: {{.NR_CLI_DB_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
                 password: {{.NR_CLI_DB_PASSWORD}}
                 remote_monitoring: true
-            - name: cassandra-db-inventory
-              command: inventory
-              arguments:
+              interval: 30
+            - name: nri-cassandra
+              env:
+                inventory: true
                 hostname: {{.NR_CLI_DB_HOSTNAME}}
                 config_path: /etc/cassandra/cassandra.yaml
                 remote_monitoring: true
+              inventory_source: config/redis
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -109,19 +109,19 @@ install:
           integrations:
             - name: nri-cassandra
               env:
-                metrics: true
-                hostname: {{.NR_CLI_DB_HOSTNAME}}
-                port: {{.NR_CLI_DB_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                remote_monitoring: true
+                METRICS: true
+                HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
+                PORT: {{.NR_CLI_DB_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                REMOTE_MONITORING: true
               interval: 30
             - name: nri-cassandra
               env:
-                inventory: true
-                hostname: {{.NR_CLI_DB_HOSTNAME}}
-                config_path: /etc/cassandra/cassandra.yaml
-                remote_monitoring: true
+                INVENTORY: true
+                HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
+                CONFIG_PATH: /etc/cassandra/cassandra.yaml
+                REMOTE_MONITORING: true
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -100,54 +100,48 @@ install:
           if [ -z "{{.NR_CLI_TOKEN}}" ] || [ "{{.NR_CLI_TOKEN}}" == "test" ]; then
             if [ "{{.NR_CLI_ENABLE_SSL}}" == false ]; then
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             else
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
                 trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
                 ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             fi
           else
             if [ "{{.NR_CLI_ENABLE_SSL}}" == false ]; then
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 token: {{.NR_CLI_TOKEN}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             else
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 token: {{.NR_CLI_TOKEN}}
@@ -155,6 +149,8 @@ install:
                 trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
                 ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             fi
           fi

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -103,9 +103,9 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -114,12 +114,12 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
-                trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
-                ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
+                TRUST_SERVER_CERTIFICATE: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
+                CA_BUNDLE_DIR: {{.NR_CLI_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_FILE_DIR}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -130,10 +130,10 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                token: {{.NR_CLI_TOKEN}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                TOKEN: {{.NR_CLI_TOKEN}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -142,13 +142,13 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                token: {{.NR_CLI_TOKEN}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
-                trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
-                ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                TOKEN: {{.NR_CLI_TOKEN}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
+                TRUST_SERVER_CERTIFICATE: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
+                CA_BUNDLE_DIR: {{.NR_CLI_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_FILE_DIR}}
               inventory_source: config/consul
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -100,50 +100,48 @@ install:
           if [ -z "{{.NR_CLI_TOKEN}}" ] || [ "{{.NR_CLI_TOKEN}}" == "test" ]; then
             if [ "{{.NR_CLI_ENABLE_SSL}}" == false ]; then
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             else
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
                 trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
                 ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             fi
           else
             if [ "{{.NR_CLI_ENABLE_SSL}}" == false ]; then
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 token: {{.NR_CLI_TOKEN}}
                 enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             else
               sudo tee /etc/newrelic-infra/integrations.d/consul-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.consul
-          instances:
-            - name: consul
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-consul
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 token: {{.NR_CLI_TOKEN}}
@@ -151,6 +149,8 @@ install:
                 trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
                 ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+              inventory_source: config/consul
+              interval: 15
           EOT
             fi
           fi

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -103,9 +103,9 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -114,12 +114,12 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
-                trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
-                ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
+                TRUST_SERVER_CERTIFICATE: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
+                CA_BUNDLE_DIR: {{.NR_CLI_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_FILE_DIR}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -130,10 +130,10 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                token: {{.NR_CLI_TOKEN}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                TOKEN: {{.NR_CLI_TOKEN}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
               inventory_source: config/consul
               interval: 15
           EOT
@@ -142,13 +142,13 @@ install:
           integrations:
             - name: nri-consul
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                token: {{.NR_CLI_TOKEN}}
-                enable_ssl: {{.NR_CLI_ENABLE_SSL}}
-                trust_server_certificate: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
-                ca_bundle_dir: {{.NR_CLI_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_FILE_DIR}}
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                TOKEN: {{.NR_CLI_TOKEN}}
+                ENABLE_SSL: {{.NR_CLI_ENABLE_SSL}}
+                TRUST_SERVER_CERTIFICATE: {{.NR_CLI_TRUST_SERVER_CERTIFICATE}}
+                CA_BUNDLE_DIR: {{.NR_CLI_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_FILE_DIR}}
               inventory_source: config/consul
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -102,25 +102,23 @@ install:
         - |
           if [ {{.NR_CLI_API_USE_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/couchbase-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.couchbase
-          instances:
-            - name: couchbase
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-couchbase
+              env:
                 hostname: {{.NR_CLI_API_HOSTNAME}}
                 port: {{.NR_CLI_API_PORT}}
                 query_port: {{.NR_CLI_API_QUERY_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
                 password: {{.NR_CLI_DB_PASSWORD}}
                 use_ssl: {{.NR_CLI_API_USE_SSL}}
+              inventory_source: config/couchbase
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/couchbase-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.couchbase
-          instances:
-            - name: couchbase
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-couchbase
+              env:
                 hostname: {{.NR_CLI_API_HOSTNAME}}
                 port: {{.NR_CLI_API_PORT}}
                 query_port: {{.NR_CLI_API_QUERY_PORT}}
@@ -129,6 +127,8 @@ install:
                 use_ssl: {{.NR_CLI_API_USE_SSL}}
                 ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+              inventory_source: config/couchbase
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -105,12 +105,12 @@ install:
           integrations:
             - name: nri-couchbase
               env:
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                port: {{.NR_CLI_API_PORT}}
-                query_port: {{.NR_CLI_API_QUERY_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_API_USE_SSL}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                PORT: {{.NR_CLI_API_PORT}}
+                QUERY_PORT: {{.NR_CLI_API_QUERY_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_API_USE_SSL}}
               inventory_source: config/couchbase
               interval: 15
           EOT
@@ -119,14 +119,14 @@ install:
           integrations:
             - name: nri-couchbase
               env:
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                port: {{.NR_CLI_API_PORT}}
-                query_port: {{.NR_CLI_API_QUERY_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_API_USE_SSL}}
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                PORT: {{.NR_CLI_API_PORT}}
+                QUERY_PORT: {{.NR_CLI_API_QUERY_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_API_USE_SSL}}
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
               inventory_source: config/couchbase
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -109,12 +109,12 @@ install:
           integrations:
             - name: nri-couchbase
               env:
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                port: {{.NR_CLI_API_PORT}}
-                query_port: {{.NR_CLI_API_QUERY_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_API_USE_SSL}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                PORT: {{.NR_CLI_API_PORT}}
+                QUERY_PORT: {{.NR_CLI_API_QUERY_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_API_USE_SSL}}
             inventory_source: config/couchbase
             interval: 15
           EOT
@@ -123,14 +123,14 @@ install:
           integrations:
             - name: nri-couchbase
               env:
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                port: {{.NR_CLI_API_PORT}}
-                query_port: {{.NR_CLI_API_QUERY_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_API_USE_SSL}}
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                PORT: {{.NR_CLI_API_PORT}}
+                QUERY_PORT: {{.NR_CLI_API_QUERY_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_API_USE_SSL}}
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
               inventory_source: config/couchbase
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -106,27 +106,23 @@ install:
         - |
           if [ {{.NR_CLI_API_USE_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/couchbase-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.couchbase
-
-          instances:
-            - name: couchbase
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-couchbase
+              env:
                 hostname: {{.NR_CLI_API_HOSTNAME}}
                 port: {{.NR_CLI_API_PORT}}
                 query_port: {{.NR_CLI_API_QUERY_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
                 password: {{.NR_CLI_DB_PASSWORD}}
                 use_ssl: {{.NR_CLI_API_USE_SSL}}
+            inventory_source: config/couchbase
+            interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/couchbase-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.couchbase
-
-          instances:
-            - name: couchbase
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-couchbase
+              env:
                 hostname: {{.NR_CLI_API_HOSTNAME}}
                 port: {{.NR_CLI_API_PORT}}
                 query_port: {{.NR_CLI_API_QUERY_PORT}}
@@ -135,6 +131,8 @@ install:
                 use_ssl: {{.NR_CLI_API_USE_SSL}}
                 ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
                 ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+              inventory_source: config/couchbase
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -122,12 +122,9 @@ install:
         - |
           if [ {{.NR_CLI_API_USE_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -139,15 +136,16 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
           integration_name: com.newrelic.elasticsearch
 
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -161,6 +159,8 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -125,17 +125,17 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: false
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: false
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT
@@ -146,19 +146,19 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: true
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: true
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -133,7 +133,6 @@ install:
                 PORT: {{.NR_CLI_API_PORT}}
                 TIMEOUT: 30
                 USE_SSL: false
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
@@ -154,7 +153,6 @@ install:
                 USE_SSL: true
                 CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
                 CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -141,8 +141,6 @@ install:
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
           integrations:
             - name: nri-elasticsearch
               env:

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -124,12 +124,9 @@ install:
         - |
           if [ {{.NR_CLI_API_USE_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -141,15 +138,14 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -163,6 +159,8 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -127,17 +127,17 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: false
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: false
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT
@@ -146,19 +146,19 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: true
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: true
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -135,7 +135,6 @@ install:
                 PORT: {{.NR_CLI_API_PORT}}
                 TIMEOUT: 30
                 USE_SSL: false
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
@@ -156,7 +155,6 @@ install:
                 USE_SSL: true
                 CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
                 CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -118,12 +118,9 @@ install:
         - |
           if [ {{.NR_CLI_API_USE_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -135,15 +132,14 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/elasticsearch-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.elasticsearch
-
-          instances:
-            - name: elasticsearch
-              command: all
-              arguments:
+          integrations:
+            - name: nri-elasticsearch
+              env:
                 cluster_environment: staging
                 config_path: {{.NR_CLI_API_CONFIG_PATH}}
                 hostname: {{.NR_CLI_API_HOSTNAME}}
@@ -157,6 +153,8 @@ install:
                 indices_regex:
                 collect_indices: true
                 collect_primaries: true
+              inventory_source: config/elasticsearch
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -129,7 +129,6 @@ install:
                 PORT: {{.NR_CLI_API_PORT}}
                 TIMEOUT: 30
                 USE_SSL: false
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
@@ -150,7 +149,6 @@ install:
                 USE_SSL: true
                 CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
                 CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                INDICES_REGEX:
                 COLLECT_INDICES: true
                 COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -121,17 +121,17 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: false
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: false
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT
@@ -140,19 +140,19 @@ install:
           integrations:
             - name: nri-elasticsearch
               env:
-                cluster_environment: staging
-                config_path: {{.NR_CLI_API_CONFIG_PATH}}
-                hostname: {{.NR_CLI_API_HOSTNAME}}
-                username: {{.NR_CLI_API_USERNAME}}
-                password: {{.NR_CLI_API_PASSWORD}}
-                port: {{.NR_CLI_API_PORT}}
-                timeout: 30
-                use_ssl: true
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                indices_regex:
-                collect_indices: true
-                collect_primaries: true
+                CLUSTER_ENVIRONMENT: staging
+                CONFIG_PATH: {{.NR_CLI_API_CONFIG_PATH}}
+                HOSTNAME: {{.NR_CLI_API_HOSTNAME}}
+                USERNAME: {{.NR_CLI_API_USERNAME}}
+                PASSWORD: {{.NR_CLI_API_PASSWORD}}
+                PORT: {{.NR_CLI_API_PORT}}
+                TIMEOUT: 30
+                USE_SSL: true
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                INDICES_REGEX:
+                COLLECT_INDICES: true
+                COLLECT_PRIMARIES: true
               inventory_source: config/elasticsearch
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -89,13 +89,9 @@ install:
           sudo touch /etc/newrelic-infra/integrations.d/haproxy-config.yml;
         - |
           sudo tee -a /etc/newrelic-infra/integrations.d/haproxy-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.haproxy
-
-          instances:
-            - name: haproxy
-              # Command can be all_data, metrics, or inventory
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-haproxy
+              env:
                 # The URL to the enabled stats page on the
                 # HAProxy instance
                 stats_url: {{.NR_CLI_STATS_URL}}
@@ -104,6 +100,8 @@ install:
                 # Basic auth password
                 password: {{.NR_CLI_DB_PASSWORD}}
                 cluster_name: {{.NR_CLI_CLUSTER_NAME}}
+              inventory_source: config/haproxy
+              interval: 15
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -94,12 +94,12 @@ install:
               env:
                 # The URL to the enabled stats page on the
                 # HAProxy instance
-                stats_url: {{.NR_CLI_STATS_URL}}
+                STATS_URL: {{.NR_CLI_STATS_URL}}
                 # Basic auth username
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # Basic auth password
-                password: {{.NR_CLI_DB_PASSWORD}}
-                cluster_name: {{.NR_CLI_CLUSTER_NAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                CLUSTER_NAME: {{.NR_CLI_CLUSTER_NAME}}
               inventory_source: config/haproxy
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -95,12 +95,12 @@ install:
               env:
                 # The URL to the enabled stats page on the
                 # HAProxy instance
-                stats_url: {{.NR_CLI_STATS_URL}}
+                STATS_URL: {{.NR_CLI_STATS_URL}}
                 # Basic auth username
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # Basic auth password
-                password: {{.NR_CLI_DB_PASSWORD}}
-                cluster_name: {{.NR_CLI_CLUSTER_NAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                CLUSTER_NAME: {{.NR_CLI_CLUSTER_NAME}}
               inventory_source: config/haproxy
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -90,12 +90,9 @@ install:
           fi
         - |
           sudo tee -a /etc/newrelic-infra/integrations.d/haproxy-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.haproxy
-          instances:
-            - name: haproxy
-              # Command can be all_data, metrics, or inventory
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-haproxy
+              env:
                 # The URL to the enabled stats page on the
                 # HAProxy instance
                 stats_url: {{.NR_CLI_STATS_URL}}
@@ -104,6 +101,8 @@ install:
                 # Basic auth password
                 password: {{.NR_CLI_DB_PASSWORD}}
                 cluster_name: {{.NR_CLI_CLUSTER_NAME}}
+              inventory_source: config/haproxy
+              interval: 15
           EOT
         - |
           sudo systemctl restart newrelic-infra.service

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -99,27 +99,23 @@ install:
         - |
           if [ -z {{.NR_CLI_DB_USERNAME}} ] && [ -z {{.NR_CLI_DB_PASSWORD}} ]; then
             sudo tee /etc/newrelic-infra/integrations.d/memcached-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.memcached
-
-          instances:
-            - name: memcached
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-memcached
+              env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
                 host: {{.NR_CLI_HOST}}
                 # Port memcached is running on.
                 # Defaults to 11211
                 port: {{.NR_CLI_PORT}}
+              inventory_source: config/memcached
+              interval: 15
           EOT
           else
             sudo tee /etc/newrelic-infra/integrations.d/memcached-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.memcached
-
-          instances:
-            - name: memcached
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-memcached
+              env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
                 host: {{.NR_CLI_HOST}}
@@ -132,6 +128,8 @@ install:
                 # Memcached SASL password. Only required if
                 # authentication is enabled.
                 password: {{.NR_CLI_DB_PASSWORD}}
+              inventory_source: config/memcached
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -104,10 +104,10 @@ install:
               env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
-                host: {{.NR_CLI_HOST}}
+                HOST: {{.NR_CLI_HOST}}
                 # Port memcached is running on.
                 # Defaults to 11211
-                port: {{.NR_CLI_PORT}}
+                PORT: {{.NR_CLI_PORT}}
               inventory_source: config/memcached
               interval: 15
           EOT
@@ -118,16 +118,16 @@ install:
               env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
-                host: {{.NR_CLI_HOST}}
+                HOST: {{.NR_CLI_HOST}}
                 # Port memcached is running on.
                 # Defaults to 11211
-                port: {{.NR_CLI_PORT}}
+                PORT: {{.NR_CLI_PORT}}
                 # Memcached SASL username. Only required if
                 # authentication is enabled.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # Memcached SASL password. Only required if
                 # authentication is enabled.
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
               inventory_source: config/memcached
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
@@ -100,10 +100,10 @@ install:
               env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
-                host: {{.NR_CLI_HOSTNAME}}
+                HOST: {{.NR_CLI_HOSTNAME}}
                 # Port memcached is running on.
                 # Defaults to 11211
-                port: {{.NR_CLI_PORT}}
+                PORT: {{.NR_CLI_PORT}}
               inventory_source: config/memcached
               interval: 15
           EOT
@@ -114,16 +114,16 @@ install:
               env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
-                host: {{.NR_CLI_HOSTNAME}}
+                HOST: {{.NR_CLI_HOSTNAME}}
                 # Port memcached is running on.
                 # Defaults to 11211
-                port: {{.NR_CLI_PORT}}
+                PORT: {{.NR_CLI_PORT}}
                 # Memcached SASL username. Only required if
                 # authentication is enabled.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # Memcached SASL password. Only required if
                 # authentication is enabled.
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
               inventory_source: config/memcached
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
@@ -95,27 +95,23 @@ install:
         - |
           if [ -z {{.NR_CLI_DB_USERNAME}} ] && [ -z {{.NR_CLI_DB_PASSWORD}} ]; then
             sudo tee /etc/newrelic-infra/integrations.d/memcached-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.memcached
-
-          instances:
-            - name: memcached
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-memcached
+              env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
                 host: {{.NR_CLI_HOSTNAME}}
                 # Port memcached is running on.
                 # Defaults to 11211
                 port: {{.NR_CLI_PORT}}
+              inventory_source: config/memcached
+              interval: 15
           EOT
           else
             sudo tee /etc/newrelic-infra/integrations.d/memcached-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.memcached
-
-          instances:
-            - name: memcached
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-memcached
+              env:
                 # Hostname of the memcached instance.
                 # Defaults to localhost.
                 host: {{.NR_CLI_HOSTNAME}}
@@ -128,6 +124,8 @@ install:
                 # Memcached SASL password. Only required if
                 # authentication is enabled.
                 password: {{.NR_CLI_DB_PASSWORD}}
+              inventory_source: config/memcached
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -158,25 +158,25 @@ install:
             - name: nri-mongodb
               env:
                 # The mongos to connect to
-                host: {{.NR_CLI_DB_HOSTNAME}}
+                HOST: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
-                port: {{.NR_CLI_DB_PORT}}
+                PORT: {{.NR_CLI_DB_PORT}}
                 # The username of the user created to monitor the cluster.
                 # This user should exist on the cluster as a whole as well
                 # as on each of the individual mongods.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # The password for the monitoring user
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
                 # The database on which the monitoring user is stored
-                auth_source: {{.NR_CLI_DB_AUTH}}
+                AUTH_SOURCE: {{.NR_CLI_DB_AUTH}}
                 # A user-defined cluster name. Required.
-                cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
+                CLUSTER_NAME: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
-                ssl: true
+                SSL: true
                 # Path to the CA certs file
-                ssl_ca_certs: {{.NR_CLI_CERT_AUTH_FILE}}
+                SSL_CA_CERTS: {{.NR_CLI_CERT_AUTH_FILE}}
                 # Client Certificate to present to the server (optional)
-                pem_key_file: {{.NR_CLI_CLIENT_CERT_FILE}}
+                PEM_KEY_FILE: {{.NR_CLI_CLIENT_CERT_FILE}}
               inventory_source: config/mongodb
               interval: 15
           EOT
@@ -186,21 +186,21 @@ install:
             - name: nri-mongodb
               env:
                 # The mongos to connect to
-                host: {{.NR_CLI_DB_HOSTNAME}}
+                HOST: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
-                port: {{.NR_CLI_DB_PORT}}
+                PORT: {{.NR_CLI_DB_PORT}}
                 # The username of the user created to monitor the cluster.
                 # This user should exist on the cluster as a whole as well
                 # as on each of the individual mongods.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # The password for the monitoring user
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
                 # The database on which the monitoring user is stored
-                auth_source: {{.NR_CLI_DB_AUTH}}
+                AUTH_SOURCE: {{.NR_CLI_DB_AUTH}}
                 # A user-defined cluster name. Required.
-                cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
+                CLUSTER_NAME: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
-                ssl: false
+                SSL: false
               inventory_source: config/mongodb
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -154,11 +154,9 @@ install:
         - |
           if [ {{.NR_CLI_SSL}} == true ]; then
             sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.mongodb
-          instances:
-            - name: all
-              command: all
-              arguments:
+          integrations:
+            - name: nri-mongodb
+              env:
                 # The mongos to connect to
                 host: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
@@ -179,14 +177,14 @@ install:
                 ssl_ca_certs: {{.NR_CLI_CERT_AUTH_FILE}}
                 # Client Certificate to present to the server (optional)
                 pem_key_file: {{.NR_CLI_CLIENT_CERT_FILE}}
+              inventory_source: config/mongodb
+              interval: 15
           EOT
           else
             sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.mongodb
-          instances:
-            - name: all
-              command: all
-              arguments:
+          integrations:
+            - name: nri-mongodb
+              env:
                 # The mongos to connect to
                 host: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
@@ -203,6 +201,8 @@ install:
                 cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
                 ssl: false
+              inventory_source: config/mongodb
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -149,11 +149,9 @@ install:
         - |
           if [ {{.NR_CLI_SSL}} == true ]; then
             sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.mongodb
-          instances:
-            - name: all
-              command: all
-              arguments:
+          integrations:
+            - name: nri-mongodb
+              env:
                 # The mongos to connect to
                 host: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
@@ -174,14 +172,14 @@ install:
                 ssl_ca_certs: {{.NR_CLI_CERT_AUTH_FILE}}
                 # Client Certificate to present to the server (optional)
                 pem_key_file: {{.NR_CLI_CLIENT_CERT_FILE}}
+              inventory_source: config/mongodb
+              interval: 15
           EOT
           else
             sudo tee /etc/newrelic-infra/integrations.d/mongodb-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.mongodb
-          instances:
-            - name: all
-              command: all
-              arguments:
+          integrations:
+            - name: nri-mongodb
+              env:
                 # The mongos to connect to
                 host: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
@@ -198,6 +196,8 @@ install:
                 cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
                 ssl: false
+              inventory_source: config/mongodb
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -153,25 +153,25 @@ install:
             - name: nri-mongodb
               env:
                 # The mongos to connect to
-                host: {{.NR_CLI_DB_HOSTNAME}}
+                HOST: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
-                port: {{.NR_CLI_DB_PORT}}
+                PORT: {{.NR_CLI_DB_PORT}}
                 # The username of the user created to monitor the cluster.
                 # This user should exist on the cluster as a whole as well
                 # as on each of the individual mongods.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # The password for the monitoring user
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
                 # The database on which the monitoring user is stored
-                auth_source: {{.NR_CLI_DB_AUTH}}
+                AUTH_SOURCE: {{.NR_CLI_DB_AUTH}}
                 # A user-defined cluster name. Required.
-                cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
+                CLUSTER_NAME: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
-                ssl: true
+                SSL: true
                 # Path to the CA certs file
-                ssl_ca_certs: {{.NR_CLI_CERT_AUTH_FILE}}
+                SSL_CA_CERTS: {{.NR_CLI_CERT_AUTH_FILE}}
                 # Client Certificate to present to the server (optional)
-                pem_key_file: {{.NR_CLI_CLIENT_CERT_FILE}}
+                PEM_KEY_FILE: {{.NR_CLI_CLIENT_CERT_FILE}}
               inventory_source: config/mongodb
               interval: 15
           EOT
@@ -181,21 +181,21 @@ install:
             - name: nri-mongodb
               env:
                 # The mongos to connect to
-                host: {{.NR_CLI_DB_HOSTNAME}}
+                HOST: {{.NR_CLI_DB_HOSTNAME}}
                 # The port the mongos is running on
-                port: {{.NR_CLI_DB_PORT}}
+                PORT: {{.NR_CLI_DB_PORT}}
                 # The username of the user created to monitor the cluster.
                 # This user should exist on the cluster as a whole as well
                 # as on each of the individual mongods.
-                username: {{.NR_CLI_DB_USERNAME}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
                 # The password for the monitoring user
-                password: {{.NR_CLI_DB_PASSWORD}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
                 # The database on which the monitoring user is stored
-                auth_source: {{.NR_CLI_DB_AUTH}}
+                AUTH_SOURCE: {{.NR_CLI_DB_AUTH}}
                 # A user-defined cluster name. Required.
-                cluster_name: {{.NR_CLI_DB_CLUSTERNAME}}
+                CLUSTER_NAME: {{.NR_CLI_DB_CLUSTERNAME}}
                 # Connect using SSL
-                ssl: false
+                SSL: false
               inventory_source: config/mongodb
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -200,12 +200,9 @@ install:
 
           sudo cp /etc/newrelic-infra/integrations.d/mysql-config.yml.sample /etc/newrelic-infra/integrations.d/mysql-config.yml;
           sudo tee /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.mysql
-
-          instances:
-            - name: mysql-status
-              command: status
-              arguments:
+          integrations:
+            - name: nri-mysql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -215,6 +212,8 @@ install:
                 extended_innodb_metrics: true
                 extended_myisam_metrics: true
                 remote_monitoring: true
+              inventory_source: config/mysql
+              interval: 30
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -203,15 +203,15 @@ install:
           integrations:
             - name: nri-mysql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database:
-                extended_metrics: true
-                extended_innodb_metrics: true
-                extended_myisam_metrics: true
-                remote_monitoring: true
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE:
+                EXTENDED_METRICS: true
+                EXTENDED_INNODB_METRICS: true
+                EXTENDED_MYISAM_METRICS: true
+                REMOTE_MONITORING: true
               inventory_source: config/mysql
               interval: 30
           EOT

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -199,12 +199,9 @@ install:
 
           sudo cp /etc/newrelic-infra/integrations.d/mysql-config.yml.sample /etc/newrelic-infra/integrations.d/mysql-config.yml;
           sudo tee /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.mysql
-
-          instances:
-            - name: mysql-status
-              command: status
-              arguments:
+          integrations:
+            - name: nri-mysql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -214,6 +211,8 @@ install:
                 extended_innodb_metrics: true
                 extended_myisam_metrics: true
                 remote_monitoring: true
+              inventory_source: config/mysql
+              interval: 30
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -202,15 +202,15 @@ install:
           integrations:
             - name: nri-mysql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database:
-                extended_metrics: true
-                extended_innodb_metrics: true
-                extended_myisam_metrics: true
-                remote_monitoring: true
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE:
+                EXTENDED_METRICS: true
+                EXTENDED_INNODB_METRICS: true
+                EXTENDED_MYISAM_METRICS: true
+                REMOTE_MONITORING: true
               inventory_source: config/mysql
               interval: 30
           EOT

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -187,15 +187,15 @@ install:
           integrations:
             - name: nri-mysql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database:
-                extended_metrics: true
-                extended_innodb_metrics: true
-                extended_myisam_metrics: true
-                remote_monitoring: true
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE:
+                EXTENDED_METRICS: true
+                EXTENDED_INNODB_METRICS: true
+                EXTENDED_MYISAM_METRICS: true
+                REMOTE_MONITORING: true
               inventory_source: config/mysql
               interval: 30
           EOT

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -184,12 +184,9 @@ install:
 
           sudo touch /etc/newrelic-infra/integrations.d/mysql-config.yml;
           sudo tee -a /etc/newrelic-infra/integrations.d/mysql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.mysql
-
-          instances:
-            - name: mysql-status
-              command: status
-              arguments:
+          integrations:
+            - name: nri-mysql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -199,6 +196,8 @@ install:
                 extended_innodb_metrics: true
                 extended_myisam_metrics: true
                 remote_monitoring: true
+              inventory_source: config/mysql
+              interval: 30
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -174,8 +174,9 @@ install:
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
                 REMOTE_MONITORING: true
+
+                # default true. If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
                 # VALIDATE_CERTS: true
-                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -156,12 +156,10 @@ install:
           fi
           sudo touch /etc/newrelic-infra/integrations.d/nginx-config.yml;
           sudo tee -a /etc/newrelic-infra/integrations.d/nginx-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.nginx
-
-          instances:
-            - name: nginx-server-metrics
-              command: metrics
-              arguments:
+          integrations:
+            - name: nri-nginx
+              env:
+                metrics: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
                 status_url: $NR_CLI_STUB_STATUS_URL
 
@@ -178,10 +176,11 @@ install:
                 remote_monitoring: true
                 # validate_certs: true
                 # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+              interval: 30
 
-            - name: nginx-server-inventory
-              command: inventory
-              arguments:
+            - name: nri-nginx
+              env:
+                inventory: true
                 config_path: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
@@ -195,6 +194,9 @@ install:
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
                 status_url: $NR_CLI_STUB_STATUS_URL
+              inventory_source: config/nginx
+              interval: 60
+
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/debian.yml
@@ -159,12 +159,12 @@ install:
           integrations:
             - name: nri-nginx
               env:
-                metrics: true
+                METRICS: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
 
                 # Name of Nginx status module OHI is to query against. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-                status_module: $NR_CLI_STATUS_MODULE
+                STATUS_MODULE: $NR_CLI_STATUS_MODULE
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -173,15 +173,15 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
-                # validate_certs: true
-                # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+                REMOTE_MONITORING: true
+                # VALIDATE_CERTS: true
+                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx
               env:
-                inventory: true
-                config_path: /etc/nginx/nginx.conf
+                INVENTORY: true
+                CONFIG_PATH: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -190,10 +190,10 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true #new users should leave remote_monitoring = true
+                REMOTE_MONITORING: true #new users should leave remote_monitoring = true
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
               inventory_source: config/nginx
               interval: 60
 

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -161,12 +161,10 @@ install:
           fi
           sudo touch /etc/newrelic-infra/integrations.d/nginx-config.yml;
           sudo tee -a /etc/newrelic-infra/integrations.d/nginx-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.nginx
-
-          instances:
-            - name: nginx-server-metrics
-              command: metrics
-              arguments:
+          integrations:
+            - name: nri-nginx
+              env:
+                metrics: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
                 status_url: $NR_CLI_STUB_STATUS_URL
 
@@ -183,10 +181,11 @@ install:
                 remote_monitoring: true
                 # validate_certs: true
                 # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+              interval: 30
 
-            - name: nginx-server-inventory
-              command: inventory
-              arguments:
+            - name: nri-nginx
+              env:
+                inventory: true
                 config_path: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
@@ -200,6 +199,9 @@ install:
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
                 status_url: $NR_CLI_STUB_STATUS_URL
+              inventory_source: config/nginx
+              interval: 60
+
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -179,8 +179,9 @@ install:
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
                 REMOTE_MONITORING: true
+
+                # default true. If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
                 # VALIDATE_CERTS: true
-                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx

--- a/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/rhel.yml
@@ -164,12 +164,12 @@ install:
           integrations:
             - name: nri-nginx
               env:
-                metrics: true
+                METRICS: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
 
                 # Name of Nginx status module OHI is to query against. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-                status_module: $NR_CLI_STATUS_MODULE
+                STATUS_MODULE: $NR_CLI_STATUS_MODULE
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -178,15 +178,15 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
-                # validate_certs: true
-                # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+                REMOTE_MONITORING: true
+                # VALIDATE_CERTS: true
+                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx
               env:
-                inventory: true
-                config_path: /etc/nginx/nginx.conf
+                INVENTORY: true
+                CONFIG_PATH: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -195,10 +195,10 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true #new users should leave remote_monitoring = true
+                REMOTE_MONITORING: true #new users should leave remote_monitoring = true
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
               inventory_source: config/nginx
               interval: 60
 

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -157,12 +157,12 @@ install:
           integrations:
             - name: nri-nginx
               env:
-                metrics: true
+                METRICS: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
 
                 # Name of Nginx status module OHI is to query against. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-                status_module: $NR_CLI_STATUS_MODULE
+                STATUS_MODULE: $NR_CLI_STATUS_MODULE
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -171,15 +171,15 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
-                # validate_certs: true
-                # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+                REMOTE_MONITORING: true
+                # VALIDATE_CERTS: true
+                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx
               env:
-                inventory: true
-                config_path: /etc/nginx/nginx.conf
+                INVENTORY: true
+                CONFIG_PATH: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -188,10 +188,10 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true #new users should leave remote_monitoring = true
+                REMOTE_MONITORING: true #new users should leave remote_monitoring = true
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
-                status_url: $NR_CLI_STUB_STATUS_URL
+                STATUS_URL: $NR_CLI_STUB_STATUS_URL
               inventory_source: config/nginx
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -154,12 +154,10 @@ install:
           fi
           sudo touch /etc/newrelic-infra/integrations.d/nginx-config.yml;
           sudo tee -a /etc/newrelic-infra/integrations.d/nginx-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.nginx
-
-          instances:
-            - name: nginx-server-metrics
-              command: metrics
-              arguments:
+          integrations:
+            - name: nri-nginx
+              env:
+                metrics: true
                 # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
                 status_url: $NR_CLI_STUB_STATUS_URL
 
@@ -176,10 +174,11 @@ install:
                 remote_monitoring: true
                 # validate_certs: true
                 # default: true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
+              interval: 30
 
-            - name: nginx-server-inventory
-              command: inventory
-              arguments:
+            - name: nri-nginx
+              env:
+                inventory: true
                 config_path: /etc/nginx/nginx.conf
 
                 # New users should leave this property as 'true', to identify the
@@ -193,6 +192,8 @@ install:
 
                 # status_url is used to identify the monitored entity to which the inventory will be attached.
                 status_url: $NR_CLI_STUB_STATUS_URL
+              inventory_source: config/nginx
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -172,8 +172,9 @@ install:
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
                 REMOTE_MONITORING: true
+
+                # default true. If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
                 # VALIDATE_CERTS: true
-                # default true If the status URL is HTTPS with a self-signed certificate, set this to false if you want to avoid certificate validation
               interval: 30
 
             - name: nri-nginx

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -222,11 +222,9 @@ install:
 
           if [ "$NR_CLI_SSL" == "true" ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/postgresql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.postgresql
-          instances:
-            - name: postgres
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-postgresql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -240,14 +238,14 @@ install:
                 ssl_cert_location: $NR_CLI_CLIENT_CERT_FILE
                 ssl_key_location: $NR_CLI_CERT_KEY
                 timeout: 10
+              inventory_source: config/postgresql
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/postgresql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.postgresql
-          instances:
-            - name: postgres
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-postgresql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -257,6 +255,8 @@ install:
                 collect_db_lock_metrics: false
                 enable_ssl: false
                 timeout: 10
+              inventory_source: config/postgresql
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -225,19 +225,19 @@ install:
           integrations:
             - name: nri-postgresql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database: $NR_CLI_DATABASE
-                collection_list: 'ALL'
-                collect_db_lock_metrics: false
-                enable_ssl: true
-                trust_server_certificate: $NR_CLI_TRUST_SERVER_CERTIFICATE
-                ssl_root_cert_location: $NR_CLI_CERT_AUTH_FILE
-                ssl_cert_location: $NR_CLI_CLIENT_CERT_FILE
-                ssl_key_location: $NR_CLI_CERT_KEY
-                timeout: 10
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE: $NR_CLI_DATABASE
+                COLLECTION_LIST: 'ALL'
+                COLLECT_DB_LOCK_METRICS: false
+                ENABLE_SSL: true
+                TRUST_SERVER_CERTIFICATE: $NR_CLI_TRUST_SERVER_CERTIFICATE
+                SSL_ROOT_CERT_LOCATION: $NR_CLI_CERT_AUTH_FILE
+                SSL_CERT_LOCATION: $NR_CLI_CLIENT_CERT_FILE
+                SSL_KEY_LOCATION: $NR_CLI_CERT_KEY
+                TIMEOUT: 10
               inventory_source: config/postgresql
               interval: 15
           EOT
@@ -246,14 +246,14 @@ install:
           integrations:
             - name: nri-postgresql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database: $NR_CLI_DATABASE
-                collection_list: 'ALL'
-                collect_db_lock_metrics: false
-                enable_ssl: false
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE: $NR_CLI_DATABASE
+                COLLECTION_LIST: 'ALL'
+                COLLECT_DB_LOCK_METRICS: false
+                ENABLE_SSL: false
                 timeout: 10
               inventory_source: config/postgresql
               interval: 15

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -225,11 +225,9 @@ install:
 
           if [ "$NR_CLI_SSL" == "true" ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/postgresql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.postgresql
-          instances:
-            - name: postgres
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-postgresql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -243,14 +241,14 @@ install:
                 ssl_cert_location: $NR_CLI_CLIENT_CERT_FILE
                 ssl_key_location: $NR_CLI_CERT_KEY
                 timeout: 10
+              inventory_source: config/postgresql
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/postgresql-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.postgresql
-          instances:
-            - name: postgres
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-postgresql
+              env:
                 hostname: $NR_CLI_DB_HOSTNAME
                 port: $NR_CLI_DB_PORT
                 username: $NR_CLI_DB_USERNAME
@@ -260,6 +258,8 @@ install:
                 collect_db_lock_metrics: false
                 enable_ssl: false
                 timeout: 10
+              inventory_source: config/postgresql
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -228,19 +228,19 @@ install:
           integrations:
             - name: nri-postgresql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database: $NR_CLI_DATABASE
-                collection_list: 'ALL'
-                collect_db_lock_metrics: false
-                enable_ssl: true
-                trust_server_certificate: $NR_CLI_TRUST_SERVER_CERTIFICATE
-                ssl_root_cert_location: $NR_CLI_CERT_AUTH_FILE
-                ssl_cert_location: $NR_CLI_CLIENT_CERT_FILE
-                ssl_key_location: $NR_CLI_CERT_KEY
-                timeout: 10
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE: $NR_CLI_DATABASE
+                COLLECTION_LIST: 'ALL'
+                COLLECT_DB_LOCK_METRICS: false
+                ENABLE_SSL: true
+                TRUST_SERVER_CERTIFICATE: $NR_CLI_TRUST_SERVER_CERTIFICATE
+                SSL_ROOT_CERT_LOCATION: $NR_CLI_CERT_AUTH_FILE
+                SSL_CERT_LOCATION: $NR_CLI_CLIENT_CERT_FILE
+                SSL_KEY_LOCATION: $NR_CLI_CERT_KEY
+                TIMEOUT: 10
               inventory_source: config/postgresql
               interval: 15
           EOT
@@ -249,15 +249,15 @@ install:
           integrations:
             - name: nri-postgresql
               env:
-                hostname: $NR_CLI_DB_HOSTNAME
-                port: $NR_CLI_DB_PORT
-                username: $NR_CLI_DB_USERNAME
-                password: $NR_CLI_DB_PASSWORD
-                database: $NR_CLI_DATABASE
-                collection_list: 'ALL'
-                collect_db_lock_metrics: false
-                enable_ssl: false
-                timeout: 10
+                HOSTNAME: $NR_CLI_DB_HOSTNAME
+                PORT: $NR_CLI_DB_PORT
+                USERNAME: $NR_CLI_DB_USERNAME
+                PASSWORD: $NR_CLI_DB_PASSWORD
+                DATABASE: $NR_CLI_DATABASE
+                COLLECTION_LIST: 'ALL'
+                COLLECT_DB_LOCK_METRICS: false
+                ENABLE_SSL: false
+                TIMEOUT: 10
               inventory_source: config/postgresql
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -114,11 +114,9 @@ install:
         - |
           if [ {{.NR_CLI_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/rabbitmq-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.rabbitmq
-          instances:
-            - name: rabbitmq
-              command: all
-              arguments:
+          integrations:
+            - name: nri-rabbitmq
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
@@ -130,15 +128,15 @@ install:
                 exchanges: '{{.NR_CLI_EXCHANGES}}'
                 exchanges_regexes:
                 vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes: 
+                vhosts_regexes:
+              inventory_source: config/rabbitmq
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/rabbitmq-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.rabbitmq
-          instances:
-            - name: rabbitmq
-              command: all
-              arguments:
+          integrations:
+            - name: nri-rabbitmq
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
@@ -153,6 +151,8 @@ install:
                 exchanges_regexes:
                 vhosts: '{{.NR_CLI_VHOSTS}}'
                 vhosts_regexes:
+              inventory_source: config/rabbitmq
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -117,18 +117,18 @@ install:
           integrations:
             - name: nri-rabbitmq
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_SSL}}
-                config_path: {{.NR_CLI_RABBIT_CONFIG_PATH}}
-                queues: '{{.NR_CLI_QUEUES}}'
-                queues_regexes: 
-                exchanges: '{{.NR_CLI_EXCHANGES}}'
-                exchanges_regexes:
-                vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes:
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_SSL}}
+                CONFIG_PATH: {{.NR_CLI_RABBIT_CONFIG_PATH}}
+                QUEUES: '{{.NR_CLI_QUEUES}}'
+                QUEUES_REGEXES:
+                EXCHANGES: '{{.NR_CLI_EXCHANGES}}'
+                EXCHANGES_REGEXES:
+                VHOSTS: '{{.NR_CLI_VHOSTS}}'
+                VHOSTS_REGEXES:
               inventory_source: config/rabbitmq
               interval: 15
           EOT
@@ -137,20 +137,20 @@ install:
           integrations:
             - name: nri-rabbitmq
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                use_ssl: {{.NR_CLI_SSL}}
-                config_path: {{.NR_CLI_RABBIT_CONFIG_PATH}}
-                queues: '{{.NR_CLI_QUEUES}}'
-                queues_regexes:
-                exchanges: '{{.NR_CLI_EXCHANGES}}'
-                exchanges_regexes:
-                vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes:
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                USE_SSL: {{.NR_CLI_SSL}}
+                CONFIG_PATH: {{.NR_CLI_RABBIT_CONFIG_PATH}}
+                QUEUES: '{{.NR_CLI_QUEUES}}'
+                QUEUES_REGEXES:
+                EXCHANGES: '{{.NR_CLI_EXCHANGES}}'
+                EXCHANGES_REGEXES:
+                VHOSTS: '{{.NR_CLI_VHOSTS}}'
+                VHOSTS_REGEXES:
               inventory_source: config/rabbitmq
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -121,18 +121,18 @@ install:
           integrations:
             - name: nri-rabbitmq
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                use_ssl: {{.NR_CLI_SSL}}
-                config_path: {{.NR_CLI_RABBIT_CONFIG_PATH}}
-                queues: '{{.NR_CLI_QUEUES}}'
-                queues_regexes:
-                exchanges: '{{.NR_CLI_EXCHANGES}}'
-                exchanges_regexes: 
-                vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes:
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                USE_SSL: {{.NR_CLI_SSL}}
+                CONFIG_PATH: {{.NR_CLI_RABBIT_CONFIG_PATH}}
+                QUEUES: '{{.NR_CLI_QUEUES}}'
+                QUEUES_REGEXES:
+                EXCHANGES: '{{.NR_CLI_EXCHANGES}}'
+                EXCHANGES_REGEXES:
+                VHOSTS: '{{.NR_CLI_VHOSTS}}'
+                VHOSTS_REGEXES:
               inventory_source: config/rabbitmq
               interval: 15
           EOT
@@ -141,20 +141,20 @@ install:
           integrations:
             - name: nri-rabbitmq
               env:
-                hostname: {{.NR_CLI_HOSTNAME}}
-                port: {{.NR_CLI_PORT}}
-                username: {{.NR_CLI_DB_USERNAME}}
-                password: {{.NR_CLI_DB_PASSWORD}}
-                ca_bundle_dir: {{.NR_CLI_API_CA_BUNDLE_DIR}}
-                ca_bundle_file: {{.NR_CLI_API_CA_BUNDLE_FILE}}
-                use_ssl: {{.NR_CLI_SSL}}
-                config_path: {{.NR_CLI_RABBIT_CONFIG_PATH}}
-                queues: '{{.NR_CLI_QUEUES}}'
-                queues_regexes:
-                exchanges: '{{.NR_CLI_EXCHANGES}}'
-                exchanges_regexes:
-                vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes:
+                HOSTNAME: {{.NR_CLI_HOSTNAME}}
+                PORT: {{.NR_CLI_PORT}}
+                USERNAME: {{.NR_CLI_DB_USERNAME}}
+                PASSWORD: {{.NR_CLI_DB_PASSWORD}}
+                CA_BUNDLE_DIR: {{.NR_CLI_API_CA_BUNDLE_DIR}}
+                CA_BUNDLE_FILE: {{.NR_CLI_API_CA_BUNDLE_FILE}}
+                USE_SSL: {{.NR_CLI_SSL}}
+                CONFIG_PATH: {{.NR_CLI_RABBIT_CONFIG_PATH}}
+                QUEUES: '{{.NR_CLI_QUEUES}}'
+                QUEUES_REGEXES:
+                EXCHANGES: '{{.NR_CLI_EXCHANGES}}'
+                EXCHANGES_REGEXES:
+                VHOSTS: '{{.NR_CLI_VHOSTS}}'
+                VHOSTS_REGEXES:
               inventory_source: config/rabbitmq
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -118,12 +118,9 @@ install:
         - |
           if [ {{.NR_CLI_SSL}} == false ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/rabbitmq-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.rabbitmq
-
-          instances:
-            - name: rabbitmq
-              command: all
-              arguments:
+          integrations:
+            - name: nri-rabbitmq
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
@@ -135,16 +132,15 @@ install:
                 exchanges: '{{.NR_CLI_EXCHANGES}}'
                 exchanges_regexes: 
                 vhosts: '{{.NR_CLI_VHOSTS}}'
-                vhosts_regexes: 
+                vhosts_regexes:
+              inventory_source: config/rabbitmq
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/rabbitmq-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.rabbitmq
-
-          instances:
-            - name: rabbitmq
-              command: all
-              arguments:
+          integrations:
+            - name: nri-rabbitmq
+              env:
                 hostname: {{.NR_CLI_HOSTNAME}}
                 port: {{.NR_CLI_PORT}}
                 username: {{.NR_CLI_DB_USERNAME}}
@@ -159,6 +155,8 @@ install:
                 exchanges_regexes:
                 vhosts: '{{.NR_CLI_VHOSTS}}'
                 vhosts_regexes:
+              inventory_source: config/rabbitmq
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -157,13 +157,13 @@ install:
           integrations:
             - name: nri-redis
               env:
-                metrics: true
-                hostname: $NR_CLI_HOSTNAME
-                port: $NR_CLI_PORT
-                keys: $NR_CLI_KEYS
-                password: $NR_CLI_PASSWORD
-                config_inventory: true
-                keys_limit: 30
+                METRICS: true
+                HOSTNAME: $NR_CLI_HOSTNAME
+                PORT: $NR_CLI_PORT
+                KEYS: $NR_CLI_KEYS
+                PASSWORD: $NR_CLI_PASSWORD
+                CONFIG_INVENTORY: true
+                KEYS_LIMIT: 30
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -172,19 +172,19 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: true
+                USE_UNIX_SOCKET: true
               interval: 15
 
             - name: nri-redis
               env:
-                inventory: true
-                hostname: $NR_CLI_HOSTNAME
-                port: $NR_CLI_PORT
-                password: $NR_CLI_PASSWORD
+                INVENTORY: true
+                HOSTNAME: $NR_CLI_HOSTNAME
+                PORT: $NR_CLI_PORT
+                PASSWORD: $NR_CLI_PASSWORD
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -193,11 +193,11 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: true
+                USE_UNIX_SOCKET: true
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -175,8 +175,8 @@ install:
                 REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
-                # Unix sockets.
-                USE_UNIX_SOCKET: true
+                # Unix sockets. It requires UNIX_SOCKET_PATH
+                USE_UNIX_SOCKET: false
               interval: 15
 
             - name: nri-redis
@@ -196,8 +196,8 @@ install:
                 REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
-                # Unix sockets.
-                USE_UNIX_SOCKET: true
+                # Unix sockets. It requires UNIX_SOCKET_PATH
+                USE_UNIX_SOCKET: false
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -154,12 +154,10 @@ install:
             sudo rm /etc/newrelic-infra/integrations.d/redis-config.yml;
           fi
           sudo tee /etc/newrelic-infra/integrations.d/redis-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.redis
-
-          instances:
-            - name: redis-metrics
-              command: metrics
-              arguments:
+          integrations:
+            - name: nri-redis
+              env:
+                metrics: true
                 hostname: $NR_CLI_HOSTNAME
                 port: $NR_CLI_PORT
                 keys: $NR_CLI_KEYS
@@ -178,11 +176,12 @@ install:
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: false
+                use_unix_socket: true
+              interval: 15
 
-            - name: redis-inventory
-              command: inventory
-              arguments:
+            - name: nri-redis
+              env:
+                inventory: true
                 hostname: $NR_CLI_HOSTNAME
                 port: $NR_CLI_PORT
                 password: $NR_CLI_PASSWORD
@@ -198,7 +197,9 @@ install:
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: false
+                use_unix_socket: true
+              inventory_source: config/redis
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -178,8 +178,8 @@ install:
                 REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
-                # Unix sockets.
-                USE_UNIX_SOCKET: true
+                # Unix sockets. It requires UNIX_SOCKET_PATH
+                USE_UNIX_SOCKET: false
               interval: 15
 
             - name: nri-redis
@@ -199,8 +199,8 @@ install:
                 REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
-                # Unix sockets.
-                USE_UNIX_SOCKET: true
+                # Unix sockets. It requires UNIX_SOCKET_PATH
+                USE_UNIX_SOCKET: false
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -160,13 +160,13 @@ install:
           integrations:
             - name: nri-redis
               env:
-                metrics: true
-                hostname: $NR_CLI_HOSTNAME
-                port: $NR_CLI_PORT
-                keys: $NR_CLI_KEYS
-                password: $NR_CLI_PASSWORD
-                config_inventory: true
-                keys_limit: 30
+                METRICS: true
+                HOSTNAME: $NR_CLI_HOSTNAME
+                PORT: $NR_CLI_PORT
+                KEYS: $NR_CLI_KEYS
+                PASSWORD: $NR_CLI_PASSWORD
+                CONFIG_INVENTORY: true
+                KEYS_LIMIT: 30
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -175,19 +175,19 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: true
+                USE_UNIX_SOCKET: true
               interval: 15
 
             - name: nri-redis
               env:
-                inventory: true
-                hostname: $NR_CLI_HOSTNAME
-                port: $NR_CLI_PORT
-                password: $NR_CLI_PASSWORD
+                INVENTORY: true
+                HOSTNAME: $NR_CLI_HOSTNAME
+                PORT: $NR_CLI_PORT
+                PASSWORD: $NR_CLI_PASSWORD
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -196,11 +196,11 @@ install:
                 # Please check the documentation to get more information about local
                 # versus remote entities:
                 # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
-                remote_monitoring: true
+                REMOTE_MONITORING: true
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: true
+                USE_UNIX_SOCKET: true
               inventory_source: config/redis
               interval: 60
           EOT

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -157,12 +157,10 @@ install:
             sudo rm /etc/newrelic-infra/integrations.d/redis-config.yml;
           fi
           sudo tee /etc/newrelic-infra/integrations.d/redis-config.yml > /dev/null <<EOT
-          integration_name: com.newrelic.redis
-
-          instances:
-            - name: redis-metrics
-              command: metrics
-              arguments:
+          integrations:
+            - name: nri-redis
+              env:
+                metrics: true
                 hostname: $NR_CLI_HOSTNAME
                 port: $NR_CLI_PORT
                 keys: $NR_CLI_KEYS
@@ -181,11 +179,12 @@ install:
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: false
+                use_unix_socket: true
+              interval: 15
 
-            - name: redis-inventory
-              command: inventory
-              arguments:
+            - name: nri-redis
+              env:
+                inventory: true
                 hostname: $NR_CLI_HOSTNAME
                 port: $NR_CLI_PORT
                 password: $NR_CLI_PASSWORD
@@ -201,7 +200,9 @@ install:
 
                 # New users should leave this property as 'true', to uniquely identify the monitored entities when using
                 # Unix sockets.
-                use_unix_socket: false
+                use_unix_socket: true
+              inventory_source: config/redis
+              interval: 60
           EOT
 
     restart:

--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -121,13 +121,12 @@ install:
             $NR_CLI_DB_PASSWORD = [System.Web.Security.Membership]::GeneratePassword(20,2);
           }
 
-          $OhiConfig = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\mssql-config.yml"; 
+          $OhiConfig = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\mssql-config.yml";
           # Remove any previous config
           if (Test-Path $OhiConfig) { Remove-Item $OhiConfig };
 
           Add-Content -Path $OhiConfig -Value @"
-          integration_name: com.newrelic.mssql
-          instances:
+          integrations:
           "@ -Force | Out-Null;
 
           # Write config function
@@ -139,18 +138,20 @@ install:
               [string] $Port
             )
 
-            Add-Content -Path $OhiConfig -Value "  - name`:` mssql-${InstanceName}" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "    command`:` all_data" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "    arguments`:` " -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      hostname`:` ${NR_CLI_DB_HOSTNAME}" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      username`:` ${NR_CLI_DB_USERNAME}" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      password`:` ${NR_CLI_DB_PASSWORD}" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "  - name`:` nri-mssql" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "    env`:` " -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      HOSTNAME`:` ${NR_CLI_DB_HOSTNAME}" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      USERNAME`:` ${NR_CLI_DB_USERNAME}" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      PASSWORD`:` ${NR_CLI_DB_PASSWORD}" -Force | Out-Null;
 
             if ([string]::IsNullOrWhiteSpace($Port)) {
-              Add-Content -Path $OhiConfig -Value "      instance`:` ${InstanceName}" -Force | Out-Null;
+              Add-Content -Path $OhiConfig -Value "      INSTANCE`:` ${InstanceName}" -Force | Out-Null;
             } else {
-              Add-Content -Path $OhiConfig -Value "      port`:` ${Port}" -Force | Out-Null;
+              Add-Content -Path $OhiConfig -Value "      PORT`:` ${Port}" -Force | Out-Null;
             }
+
+            Add-Content -Path $OhiConfig -Value "    inventory_source`:` config/mssql" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "    interval`:` 15" -Force | Out-Null;
           }
 
           # Create SQL user function
@@ -171,7 +172,7 @@ install:
             $SQL=@"
           SET QUOTED_IDENTIFIER OFF;
           DECLARE @name SYSNAME
-          DECLARE db_user_cursor CURSOR 
+          DECLARE db_user_cursor CURSOR
           READ_ONLY FORWARD_ONLY
           FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`")
           OPEN db_user_cursor
@@ -186,10 +187,10 @@ install:
           IF EXISTS(select top 1 name from sys.syslogins where name = `"${NR_CLI_DB_USERNAME}`")
           BEGIN
             DECLARE @session_id INT
-            DECLARE db_login_cursor CURSOR 
+            DECLARE db_login_cursor CURSOR
             READ_ONLY FORWARD_ONLY
             FOR SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = `"${NR_CLI_DB_USERNAME}`"
-            OPEN db_login_cursor 
+            OPEN db_login_cursor
             FETCH NEXT FROM db_login_cursor  INTO @session_id WHILE @@FETCH_STATUS = 0
             BEGIN
                 EXECUTE(`"KILL `" + @session_id )
@@ -204,7 +205,7 @@ install:
           CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
 
           GRANT CONNECT SQL, VIEW SERVER STATE, VIEW ANY DEFINITION TO ${NR_CLI_DB_USERNAME}
-          DECLARE db_create_cursor CURSOR 
+          DECLARE db_create_cursor CURSOR
           READ_ONLY FORWARD_ONLY
           FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`")
           OPEN db_create_cursor

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -87,22 +87,22 @@ install:
         - |
           if [ -z {{.NR_CLI_PARAMS_CONFIG_FILE}} ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/varnish-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.varnish
-          instances:
-            - name: varnish
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-varnish
+              env:
                 instance_name: {{.NR_CLI_INSTANCE_NAME}}
+              inventory_source: config/varnish
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/varnish-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.varnish
-          instances:
-            - name: varnish
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-varnish
+              env:
                 params_config_file: {{.NR_CLI_PARAMS_CONFIG_FILE}}
-                instance_name: {{.NR_CLI_INSTANCE_NAME}} 
+                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+              inventory_source: config/varnish
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -90,7 +90,7 @@ install:
           integrations:
             - name: nri-varnish
               env:
-                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+                INSTANCE_NAME: {{.NR_CLI_INSTANCE_NAME}}
               inventory_source: config/varnish
               interval: 15
           EOT
@@ -99,8 +99,8 @@ install:
           integrations:
             - name: nri-varnish
               env:
-                params_config_file: {{.NR_CLI_PARAMS_CONFIG_FILE}}
-                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+                INSTANCE_NAME: {{.NR_CLI_INSTANCE_NAME}}
+                PARAMS_CONFIG_FILE: {{.NR_CLI_PARAMS_CONFIG_FILE}}
               inventory_source: config/varnish
               interval: 15
           EOT

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -93,22 +93,22 @@ install:
         - |
           if [ -z {{.NR_CLI_PARAMS_CONFIG_FILE}} ]; then
             sudo tee -a /etc/newrelic-infra/integrations.d/varnish-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.varnish
-          instances:
-            - name: varnish
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-varnish
+              env:
                 instance_name: {{.NR_CLI_INSTANCE_NAME}}
+              inventory_source: config/varnish
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/varnish-config.yml > /dev/null <<"EOT"
-          integration_name: com.newrelic.varnish
-          instances:
-            - name: varnish
-              command: all_data
-              arguments:
+          integrations:
+            - name: nri-varnish
+              env:
                 params_config_file: {{.NR_CLI_PARAMS_CONFIG_FILE}}
-                instance_name: {{.NR_CLI_INSTANCE_NAME}} 
+                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+              inventory_source: config/varnish
+              interval: 15
           EOT
           fi
 

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -96,7 +96,7 @@ install:
           integrations:
             - name: nri-varnish
               env:
-                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+                INSTANCE_NAME: {{.NR_CLI_INSTANCE_NAME}}
               inventory_source: config/varnish
               interval: 15
           EOT
@@ -105,8 +105,8 @@ install:
           integrations:
             - name: nri-varnish
               env:
-                params_config_file: {{.NR_CLI_PARAMS_CONFIG_FILE}}
-                instance_name: {{.NR_CLI_INSTANCE_NAME}}
+                INSTANCE_NAME: {{.NR_CLI_INSTANCE_NAME}}
+                PARAMS_CONFIG_FILE: {{.NR_CLI_PARAMS_CONFIG_FILE}}
               inventory_source: config/varnish
               interval: 15
           EOT


### PR DESCRIPTION
This PR is to change the configuration files produced by the infrastructure integration OHI recipes to the new v4 format.

Please do not merge yet as we are coordinating with other changes, like public documentation to release this at the. same time.