### PR TITLE
fix: issue on darwin with sed command

### DIFF
--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -82,11 +82,11 @@ install:
       cmds:
         - |
           if [ -f "{{.CONFIG_FILE}}" ]; then
-            sed -i "" "/^staging/d" "{{.CONFIG_FILE}}"
-            sed -i "" "/^enable_process_metrics/d" "{{.CONFIG_FILE}}"
-            sed -i "" "/^status_server_enabled/d" "{{.CONFIG_FILE}}"
-            sed -i "" "/^status_server_port/d" "{{.CONFIG_FILE}}"
-            sed -i "" "/^license_key/d" "{{.CONFIG_FILE}}"
+            sed -i.bak "/^staging/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
+            sed -i.bak "/^enable_process_metrics/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
+            sed -i.bak "/^status_server_enabled/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
+            sed -i.bak "/^status_server_port/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
+            sed -i.bak "/^license_key/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
           else
             mkdir -p "{{.CONFIG_FILE_DIR}}"
             touch "{{.CONFIG_FILE}}"
@@ -104,7 +104,7 @@ install:
       cmds:
         - |
           if [ -f "{{.CONFIG_FILE}}" ]; then
-            sudo sed -i "" "/^proxy/d" "{{.CONFIG_FILE}}"
+            sudo sed -i.bak "/^proxy/d" "{{.CONFIG_FILE}}" && rm "{{.CONFIG_FILE}}".bak
           fi
 
           if [ ! -z "$HTTPS_PROXY" ]; then


### PR DESCRIPTION
This PR will fix issues on different versions of sed command on darwin:

e.g.
==> Installing infrastructure-agent-installer...
sed: can't read /^proxy/d: No such file or directory
==> Installing infrastructure-agent-installer...failed.