### PR TITLE
Fixes to PHP agent install recipe detect_services task

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -169,6 +169,9 @@ install:
             # for other searches.
             #
             full_process_name=$(ps xf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $5}')
+            if [ -z $full_process_name ]; then
+              continue
+            fi
             priv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
@@ -184,6 +187,9 @@ install:
             else
               process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
             fi
+
+            echo -e "{{.WHITE}}Found service: {{.CYAN}}$process_name{{.NOCOLOR}}"
+
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
               nonpriv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -166,6 +166,9 @@ install:
             # for other searches.
             #
             full_process_name=$(ps xf | egrep $PROCESS | grep -v grep | grep -v yml | head -n1 | awk '{print $5}')
+            if [ -z $full_process_name ]; then
+              continue
+            fi
             priv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | head -n1 | awk '{print $1}')
             fpm_nginx_process_name=$(echo "${full_process_name}" | sed -n 's/\(.*\):$/\1/p')
             if [ -n "${fpm_nginx_process_name}" ]; then
@@ -181,6 +184,9 @@ install:
             else
               process_name=$(echo $full_process_name | sed -n 's/.*\/\(.*\)$/\1/p')
             fi
+
+            echo -e "{{.WHITE}}Found service: {{.CYAN}}$process_name{{.NOCOLOR}}"
+
             nonpriv_user=
             if [ -n "${priv_user}" ]; then
               nonpriv_user=$(ps auxf | egrep $full_process_name | grep -v grep | grep -v yml | grep -v $priv_user | head -n1 | awk '{print $1}')


### PR DESCRIPTION
Fix to prevent grep being run with no args if a service was not detected.
Added feedback to console/log for user when a service was detected.

This addresses the PHP Agent issue newrelic/newrelic-php-agent#214.