### PR TITLE
guarantee sources.list.d exists before using it

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -274,6 +274,10 @@ install:
       cmds:
         - |
           echo -e "{{.ARROW}}Installing New Relic PHP Agent package{{.GRAY}}"
+          if [ ! -d "/etc/apt/sources.list.d/" ]; then
+            sudo mkdir -p /etc/apt/sources.list.d
+            sudo chmod 755 /etc/apt/sources.list.d
+          fi
           echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
           curl -s https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
           sudo apt-get -o Acquire::Check-Valid-Until=false update -yq


### PR DESCRIPTION
https://github.com/newrelic/newrelic-php-agent/issues/213

Install fails if /etc/apt/sources.list.d/ does not exist. This should exist by default if the user has apt installed. So it could not exist on a debian system for 2 reasons:

1) The user removed the directory.
This is the case addressed by this PR. The user might have wished to remove 3rd party pkg repos at some point and wiped the whole directory.

2) The system doesn't have apt.
I don't know of any situations where a debian system wouldn't have apt installed. Is this a check that should be added to prereqs?