### PR TITLE
Php agent preinstall

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -20,7 +20,43 @@ keywords:
   - fpm
 
 processMatch:
+  # several possible configurations we can match on:
+  # - older apache and no php-fpm (process named httpd)
+  # - newer apache and no php-fpm (process named apache2)
+  # - nginx and php-fpm (process named php-fpm)
+  # in the preInstall we will check if php is installed and further filter down the possible scenarios
   - php-fpm
+  - apache2
+  - httpd
+
+preInstall:
+  requireAtDiscovery: |
+      # verify running with sudo
+      if [ -z "$SUDO_USER" ]; then
+        exit 3
+      fi
+
+      # verify systemctl is installed
+      IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
+        exit 3
+      fi
+
+      # Map of tool names to the associated error code
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+
+      for tuple in $required_tools_and_error_codes; do
+        tool=$(echo ${tuple} |cut -d':' -f1)
+        code=$(echo ${tuple} |cut -d':' -f2)
+
+        IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+        if [ "$IS_TOOL_INSTALLED" -eq 0 ]; then
+          exit 3
+        fi
+      done
+
+      # everything looks good!
+      exit 0
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
@@ -113,7 +149,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
@@ -396,13 +432,13 @@ install:
               # We rely on the package installer to enable the newrelic module.
               #
 
-              # 
+              #
               # For each php directory the installation has detected, scrape three pieces
-              # of information from the logfile:  The php binary location, the location 
+              # of information from the logfile:  The php binary location, the location
               # of the php.ini file associated with that binary, and the location of the
               # newrelic.ini file associated with that binary.  If the logfile indicated
               # it was a specific web directory, the information is saved in web_info.txt;
-              # otherwise, the information is saved in cli_info.txt.  
+              # otherwise, the information is saved in cli_info.txt.
               #
               if [ -z "${CLI_DIRS}" ]; then
                 echo "$php_bin $php_ini_dir $target_ini_dir" >> {{.TMP_INSTALL_DIR}}/web_info.txt

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -38,14 +38,13 @@ preInstall:
       fi
 
       IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
-      then
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
         echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'."
         exit 20
       fi
 
       # Map of tool names to the associated error code
-      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 apt-get:22"
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:131 apt-get:131"
 
       for tuple in $required_tools_and_error_codes; do
         tool=$(echo ${tuple} |cut -d':' -f1)
@@ -58,6 +57,19 @@ preInstall:
           exit ${code}
         fi
       done
+
+      # check if /tmp is mounted noexec - this causes problems with how the recipe works
+      tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+      if [ ! -z "${tmp_is_noexec}" ]; then
+        echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+        exit 131
+      fi
+
+      # need directory for extra repositories to exist
+      if [ ! -d "/etc/apt/sources.list.d/" ]; then
+        echo "This installation recipe for the New Relic PHP Agent on Linux requires the directory /etc/apt/sources.list.d to exist."
+        exit 131
+      fi
 
       # everything looks good!
       exit 0
@@ -153,7 +165,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 apt-get:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:131 apt-get:131"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
@@ -166,6 +178,19 @@ install:
               exit ${code}
             fi
           done
+        - |
+          # check if /tmp is mounted noexec
+          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+          if [ ! -z "${tmp_is_noexec}" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+            exit 131
+          fi
+        - |
+          # need directory for extra repositories to exist
+          if [ ! -d "/etc/apt/sources.list.d/" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires the directory /etc/apt/sources.list.d to exist."
+            exit 131
+          fi
 
     create_shared:
       cmds:
@@ -314,10 +339,6 @@ install:
       cmds:
         - |
           echo -e "{{.ARROW}}Installing New Relic PHP Agent package{{.GRAY}}"
-          if [ ! -d "/etc/apt/sources.list.d/" ]; then
-            sudo mkdir -p /etc/apt/sources.list.d
-            sudo chmod 755 /etc/apt/sources.list.d
-          fi
           echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
           curl -s https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
           sudo apt-get -o Acquire::Check-Valid-Until=false update -yq

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -26,8 +26,11 @@ processMatch:
   # - nginx and php-fpm (process named php-fpm)
   # in the preInstall we will check if php is installed and further filter down the possible scenarios
   - php-fpm
-  - apache2
-  - httpd
+
+  # Going to leave these out for now as it will potentially pull in
+  # lots of matches which do not actually need PHP instrumentation
+  #- apache2
+  #- httpd
 
 preInstall:
   requireAtDiscovery: |

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -33,25 +33,29 @@ preInstall:
   requireAtDiscovery: |
       # verify running with sudo
       if [ -z "$SUDO_USER" ]; then
+        echo "This installation recipe for the New Relic PHP agent must be run under sudo."
         exit 3
       fi
 
-      # verify systemctl is installed
       IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
-        exit 3
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+      then
+        echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'."
+        exit 20
       fi
 
       # Map of tool names to the associated error code
-      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 apt-get:22"
 
       for tuple in $required_tools_and_error_codes; do
         tool=$(echo ${tuple} |cut -d':' -f1)
         code=$(echo ${tuple} |cut -d':' -f2)
 
         IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
-        if [ "$IS_TOOL_INSTALLED" -eq 0 ]; then
-          exit 3
+        if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+        then
+          echo "This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed."
+          exit ${code}
         fi
       done
 
@@ -149,7 +153,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 apt-get:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -35,14 +35,13 @@ preInstall:
       fi
 
       IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
-      then
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
         echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'."
         exit 20
       fi
 
       # Map of tool names to the associated error code
-      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 yum:22"
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:22 yum:22"
 
       for tuple in $required_tools_and_error_codes; do
         tool=$(echo ${tuple} |cut -d':' -f1)
@@ -55,6 +54,13 @@ preInstall:
           exit ${code}
         fi
       done
+
+      # check if /tmp is mounted noexec - this causes problems with how the recipe works
+      tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+      if [ ! -z "${tmp_is_noexec}" ]; then
+        echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+        exit 131
+      fi
 
       # everything looks good!
       exit 0
@@ -150,7 +156,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 yum:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:22 yum:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)
@@ -163,6 +169,13 @@ install:
               exit ${code}
             fi
           done
+        - |
+          # check if /tmp is mounted noexec
+          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+          if [ ! -z "${tmp_is_noexec}" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+            exit 131
+          fi
 
     create_shared:
       cmds:

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -30,25 +30,29 @@ preInstall:
   requireAtDiscovery: |
       # verify running with sudo
       if [ -z "$SUDO_USER" ]; then
+        echo "This installation recipe for the New Relic PHP agent must be run under sudo."
         exit 3
       fi
 
-      # verify systemctl is installed
       IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
-        exit 3
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+      then
+        echo "This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'."
+        exit 20
       fi
 
       # Map of tool names to the associated error code
-      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 yum:22"
 
       for tuple in $required_tools_and_error_codes; do
         tool=$(echo ${tuple} |cut -d':' -f1)
         code=$(echo ${tuple} |cut -d':' -f2)
 
         IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
-        if [ "$IS_TOOL_INSTALLED" -eq 0 ]; then
-          exit 3
+        if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+        then
+          echo "This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed."
+          exit ${code}
         fi
       done
 
@@ -146,7 +150,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22 yum:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -23,8 +23,11 @@ processMatch:
   # - nginx and php-fpm (process named php-fpm)
   # in the preInstall we will check if php is installed and further filter down the possible scenarios
   - php-fpm
-  - apache2
-  - httpd
+
+  # Going to leave these out for now as it will potentially pull in
+  # lots of matches which do not actually need PHP instrumentation
+  #- apache2
+  #- httpd
 
 preInstall:
   requireAtDiscovery: |

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -17,7 +17,43 @@ keywords:
   - fpm
 
 processMatch:
+  # several possible configurations we can match on:
+  # - older apache and no php-fpm (process named httpd)
+  # - newer apache and no php-fpm (process named apache2)
+  # - nginx and php-fpm (process named php-fpm)
+  # in the preInstall we will check if php is installed and further filter down the possible scenarios
   - php-fpm
+  - apache2
+  - httpd
+
+preInstall:
+  requireAtDiscovery: |
+      # verify running with sudo
+      if [ -z "$SUDO_USER" ]; then
+        exit 3
+      fi
+
+      # verify systemctl is installed
+      IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+      if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]; then
+        exit 3
+      fi
+
+      # Map of tool names to the associated error code
+      required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
+
+      for tuple in $required_tools_and_error_codes; do
+        tool=$(echo ${tuple} |cut -d':' -f1)
+        code=$(echo ${tuple} |cut -d':' -f2)
+
+        IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+        if [ "$IS_TOOL_INSTALLED" -eq 0 ]; then
+          exit 3
+        fi
+      done
+
+      # everything looks good!
+      exit 0
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
@@ -110,7 +146,7 @@ install:
           fi
         - |
           # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22"
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 php:22"
 
           for tuple in $required_tools_and_error_codes; do
             tool=$(echo ${tuple} |cut -d':' -f1)


### PR DESCRIPTION
This PR implements the preInstall:requireAtDiscovery method for the PHP agent recipes for RHEL and "debian-like" Linux distributions.  It adds numerous tests in the preInstall to verify the environment has a high probability of supporting the PHP agent installation.  Any test failures are documented by output which will appear in the newrelic-cli.log log file and also on the console if the '--debug' command line option is passed to the newrelic CLI.

This PR addresses the following issues:
- newrelic/newrelic-php-agent#208
- newrelic/newrelic-php-agent#212
- newrelic/newrelic-php-agent#213
- newrelic/newrelic-php-agent#222
- newrelic/newrelic-php-agent#227