### PR TITLE
Corrected yaml indentation on couchbase-rhel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .terraform
 **/terraform.tfstate*
 node_modules

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -115,8 +115,8 @@ install:
                 USERNAME: {{.NR_CLI_DB_USERNAME}}
                 PASSWORD: {{.NR_CLI_DB_PASSWORD}}
                 USE_SSL: {{.NR_CLI_API_USE_SSL}}
-            inventory_source: config/couchbase
-            interval: 15
+              inventory_source: config/couchbase
+              interval: 15
           EOT
           else
             sudo tee -a /etc/newrelic-infra/integrations.d/couchbase-config.yml > /dev/null <<"EOT"


### PR DESCRIPTION
Incorrect indentation on non-SSL yaml configuration was causing couchbase-rhel to hang.