### PR TITLE
Remove php-fpm from the apache-wordpress role for debian.

### DIFF
--- a/test/deploy/linux/php/apache-wordpress/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/php/apache-wordpress/debian/roles/configure/tasks/main.yml
@@ -6,7 +6,6 @@
   apt:
     pkg:
       - libapache2-mod-php
-      - php-fpm
       - mysql-server
       - mysql-client
       - php-mysql


### PR DESCRIPTION
The deploy definitions for debian for apache without php-fpm were installing php-fpm erronenously.

Addresses newrelic/newrelic-php-agent/#235.