### PR TITLE
feat: use brew official tap to install infra-agent in mac

### DIFF
--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -113,7 +113,7 @@ install:
     install_infra:
       cmds:
         - |
-          sudo -i -u $SUDO_USER brew install newrelic/tap/newrelic-infra-agent -q
+          sudo -i -u $SUDO_USER brew install newrelic-infra-agent -q
 
     restart:
       cmds:


### PR DESCRIPTION
Now that go version in formula has been downgraded to 1.16, official formula can be used again.
Official formula has bottles and so no xcode tools will be required to install.