### PR TITLE
chore(schema): remove stability, observabilityPack, and quickstarts

### DIFF
--- a/docs/recipe-spec/recipe-spec.md
+++ b/docs/recipe-spec/recipe-spec.md
@@ -35,41 +35,12 @@ description: string, required
 # Example: https://github.com/newrelic/infrastructure-agent
 repository: string, required
 
-# Indicates stability level of recipe. Useful for gradually enabling the
-# availablity of a recipe to users as it is developed and tested. Can be
-# thought of as an indicator for how stable/ready a recipe is for general
-# consumption and can be used to quickly disable problematic recipes.
-#
-# Usage: # newrelic install --stability=stable
-#
-# Levels:
-#   disabled - No availability (recipe will not return from NerdGraph)
-#   experimental - Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments.
-#   stable - General availability - ongoing support and compatability is a high priority
-stability: enum, optional # One of [ disabled, experimental, stable ]
-
 # Dependency list for recipes (by name) that must be run successfully prior to attempting
 # the current recipe
 # ex:
 # dependencies:
 #   - infrastructure-agent-installer
 dependencies: list, optional
-
-# DEPRECATED: use observabilityPacks instead
-# Metadata used to recommend and install Quickstarts (dashboards, alerts, synthetics, etc.)
-# This is filtering criteria for the quickstartSearch endpoint in NerdGraph
-quickstarts: list (object), optional
-  - name: string, required
-    entityType: object, optional
-      type: string, required
-      domain: string, required
-    category: string (enum), optional # One of [ newrelic, community ]. Defaults to newrelic.
-
-# Metadata used to recommend and install Observability Packs (dashboards, alerts, synthetics, etc.)
-# This is filtering criteria for the observabilityPackSearch endpoint in NerdGraph
-observabilityPacks: list (object), optional
-  - name: string, required
-    level: string (enum), optional # One of [ newrelic, verified, community ]. Defaults to newrelic.
 
 # Still TBD
 # Indicates the target host/runtime/env where user is trying to install (Note: isn't necessarily where you're running the newrelic-cli from)

--- a/docs/recipe-spec/spec.json
+++ b/docs/recipe-spec/spec.json
@@ -3,22 +3,9 @@
   "displayName": "Infrastructure Agent Linux Installer",
   "description": "New Relic install recipe for the Infrastructure agent",
   "repository": "https://github.com/newrelic/infrastructure-agent",
-  "stability": "stable",
   "dependencies": [
     "infrastructure-agent-installer"
   ],
-  "quickstarts": [{
-    "name": "APM",
-    "entities": {
-      "type": "APPLICATION",
-      "domain": "APM"
-    },
-    "category": "newrelic"
-  }],
-  "observabilityPacks": [{
-    "name": "apache",
-    "level": "newrelic"
-  }],
   "installTargets": [{
     "type": "host",
     "os": "linux",
@@ -52,6 +39,7 @@
     "default": "/var/log/messages,/var/log/cloud-init.log,/var/log/secure"
   }],
   "validationNrql": "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago",
+  "validationUrl": "http://localhost:18003/v1/status/entity",
   "successLinkConfig": {
     "type": "EXPLORER",
     "filter": "\"`tags.language` = 'java'\""

--- a/validator/schema-v1.json
+++ b/validator/schema-v1.json
@@ -11,25 +11,8 @@
             "displayName": "Infrastructure Agent Linux Installer",
             "description": "New Relic install recipe for the Infrastructure agent",
             "repository": "https://github.com/newrelic/infrastructure-agent",
-            "stability": "stable",
             "dependencies": [
                 "infrastructure-agent-installer"
-            ],
-            "quickstarts": [
-                {
-                    "name": "APM",
-                    "entities": {
-                        "type": "APPLICATION",
-                        "domain": "APM"
-                    },
-                    "category": "newrelic"
-                }
-            ],
-            "observabilityPacks": [
-                {
-                    "name": "apache",
-                    "level": "newrelic"
-                }
             ],
             "installTargets": [
                 {
@@ -70,6 +53,7 @@
                 }
             ],
             "validationNrql": "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago",
+            "validationUrl": "http://localhost:18003/v1/status/entity",
             "successLinkConfig": {
                 "type": "EXPLORER",
                 "filter": "\"`tags.language` = 'java'\""
@@ -139,21 +123,6 @@
                 "https://github.com/newrelic/infrastructure-agent"
             ]
         },
-        "stability": {
-            "$id": "#/properties/stability",
-            "type": "string",
-            "enum": [
-                "disabled",
-                "experimental",
-                "stable"
-            ],
-            "title": "The stability schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": "",
-            "examples": [
-                "stable"
-            ]
-        },
         "dependencies": {
             "$id": "#/properties/dependencies",
             "type": "array",
@@ -178,179 +147,6 @@
                         "examples": [
                             "infrastructure-agent-installer"
                         ]
-                    }
-                ]
-            }
-        },
-        "quickstarts": {
-            "$id": "#/properties/quickstarts",
-            "type": "array",
-            "title": "The quickstarts schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": [],
-            "examples": [
-                [
-                    {
-                        "name": "APM",
-                        "entities": {
-                            "type": "APPLICATION",
-                            "domain": "APM"
-                        },
-                        "category": "newrelic"
-                    }
-                ]
-            ],
-            "additionalItems": true,
-            "items": {
-                "$id": "#/properties/quickstarts/items",
-                "anyOf": [
-                    {
-                        "$id": "#/properties/quickstarts/items/anyOf/0",
-                        "type": "object",
-                        "title": "The first anyOf schema",
-                        "description": "An explanation about the purpose of this instance.",
-                        "default": {},
-                        "examples": [
-                            {
-                                "name": "APM",
-                                "entities": {
-                                    "type": "APPLICATION",
-                                    "domain": "APM"
-                                },
-                                "category": "newrelic"
-                            }
-                        ],
-                        "required": [
-                            "name"
-                        ],
-                        "properties": {
-                            "name": {
-                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/name",
-                                "type": "string",
-                                "title": "The name schema",
-                                "description": "An explanation about the purpose of this instance.",
-                                "default": "",
-                                "examples": [
-                                    "APM"
-                                ]
-                            },
-                            "entities": {
-                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities",
-                                "type": "object",
-                                "title": "The entities schema",
-                                "description": "An explanation about the purpose of this instance.",
-                                "default": {},
-                                "examples": [
-                                    {
-                                        "type": "APPLICATION",
-                                        "domain": "APM"
-                                    }
-                                ],
-                                "required": [
-                                    "type",
-                                    "domain"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities/properties/type",
-                                        "type": "string",
-                                        "title": "The type schema",
-                                        "description": "An explanation about the purpose of this instance.",
-                                        "default": "",
-                                        "examples": [
-                                            "APPLICATION"
-                                        ]
-                                    },
-                                    "domain": {
-                                        "$id": "#/properties/quickstarts/items/anyOf/0/properties/entities/properties/domain",
-                                        "type": "string",
-                                        "title": "The domain schema",
-                                        "description": "An explanation about the purpose of this instance.",
-                                        "default": "",
-                                        "examples": [
-                                            "APM"
-                                        ]
-                                    }
-                                },
-                                "additionalProperties": true
-                            },
-                            "category": {
-                                "$id": "#/properties/quickstarts/items/anyOf/0/properties/category",
-                                "type": "string",
-                                "title": "The category schema",
-                                "description": "An explanation about the purpose of this instance.",
-                                "default": "",
-                                "examples": [
-                                    "newrelic"
-                                ]
-                            }
-                        },
-                        "additionalProperties": true
-                    }
-                ]
-            }
-        },
-        "observabilityPacks": {
-            "$id": "#/properties/observabilityPacks",
-            "type": "array",
-            "title": "The observabilityPacks schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": [],
-            "examples": [
-                [
-                    {
-                        "name": "apache",
-                        "level": "newrelic"
-                    }
-                ]
-            ],
-            "additionalItems": true,
-            "items": {
-                "$id": "#/properties/observabilityPacks/items",
-                "anyOf": [
-                    {
-                        "$id": "#/properties/observabilityPacks/items/anyOf/0",
-                        "type": "object",
-                        "title": "The first anyOf schema",
-                        "description": "An explanation about the purpose of this instance.",
-                        "default": {},
-                        "examples": [
-                            {
-                                "name": "apache",
-                                "level": "newrelic"
-                            }
-                        ],
-                        "required": [
-                            "name"
-                        ],
-                        "properties": {
-                            "name": {
-                                "$id": "#/properties/observabilityPacks/items/anyOf/0/properties/name",
-                                "type": "string",
-                                "title": "The name schema",
-                                "description": "An explanation about the purpose of this instance.",
-                                "default": "",
-                                "examples": [
-                                    "apache"
-                                ]
-                            },
-                            "level": {
-                                "$id": "#/properties/observabilityPacks/items/anyOf/0/properties/level",
-                                "type": "string",
-                                "enum": [
-                                    "NEWRELIC",
-                                    "VERIFIED",
-                                    "COMMUNITY"
-                                ],
-                                "title": "The level schema",
-                                "description": "An explanation about the purpose of this instance.",
-                                "default": "",
-                                "examples": [
-                                    "newrelic"
-                                ]
-                            }
-                        },
-                        "additionalProperties": true
                     }
                 ]
             }
@@ -772,6 +568,16 @@
             "default": "",
             "examples": [
                 "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' SINCE 10 minutes ago"
+            ]
+        },
+        "validationUrl": {
+            "$id": "#/properties/validationUrl",
+            "type": "string",
+            "title": "The validationUrl schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "http://localhost:18003/v1/status/entity"
             ]
         },
         "successLinkConfig": {


### PR DESCRIPTION
Just some cleanup: 
* `observabilityPacks` and `quickstarts` fields are no longer used
* `stability` was never implemented, so makes sense to just remove it and avoid confusion
* adds `validationUrl` to the schema validator