### PR TITLE
Add missing pixie address environment variable

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -107,6 +107,7 @@ install:
           NR_CLI_NEWRELIC_PIXIE="{{.NR_CLI_NEWRELIC_PIXIE}}"
           NR_CLI_PIXIE_API_KEY="{{.NR_CLI_PIXIE_API_KEY}}"
           NR_CLI_PIXIE_DEPLOY_KEY="{{.NR_CLI_PIXIE_DEPLOY_KEY}}"
+          NR_CLI_PIXIE_ADDRESS="{{.NR_CLI_PIXIE_ADDRESS}}"
 
           SUDO=$(test ! -z "$SUDO_USER" && echo "sudo -u $SUDO_USER" || echo "")
 


### PR DESCRIPTION
Looks like the `NR_CLI_PIXIE_ADDRESS` variable is used but not assigned from the environment variable?

(Also, this is Mary Ann. 👋 )