### PR TITLE
Fix Kubernetes pod validation.

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -356,8 +356,8 @@ install:
           TRIES=0
           while [ $TRIES -lt $MAX_RETRIES ]; do
             ((TRIES++))
-            IS_INFRA_POD_STARTED=$($SUDO kubectl get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | grep -v "grep" | wc -l)
-            if [[ $IS_INFRA_POD_STARTED -eq 1 ]]; then
+            IS_INFRA_POD_STARTED=$($SUDO kubectl get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | wc -l)
+            if [[ $IS_INFRA_POD_STARTED -gt 0 ]]; then
               echo "newrelic-infrastructure pod started"
               break
             fi


### PR DESCRIPTION
The Kubernetes validation was checking whether there was exactly 1 newrelic-infrastructure pod running. In clusters with multiple nodes, there is 1 newrelic-infrastructure pod per node. This PR fixes to check whether there are more than 0 newrelic-infrastructure pods running.