### PR TITLE
Fixes for installing Pixie on Minikube

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -206,13 +206,14 @@ install:
               fi
             fi
 
-            if $SUDO which minikube 1>/dev/null 2>&1; then
-              if $SUDO minikube profile list | grep " ${CLUSTER} " 2>/dev/null; then
-                DRIVER=$($SUDO minikube profile list | grep " ${CLUSTER} " | cut -f3 -d'|')
+            MINIKUBE=$($SUDO which minikube 2>/dev/null || echo '/usr/local/bin/minikube')
+            if [[ -x $MINIKUBE ]]; then
+              if $SUDO $MINIKUBE profile list | grep " ${CLUSTER} " 1>/dev/null 2>&1; then
+                DRIVER=$($SUDO $MINIKUBE profile list | grep " ${CLUSTER} " | awk -F"|" '{ gsub(" ", "", $3); print $3; }')
                 if [[ "$DRIVER" == "kvm2" || "$DRIVER" == "hyperkit" ]] ; then
-                  echo "Unrecognized minikube driver. To create a test cluster to try out Pixie, use kvm2 or HyperKit instead." >&2
-                else
                   PIXIE_SUPPORTED=true
+                else
+                  echo "Unrecognized minikube driver. To create a test cluster to try out Pixie, use kvm2 or HyperKit instead." >&2
                 fi
               fi
             fi


### PR DESCRIPTION
The PR contains 2 fixes:

1. **Fix driver matching**: the driver matching logic was wrong and worked because the driver variable contained whitespaces. The PR removes the whitespaces and does the correct matching. Tested with hyperkit driver on macos.

2. **Find minikube in default location**: due to sudo /usr/local/bin might not be in path for the sudo-ed user. The PR adds logic to find minikube in /usr/local/bin if it cannot be found using which.