### PR TITLE
Small fixes to Kubernetes verification

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -354,11 +354,11 @@ install:
 
           # Wait on newrelic-infrastructure pod to be running
           echo "Running newrelic-infrastructure status check attempt..."
-          MAX_RETRIES=60
+          MAX_RETRIES=150
           TRIES=0
           while [ $TRIES -lt $MAX_RETRIES ]; do
             ((TRIES++))
-            IS_INFRA_POD_STARTED=$($SUDO kubectl get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | wc -l)
+            IS_INFRA_POD_STARTED=$($SUDO kubectl get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | wc -l | sed 's/ //g')
             if [[ $IS_INFRA_POD_STARTED -gt 0 ]]; then
               echo "newrelic-infrastructure pod started"
               break


### PR DESCRIPTION
On macOS, the output of the `wc -l` command contains whitespace that messes up the if check afterwards. I've added a sed to remove the whitespace, which works both linux and macOS.

On my local machine, it sometimes takes more than 2 minutes for the newrelic-infrastructure pod to become running on minikube, this PR increases the timeout to 5 minutes.