### PR TITLE
Move pre-checks for Kubernetes to the install step

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -41,43 +41,6 @@ preInstall:
       # Not a host that can manage kubernetes
       exit 10
     fi
-    if ! which curl 1>/dev/null 2>&1 ; then
-      echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
-      exit 11
-    fi
-    if ! which awk 1>/dev/null 2>&1 ; then
-      echo "awk is required to run the newrelic install. Please install awk and re-run the installation." >&2
-      exit 12
-    fi
-    if ! which grep 1>/dev/null 2>&1 ; then
-      echo "grep is required to run the newrelic install. Please install grep and re-run the installation." >&2
-      exit 13
-    fi
-    if ! which sed 1>/dev/null 2>&1 ; then
-      echo "sed is required to run the newrelic install. Please install sed and re-run the installation." >&2
-      exit 14
-    fi
-    if ! which cut 1>/dev/null 2>&1 ; then
-      echo "cut is required to run the newrelic install. Please install cut and re-run the installation." >&2
-      exit 15
-    fi
-
-    # Check the Kubernetes version
-    KUBECTL_VERSION=$($SUDO kubectl version --short)
-    CLIENT_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
-    CLIENT_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
-    SERVER_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
-    SERVER_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
-
-    if [[ "$CLIENT_MAJOR_VERSION" -lt 1 ]] || [[ "$CLIENT_MAJOR_VERSION" -eq 1 && "$CLIENT_MINOR_VERSION" -lt 10 ]]; then
-      echo "kubectl v1.10 or higher is required, found v${CLIENT_MAJOR_VERSION}.${CLIENT_MINOR_VERSION}" >&2
-      exit 21
-    fi
-
-    if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]]; then
-      echo "Kubernetes v1.16 or higher is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
-      exit 22
-    fi
 
 install:
   version: "3"
@@ -112,6 +75,45 @@ install:
           PIXIE_SUPPORTED=true
 
           SUDO=$(test ! -z "$SUDO_USER" && echo "sudo -u $SUDO_USER" || echo "")
+
+          # Check the required tools
+          if ! which curl 1>/dev/null 2>&1 ; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 11
+          fi
+          if ! which awk 1>/dev/null 2>&1 ; then
+            echo "awk is required to run the newrelic install. Please install awk and re-run the installation." >&2
+            exit 12
+          fi
+          if ! which grep 1>/dev/null 2>&1 ; then
+            echo "grep is required to run the newrelic install. Please install grep and re-run the installation." >&2
+            exit 13
+          fi
+          if ! which sed 1>/dev/null 2>&1 ; then
+            echo "sed is required to run the newrelic install. Please install sed and re-run the installation." >&2
+            exit 14
+          fi
+          if ! which cut 1>/dev/null 2>&1 ; then
+            echo "cut is required to run the newrelic install. Please install cut and re-run the installation." >&2
+            exit 15
+          fi
+
+          # Check the Kubernetes version
+          KUBECTL_VERSION=$($SUDO kubectl version --short)
+          CLIENT_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
+          CLIENT_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
+          SERVER_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
+          SERVER_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
+
+          if [[ "$CLIENT_MAJOR_VERSION" -lt 1 ]] || [[ "$CLIENT_MAJOR_VERSION" -eq 1 && "$CLIENT_MINOR_VERSION" -lt 10 ]]; then
+            echo "kubectl v1.10 or higher is required, found v${CLIENT_MAJOR_VERSION}.${CLIENT_MINOR_VERSION}" >&2
+            exit 21
+          fi
+
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]]; then
+            echo "Kubernetes v1.16 or higher is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+            exit 22
+          fi
 
           # Determine the cluster name if not provided
           CLUSTER=$($SUDO kubectl config current-context 2>/dev/null || echo "unknown")


### PR DESCRIPTION
We still detect Kubernetes based on the presence of kubectl. Other pre-checks are moved to the install step in order to provide the customer with feedback on why the installation is not successful.