### PR TITLE
Improve Kubernetes recipe

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -35,9 +35,9 @@ preInstall:
 
   requireAtDiscovery: |
     SUDO=$(test ! -z "$SUDO_USER" && echo "sudo -u $SUDO_USER" || echo "")
+    KUBECTL=$($SUDO which kubectl 2>/dev/null || echo '/usr/local/bin/kubectl')
 
-    # Check the required tools
-    if ! $SUDO which kubectl 1>/dev/null 2>&1; then
+    if [[ ! -x $KUBECTL ]]; then
       # Not a host that can manage kubernetes
       exit 10
     fi
@@ -73,8 +73,10 @@ install:
           NR_CLI_PIXIE_ADDRESS="{{.NR_CLI_PIXIE_ADDRESS}}"
 
           PIXIE_SUPPORTED=true
+          OLM_INSTALLED=false
 
           SUDO=$(test ! -z "$SUDO_USER" && echo "sudo -u $SUDO_USER" || echo "")
+          KUBECTL=$($SUDO which kubectl 2>/dev/null || echo '/usr/local/bin/kubectl')
 
           # Check the required tools
           if ! which curl 1>/dev/null 2>&1 ; then
@@ -99,7 +101,7 @@ install:
           fi
 
           # Check the Kubernetes version
-          KUBECTL_VERSION=$($SUDO kubectl version --short)
+          KUBECTL_VERSION=$($SUDO $KUBECTL version --short)
           CLIENT_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
           CLIENT_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
           SERVER_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
@@ -116,7 +118,7 @@ install:
           fi
 
           # Determine the cluster name if not provided
-          CLUSTER=$($SUDO kubectl config current-context 2>/dev/null || echo "unknown")
+          CLUSTER=$($SUDO $KUBECTL config current-context 2>/dev/null || echo "unknown")
 
           if [[ "$NR_CLI_CLUSTERNAME" == "" && "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
             while :; do
@@ -154,7 +156,7 @@ install:
 
           # Check the Linux kernel version if Pixie is enabled
           if [[ "$NR_CLI_PIXIE" == "true" ]]; then
-            KERNEL_VERSION=$($SUDO kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}')
+            KERNEL_VERSION=$($SUDO $KUBECTL get nodes -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}')
             KERNEL_MAJOR_VERSION=$(echo "${KERNEL_VERSION}" | awk -F. '{ print $1; }')
             KERNEL_MINOR_VERSION=$(echo "${KERNEL_VERSION}" | awk -F. '{ print $2; }')
             if [[ "$KERNEL_MAJOR_VERSION" -lt 4 ]] || [[ "$KERNEL_MAJOR_VERSION" -eq 4 && "$KERNEL_MINOR_VERSION" -lt 14 ]]; then
@@ -166,7 +168,7 @@ install:
 
           # Check if the nodes have sufficient memory
           if [[ "$NR_CLI_PIXIE" == "true" && "$PIXIE_SUPPORTED" == "true" ]]; then
-            MEMORY=$($SUDO kubectl get nodes -o jsonpath='{.items[0].status.capacity.memory}' | sed 's/Ki$//')
+            MEMORY=$($SUDO $KUBECTL get nodes -o jsonpath='{.items[0].status.capacity.memory}' | sed 's/Ki$//')
             if [[ "$MEMORY" -lt 7950912 ]]; then
               echo "Pixie requires nodes with 8 Gb of memory or more, got ${MEMORY}." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
@@ -175,11 +177,11 @@ install:
           fi
 
           # Check if the user has permissions to create a new namespace
-          CAN_CREATE_NAMESPACE=$($SUDO kubectl auth can-i create namespace 2>/dev/null)
+          CAN_CREATE_NAMESPACE=$($SUDO $KUBECTL auth can-i create namespace 2>/dev/null)
 
-          NAMESPACE_EXISTS=true
-          if $SUDO kubectl get namespace ${NR_CLI_NAMESPACE} 1>/dev/null 2>&1; then
-            NAMESPACE_EXISTS=false
+          NAMESPACE_EXISTS=false
+          if $SUDO $KUBECTL get namespace ${NR_CLI_NAMESPACE} 1>/dev/null 2>&1; then
+            NAMESPACE_EXISTS=true
           fi
 
           if [[ "$NAMESPACE_EXISTS" != "true" && "$CAN_CREATE_NAMESPACE" != "yes" ]]; then
@@ -203,7 +205,7 @@ install:
             fi
 
             if $SUDO which kind 1>/dev/null 2>&1; then
-              if $SUDO kind get clusters | grep '^$(echo "'"${CLUSTER}"'" | sed -e "s/^kind-//g")$'; then
+              if $SUDO kind get clusters 2>/dev/null | grep '^$(echo "'"${CLUSTER}"'" | sed -e "s/^kind-//g")$' >/dev/null; then
                 echo "Kind is not supported. To create a test cluster to try out Pixie, use minikube instead." >&2
               fi
             fi
@@ -211,7 +213,7 @@ install:
             MINIKUBE=$($SUDO which minikube 2>/dev/null || echo '/usr/local/bin/minikube')
             if [[ -x $MINIKUBE ]]; then
               if $SUDO $MINIKUBE profile list | grep " ${CLUSTER} " 1>/dev/null 2>&1; then
-                DRIVER=$($SUDO $MINIKUBE profile list | grep " ${CLUSTER} " | awk -F"|" '{ gsub(" ", "", $3); print $3; }')
+                DRIVER=$($SUDO $MINIKUBE profile list 2>/dev/null | grep " ${CLUSTER} " | awk -F"|" '{ gsub(" ", "", $3); print $3; }')
                 if [[ "$DRIVER" == "kvm2" || "$DRIVER" == "hyperkit" ]] ; then
                   PIXIE_SUPPORTED=true
                 else
@@ -221,17 +223,17 @@ install:
             fi
 
             if $SUDO which az 1>/dev/null 2>&1; then
-              if $SUDO az aks list | grep '"name": "'"${CLUSTER}"'"'; then
+              if $SUDO az aks list 2>/dev/null | grep '"name": "'"${CLUSTER}"'"' >/dev/null; then
                 PIXIE_SUPPORTED=true
               fi
             fi
 
-            K8S_VERSION=$($SUDO kubectl version --short | grep "Server Version")
-            if echo ${K8S_VERSION} | grep "\-gke\."; then
+            K8S_VERSION=$($SUDO $KUBECTL version --short | grep "Server Version")
+            if echo ${K8S_VERSION} | grep "\-gke\." >/dev/null; then
               PIXIE_SUPPORTED=true
             fi
 
-            if echo ${K8S_VERSION} | grep "\-eks\-"; then
+            if echo ${K8S_VERSION} | grep "\-eks\-" >/dev/null; then
               PIXIE_SUPPORTED=true
             fi
 
@@ -239,11 +241,15 @@ install:
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS & Minikube are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
             fi
+
+            if $SUDO $KUBECTL get crd operators.operators.coreos.com 1>/dev/null 2>&1; then
+              OLM_INSTALLED=true
+            fi
           fi
 
           # Create the namespace
-          if ! $SUDO kubectl get namespace ${NR_CLI_NAMESPACE} >/dev/null 2>&1; then
-            $SUDO kubectl create namespace ${NR_CLI_NAMESPACE}
+          if ! $SUDO $KUBECTL get namespace ${NR_CLI_NAMESPACE} >/dev/null 2>&1; then
+            $SUDO $KUBECTL create namespace ${NR_CLI_NAMESPACE}
           fi
 
           # Check if a privileged container can be deployed in the namespace
@@ -265,21 +271,23 @@ install:
               args: ["-c", "sleep 60"]
           EOF
 
-          if ! $SUDO kubectl apply -n ${NR_CLI_NAMESPACE} -f nr-check-privileged.yaml >/dev/null; then
+          if ! $SUDO $KUBECTL apply -n ${NR_CLI_NAMESPACE} -f nr-check-privileged.yaml >/dev/null; then
             echo "Failed to deploy a privileged container to the Kubernetes cluster." >&2
             echo -e "\033[0;31mReverting to unprivileged mode for this installation. Turning off Logging and Pixie.\033[0m" >&2
             NR_CLI_PRIVILEGED=false
             PIXIE_SUPPORTED=false
             NR_CLI_LOGGING=false
           fi
-          $SUDO kubectl delete --wait=false -n ${NR_CLI_NAMESPACE} -f nr-check-privileged.yaml 1>/dev/null 2>&1 || echo ""
+          $SUDO $KUBECTL delete --wait=false -n ${NR_CLI_NAMESPACE} -f nr-check-privileged.yaml 1>/dev/null 2>&1 || echo ""
           rm nr-check-privileged.yaml
           fi
 
           # Setup the Pixie CRDs
           if [[ "$NR_CLI_PIXIE" == "true" && "$PIXIE_SUPPORTED" == "true" ]]; then
-            $SUDO kubectl apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml
-            $SUDO kubectl apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/helm/crds/olm_crd.yaml
+            $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml
+            if [[ "$OLM_INSTALLED" == "false" ]]; then
+              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/helm/crds/olm_crd.yaml
+            fi
           fi
 
           # Deploy the integration
@@ -311,6 +319,9 @@ install:
                 ARGS="${ARGS} --set pixie-chart.enabled=true"
                 ARGS="${ARGS} --set pixie-chart.deployKey=${NR_CLI_PIXIE_DEPLOY_KEY}"
                 ARGS="${ARGS} --set pixie-chart.clusterName=${NR_CLI_CLUSTERNAME}"
+                if [[ "${OLM_INSTALLED}" == "true" ]]; then
+                  ARGS="${ARGS} --set pixie-chart.deployOLM=false"
+                fi
                 if [[ ! -z "${NR_CLI_PIXIE_ADDRESS}" ]]; then
                   ARGS="${ARGS} --set pixie-chart.cloudAddr=${NR_CLI_PIXIE_ADDRESS}"
                   ARGS="${ARGS} --set pixie-chart.cloudUpdateAddr=${NR_CLI_PIXIE_ADDRESS}"
@@ -344,6 +355,9 @@ install:
                 URL="${URL}&pixie-chart.enabled=true"
                 URL="${URL}&pixie-chart.deployKey=${NR_CLI_PIXIE_DEPLOY_KEY}"
                 URL="${URL}&pixie-chart.clusterName=$NR_CLI_CLUSTERNAME"
+                if [[ "${OLM_INSTALLED}" == "true" ]]; then
+                  URL="${URL}&pixie-chart.deployOLM=false"
+                fi
                 if [[ ! -z "${NR_CLI_PIXIE_ADDRESS}" ]]; then
                   URL="${URL}&pixie-chart.cloudAddr=${NR_CLI_PIXIE_ADDRESS}"
                   URL="${URL}&pixie-chart.cloudUpdateAddr=${NR_CLI_PIXIE_ADDRESS}"
@@ -351,7 +365,7 @@ install:
               fi
             fi
             curl -s "${URL}" > newrelic-k8s.yml
-            $SUDO kubectl apply -f newrelic-k8s.yml
+            $SUDO $KUBECTL apply -f newrelic-k8s.yml
           fi
 
           # Wait on newrelic-infrastructure pod to be running
@@ -360,7 +374,7 @@ install:
           TRIES=0
           while [ $TRIES -lt $MAX_RETRIES ]; do
             ((TRIES++))
-            IS_INFRA_POD_STARTED=$($SUDO kubectl get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | wc -l | sed 's/ //g')
+            IS_INFRA_POD_STARTED=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep newrelic-infrastructure | grep -i "running" | wc -l | sed 's/ //g')
             if [[ $IS_INFRA_POD_STARTED -gt 0 ]]; then
               echo "newrelic-infrastructure pod started"
               break


### PR DESCRIPTION
Improve Kubernetes recipe:
 * check standard path for kubectl
 * detect OLM and adjust Pixie install to avoid conflicting OLM deployment
 * suppress unwanted output when detecting the cluster type
 * fix wrong logic in detecting whether namespace already exists

Tested on cluster with and without OLM installed.