### PR TITLE
Don't install Prometheus and Logging by default.

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -149,8 +149,8 @@ install:
           NR_CLI_NAMESPACE=${NR_CLI_NAMESPACE:-newrelic}
           NR_CLI_KSM=${NR_CLI_KSM:-true}
           NR_CLI_KUBE_EVENTS=${NR_CLI_KUBE_EVENTS:-true}
-          NR_CLI_LOGGING=${NR_CLI_LOGGING:-true}
-          NR_CLI_PROMETHEUS=${NR_CLI_PROMETHEUS:-true}
+          NR_CLI_LOGGING=${NR_CLI_LOGGING:-false}
+          NR_CLI_PROMETHEUS=${NR_CLI_PROMETHEUS:-false}
           NR_CLI_LOW_DATA_MODE=${NR_CLI_LOW_DATA_MODE:-true}
           NR_CLI_PRIVILEGED=${NR_CLI_PRIVILEGED:-true}
 


### PR DESCRIPTION
This behaviour matches the Helm chart and is what is expected by the Guided Install UI as well: when the customer disables Prometheus and Logs, we don't set the `NR_CLI_PROMETHEUS` and `NR_CLI_LOGGING` environment variables.