### PR TITLE
infrastructure/kubernetes: pin latest version compatible with helm v2

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -339,6 +339,13 @@ install:
               fi
             fi
 
+            if helm version --short --client | grep 'v2' > /dev/null; then
+              echo "Helm version 2.x detected. Support for Helm v2 will be removed in the near future,"
+              echo "please upgrade at your earliest convenience."
+              echo "Will install Kubernetes Integration v2.8.3, last version compatible with Helm v2."
+              ARGS="${ARGS} --version 3.2.11"
+            fi
+
             $SUDO helm upgrade $ARGS
           else
             echo ""


### PR DESCRIPTION
`nri-bundle` versions older than `3.2.11` are not compatible with Helm v2, as they use a v3-introduced function `get`: https://github.com/newrelic/helm-charts/issues/671

This PR pins version `3.2.11` if Helm v2 is detected during installation.