### PR TITLE
IMDS Security Update

### DIFF
--- a/recipes/newrelic/infrastructure/cloud/aws-linux.yml
+++ b/recipes/newrelic/infrastructure/cloud/aws-linux.yml
@@ -19,7 +19,7 @@ processMatch: []
 
 preInstall:
   requireAtDiscovery: |
-      code=$(curl -I http://169.254.169.254/latest/meta-data/instance-id -w %{response_code} -so '/dev/null')
+      code=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 100" -I "http://169.254.169.254/latest/api/token" -w %{response_code} -so '/dev/null')
 
       if [ $code != "200" ]; then
         exit 1

--- a/recipes/newrelic/infrastructure/cloud/aws-windows.yml
+++ b/recipes/newrelic/infrastructure/cloud/aws-windows.yml
@@ -23,7 +23,7 @@ preInstall:
       powershell -command '
         $code = ""
         try {
-          $code=Invoke-WebRequest -UseBasicParsing -Method Get -TimeoutSec 1 -Uri http://169.254.169.254/latest/meta-data/instance-id | Select-Object -ExpandProperty StatusCode;
+          $code=Invoke-WebRequest -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "100"} -UseBasicParsing -Method PUT -TimeoutSec 1 -Uri http://169.254.169.254/latest/api/token | Select-Object -ExpandProperty StatusCode;
         } catch {}
 
         if ($code -ieq "200") {

--- a/recipes/newrelic/infrastructure/cloud/azure-linux.yml
+++ b/recipes/newrelic/infrastructure/cloud/azure-linux.yml
@@ -18,7 +18,7 @@ processMatch: []
 
 preInstall:
   requireAtDiscovery: |
-      code=$(curl -I http://169.254.169.254/metadata/instance/compute/vmId -w %{response_code} -so '/dev/null')
+      code=$(curl -H Metadata:true --noproxy "*" -I http://169.254.169.254/metadata/instance/compute/vmId -w %{response_code} -so '/dev/null')
       if [ $code == "200" ]; then
         exit 132
       fi

--- a/recipes/newrelic/infrastructure/cloud/azure-windows.yml
+++ b/recipes/newrelic/infrastructure/cloud/azure-windows.yml
@@ -22,7 +22,7 @@ preInstall:
       powershell -command '
         $code = ""
         try {
-          $code=Invoke-WebRequest -UseBasicParsing -Method Get -TimeoutSec 1 -Uri http://169.254.169.254/metadata/instance/compute/vmId | Select-Object -ExpandProperty StatusCode;
+          $code=Invoke-WebRequest -Headers @{"Metadata"="true"} -UseBasicParsing -Method Get -NoProxy -TimeoutSec 1 -Uri http://169.254.169.254/metadata/instance/compute/vmId | Select-Object -ExpandProperty StatusCode;
         } catch {}
 
         if ($code -ieq "200") {


### PR DESCRIPTION
* Azure: add [required header](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#security-and-authentication)`Metadata: true`
* AWS: upgraded check for compatibility with both IDMSv1 and IDMSv2
   * `http://169.254.169.254/latest/meta-data/instance-id` returns a `401` error on "IDMSv2 only" EC2 instances
   * token request returns a `200` on either IMDS mode