### PR TITLE
Quote special chars

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -230,7 +230,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -209,7 +209,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -212,7 +212,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false
@@ -233,7 +233,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false


### PR DESCRIPTION
Passwords as written to the config file, don't have quotes around them. This causes problems parsing YML if the password has special characters in it.

This change simply adds quotes around the two cases in each Linux recipe which involve passwords in the YML.

TODO: figure out how to do this for the PowerShell recipe.

Super Twos Day Bug Bash!