### PR TITLE
Quote special chars

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -209,7 +209,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false
@@ -230,7 +230,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -212,7 +212,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false
@@ -233,7 +233,7 @@ install:
                 HOSTNAME: $NR_CLI_DB_HOSTNAME
                 PORT: $NR_CLI_DB_PORT
                 USERNAME: $NR_CLI_DB_USERNAME
-                PASSWORD: $NR_CLI_DB_PASSWORD
+                PASSWORD: '$NR_CLI_DB_PASSWORD'
                 DATABASE: $NR_CLI_DATABASE
                 COLLECTION_LIST: 'ALL'
                 COLLECT_DB_LOCK_METRICS: false


### PR DESCRIPTION
If users have special characters in their database passwords, these may not be parsed properly in YML if the value is not surrounded by quotes.

This change adds single quotes around the YML value for the password which is written to the PostgreSQL integration file. Tested using `tee` syntax as in the recipe, with environment variables, and everything is picked up correctly from the environment when using either single or double quotes.