### PR TITLE
Enables in-agent log forwarding by default

### DIFF
--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -281,7 +281,6 @@ install:
           Environment="CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so"
           Environment="NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}"
           Environment="NEW_RELIC_APP_NAME=${sn}"
-          Environment="NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true"
           Environment="NEW_RELIC_APPLICATION_LOGGING_ENABLED=true"
           Environment="NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true"
           EOF

--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -282,6 +282,8 @@ install:
           Environment="NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}"
           Environment="NEW_RELIC_APP_NAME=${sn}"
           Environment="NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true"
+          Environment="NEW_RELIC_APPLICATION_LOGGING_ENABLED=true"
+          Environment="NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true"
           EOF
 
             nr_region="{{.NEW_RELIC_REGION}}"

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -287,6 +287,26 @@ install:
             }
           }
 
+          if ($xdoc.GetElementsByTagName("applicationLogging")[0]) {
+            $xdoc.configuration.applicationLogging.SetAttribute("enabled", "true")
+            if ($xdoc.GetElementsByTagName("forwarding")[0]) {
+              $xdoc.configuration.applicationLogging.forwarding.SetAttribute("enabled", "true")
+            }
+            else {
+              $child = $xdoc.CreateElement("forwarding", "urn:newrelic-config")
+              $child.SetAttribute("enabled", "true")
+              $xdoc.configuration.applicationLogging.AppendChild($child) | Out-Null
+            }
+          }
+          else {
+            $child = $xdoc.CreateElement("applicationLogging", "urn:newrelic-config")
+            $child.SetAttribute("enabled", "true")
+            $xdoc.configuration.AppendChild($child) | Out-Null
+            $child = $xdoc.CreateElement("forwarding", "urn:newrelic-config")
+            $child.SetAttribute("enabled", "true")
+            $xdoc.configuration.applicationLogging.AppendChild($child) | Out-Null
+          }
+
           $xdoc.Save($configPath)
           '
         - echo "New Relic .NET Agent configured"

--- a/recipes/newrelic/apm/dotNet/windows-iis.yml
+++ b/recipes/newrelic/apm/dotNet/windows-iis.yml
@@ -246,16 +246,6 @@ install:
           if ("{{.NEW_RELIC_REGION}}" -like "STAGING") {
             $xdoc.configuration.service.SetAttribute("host", "staging-collector.newrelic.com")
           }
-          if ($xdoc.GetElementsByTagName("distributedTracing")[0]) {
-            $xdoc.configuration.distributedTracing.SetAttribute("enabled", "true")
-            $xdoc.configuration.distributedTracing.SetAttribute("excludeNewrelicHeader", "false")
-          }
-          else {
-            $child = $xdoc.CreateElement("distributedTracing", "urn:newrelic-config")
-            $child.SetAttribute("enabled", "true")
-            $child.SetAttribute("excludeNewrelicHeader", "false")
-            $xdoc.configuration.AppendChild($child) | Out-Null
-          }
           if ("$env:HTTPS_PROXY") {
             $uri = ""
             try {


### PR DESCRIPTION
Updates .NET Windows and Linux recipes to enabled in-agent log forwarding by default.

Windows:
Uses the newrelic.config to enable log forwarding since this is the primary way Windows users interact with agent config.
Updated configuration task and followed same pattern as other newrelic.config updates.

Linux:
Uses the environment variables to enable log forwarding since this is the primary way Linux users interact with the config.
Updated configuration task and followed same pattern as other config env vars.

Notes on release:
The .NET teams current target for the release that will support these changes is 03/29, but can wait for this to be pushed out on 03/31.

Resolves newrelic/newrelic-dotnet-agent#1020