### PR TITLE
fix(k8s): correct cluster detection

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -42,7 +42,7 @@ preInstall:
       exit 10
     fi
 
-    K8S_CONFIG_CONTEXTS=$($SUDO $KUBECTL config get-contexts 2>/dev/null --no-headers | wc -l | xargs)
+    K8S_CONFIG_CONTEXTS=$($SUDO $KUBECTL config get-contexts 2>/dev/null | wc -l | xargs)
     if [[ $K8S_CONFIG_CONTEXTS -lt 2 ]]; then
       # No kubectl contexts
       exit 45


### PR DESCRIPTION
The addition of the `--no-headers` option to the `kubectl config get-contexts` command broke the `if` logic for the first case of the exit code `45` as the command headers were originally taken into account.

The `--no-headers` option was removed; could not see a reason for which it would be better to keep this option and instead update the `if` logic counts.