### PR TITLE
feat(logging): use winevtlog as default input for windows logs

### DIFF
--- a/recipes/newrelic/infrastructure/logs/windows-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/windows-logs.yml
@@ -44,7 +44,7 @@ install:
         LOGS_CONTENT: |
           logs:
             - name: windows-security
-              winlog:
+              winevtlog:
                 channel: Security
                 collect-eventids:
                 - 4740
@@ -57,7 +57,7 @@ install:
                 - 4648
 
             - name: windows-application
-              winlog:
+              winevtlog:
                 channel: Application
 
             - name: newrelic-cli.log


### PR DESCRIPTION
Hi!

This change is related to https://github.com/newrelic/infrastructure-agent/pull/1125

Fluent-bit has a new input plugin for windows logs that come to "replace" winlog, by now we're updating the infrastructure-agent to accept this new plugin type and the next step will be to set it as the default plugin when installing logging for windows.

We thought on make this change transparent to the users by replacing `winlog > winevtlog` directly when generating the fluent-bit configuration, but the output generated by those plugins have different attribute names and so on, so we discard that option.

Regards!

https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog
https://fluentbit.io/announcements/v1.9.0/