### PR TITLE
fix(k8s): Long detection time

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -48,8 +48,7 @@ preInstall:
       exit 45
     fi
 
-    ACTIVE_CLUSTER_PATTERN='kind.*NodeList'
-    VERIFY_ACTIVE_CLUSTER=$($SUDO $KUBECTL cluster-info dump pod-running-timeout 2 all-namespaces true 2>/dev/null | grep ${ACTIVE_CLUSTER_PATTERN} | wc -l | xargs)
+    VERIFY_ACTIVE_CLUSTER=$($SUDO $KUBECTL cluster-info 2>/dev/null | grep 'is running' | wc -l | xargs)
     if [[ $VERIFY_ACTIVE_CLUSTER -eq 0 ]]; then
       # No running clusters detected on host
       exit 45


### PR DESCRIPTION
Some `k8s recipes` installs are taking too long to complete. Dumping all the cluster information seems to be the problem for non-basic clusters setups. Thus we are removing the `dump` sub-command of `kubectl cluster-info` to reduce detection time. 