### PR TITLE
Remove K8s v3 beta check

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -414,11 +414,8 @@ install:
             $SUDO $KUBECTL apply -f newrelic-k8s.yml
           fi
 
-          # Wait on newrelic-infrastructure pod to be running
-          POD_NAME="newrelic-infrastructure"
-          if [[ "${NR_CLI_BETA}" == "true" ]]; then
-            POD_NAME="nrk8s-kubelet"
-          fi
+          # Wait on nrk8s-kubelet pod to be running
+          POD_NAME="nrk8s-kubelet"
 
           echo "Running ${POD_NAME} status check attempt..."
           MAX_RETRIES=150


### PR DESCRIPTION
The Kubernetes v3 integration moved from Beta to GA and the Infrastructure pod names have changed.  Currently, the K8s recipe is looking for a pod named `newrelic-infrastructure` which no longer exists.  I've removed the logic that was in place for the Beta and now the K8s recipe looks for a running `nrk8s-kubelet` pod instead.

https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3/