### PR TITLE
Remove kubectl apply for the CRDs

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -317,14 +317,6 @@ install:
           rm nr-check-privileged.yaml
           fi
 
-          # Setup the Pixie CRDs
-          if [[ "$NR_CLI_PIXIE" == "true" && "$PIXIE_SUPPORTED" == "true" ]]; then
-            $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml
-            if [[ "$OLM_INSTALLED" == "false" ]]; then
-              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-labs/pixie/main/k8s/operator/helm/crds/olm_crd.yaml
-            fi
-          fi
-
           # Deploy the integration
           if $SUDO which helm 1>/dev/null 2>&1; then
             echo ""


### PR DESCRIPTION
Remove the explicit `kubectl apply` commands to create the CRDs, these are now part of the Helm chart.