### PR TITLE
feat(envars): NRIA_CUSTOM_ATTRIBUTES from cli to newrelic-infra.yml for linux/windows

### DIFF
--- a/recipes/newrelic/infrastructure/amazonlinux.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux.yml
@@ -122,7 +122,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
           fi
@@ -134,6 +135,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/amazonlinux2.yml
+++ b/recipes/newrelic/infrastructure/amazonlinux2.yml
@@ -125,7 +125,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
           fi
@@ -137,6 +138,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -134,6 +134,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml            
 
           else
             sudo touch /etc/newrelic-infra.yml
@@ -146,6 +148,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -153,7 +153,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml            
           else
             sudo touch /etc/newrelic-infra.yml
           fi
@@ -165,6 +166,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -134,7 +134,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                      
           else
             sudo touch /etc/newrelic-infra.yml
           fi
@@ -146,6 +147,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml          
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -140,7 +140,8 @@ install:
             sudo sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sudo sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sudo sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sudo sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sudo sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             sudo touch /etc/newrelic-infra.yml
           fi
@@ -153,6 +154,7 @@ install:
           sudo echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           sudo echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           sudo echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          sudo echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -192,6 +192,9 @@ install:
             (Get-Content $InfraConfig) | Foreach-Object {
               $_ -replace "^license_key: .*", ("license_key: " + $LICENSE_KEY) `
             } | Set-Content $InfraConfig
+
+            (Get-Content -raw $InfraConfig) -replace "(?m)^custom_attributes:(?s:.*?)(^\s.+:.+\n)+", "" | Set-Content $InfraConfig
+
           } else {
             msiexec.exe /qn /i "$env:TEMP\newrelic-infra.msi" GENERATE_CONFIG=true LICENSE_KEY="$LICENSE_KEY" | Out-Null
           }
@@ -210,6 +213,7 @@ install:
 
             Add-Content -Path $InfraConfig -Value "proxy: $env:HTTPS_PROXY" -Force
           }
+          Add-Content -Path $InfraConfig -Value "{{.NRIA_CUSTOM_ATTRIBUTES}}" -Force
           '
 
     start_infra:


### PR DESCRIPTION
Pulling envars transformed to yaml in the cli and adding to `/etc/newrelic-infra.yml` for all linux distributions.  

- `custom_attributes` yaml key/values are replaced on every installation with valid JSON passed in `NRIA_CUSTOM_ATTRIBUTES`.  

- If `NRIA_CUSTOM_ATTRIBUTES` is invalid JSON or omitted from the installation command, any `custom_attributes` present will be removed