### PR TITLE
jq type conversion check

### DIFF
--- a/recipes/newrelic/infrastructure/alerts/golden.yml
+++ b/recipes/newrelic/infrastructure/alerts/golden.yml
@@ -79,7 +79,7 @@ install:
             if [ -f /tmp/policy.json ]; then
               sudo rm -f /tmp/policy.json
             fi
-            POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[0] | select(.name=="{{.ALERT_POLICY_NAME}}") | .id | tonumber')
+            POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[0] | select(.name=="{{.ALERT_POLICY_NAME}}") | select(.id != null) | .id | tonumber')
             if [ -n "$POLICY_ID" ] && [ $POLICY_ID -gt 0 ] ; then
               curl -sX DELETE $NEW_RELIC_API_URL'/v2/alerts_policies/'$POLICY_ID'.json' -H 'Api-Key:{{.NEW_RELIC_API_KEY}}' -i > /dev/null
               continue
@@ -100,7 +100,7 @@ install:
               -L -H 'Content-Type: application/json' \
               -d @/tmp/policy.json
           )
-          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id | tonumber')
+          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id | select(.id != null) | tonumber')
           if [ -f /tmp/policy.json ]; then
             rm -f /tmp/policy.json
           fi
@@ -129,7 +129,7 @@ install:
           fi
 
 
-          HIGH_CPU_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_CPU_CONDITION_NAME}}") | .id | tonumber')
+          HIGH_CPU_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_CPU_CONDITION_NAME}}") | select(.id != null) | .id | tonumber')
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -163,7 +163,7 @@ install:
           echo 'done'
 
 
-          HIGH_ERROR_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_ERROR_RATE_NAME}}") | .id | tonumber')
+          HIGH_ERROR_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_ERROR_RATE_NAME}}") | select(.id != null) | .id | tonumber')
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -197,7 +197,7 @@ install:
           echo 'done'
 
 
-          HIGH_RESPONSE_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_RESPONSE_TIME_NAME}}") | .id | tonumber')
+          HIGH_RESPONSE_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_RESPONSE_TIME_NAME}}") | select(.id != null) | .id | tonumber')
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -231,7 +231,7 @@ install:
           echo 'done'
 
 
-          LOW_THROUGHPUT_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_LOW_THROUGHPUT_NAME}}") | .id | tonumber')
+          LOW_THROUGHPUT_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_LOW_THROUGHPUT_NAME}}") | select(.id != null) | .id | tonumber')
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi

--- a/recipes/newrelic/infrastructure/alerts/golden.yml
+++ b/recipes/newrelic/infrastructure/alerts/golden.yml
@@ -100,7 +100,7 @@ install:
               -L -H 'Content-Type: application/json' \
               -d @/tmp/policy.json
           )
-          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id | select(.id != null) | tonumber')
+          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id | tonumber')
           if [ -f /tmp/policy.json ]; then
             rm -f /tmp/policy.json
           fi


### PR DESCRIPTION
The Golden Rules Alerts recipe has a [high error occurrence](https://staging.onenr.io/0xVwgYLv8jJ) containing this message: `tonumber cannot be applied to: null`.

That recipe relies on the `jq` utility that processes JSON data received from the appropriate NerdGraph Environment. There seems to be instances where `id` is `null` (most research is needed to find/confirm this case).

The issue is easily reproduced with this piece of code below, note `id` equals `null`:

```sh
JSON_DATA='{"data":{"actor":{"account":{"alerts":{"policiesSearch":{"policies":[{"id":null,"name":"Golden Signals"}],"totalCount":1}}}}}}'

echo $JSON_DATA | newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[0] | select(.name=="Golden Signals") | .id | tonumber'
FATAL tonumber cannot be applied to: null    # ERROR
```

Using `select(.id != null) ` filters out those null ids:

```sh
echo $POLICY_RESULT | newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[0] | select(.name=="Golden Signals") | select(.id != null) | .id | tonumber'
```

Reference: [NR-592](https://issues.newrelic.com/browse/NR-592)