### PR TITLE
fix: aws imds broken validation

### DIFF
--- a/recipes/newrelic/infrastructure/cloud/aws-linux.yml
+++ b/recipes/newrelic/infrastructure/cloud/aws-linux.yml
@@ -21,7 +21,7 @@ preInstall:
   requireAtDiscovery: |
       # IMDS v1 & v2
       code=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 100" --connect-timeout 2 --max-time 2 -I "http://169.254.169.254/latest/api/token" -w %{response_code} -so '/dev/null')
-      if [["$code" != "200"]]; then
+      if [[ "$code" != "200" ]]; then
         exit 1
       fi
 


### PR DESCRIPTION
When the host is not on AWS, a response code of `000` will be returned to the "code" variable. When the variable was used without a space between it and the bracket, bash interpreted `[[000` to be a single command. The script was unable to verify the response code in all cases.