### PR TITLE
feat: add ubuntu 22.04 infra keyword

### DIFF
--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -21,6 +21,7 @@ keywords:
   - Xenial
   - Bionic
   - Focal
+  - Jammy
 
 processMatch: []
 


### PR DESCRIPTION
New Relic infrastructure agent is now available in Ubuntu 22.04: https://download.newrelic.com/infrastructure_agent/linux/apt/dists/jammy