### PR TITLE
fix(alerts): addressing tonumber null error

### DIFF
--- a/recipes/newrelic/infrastructure/alerts/golden.yml
+++ b/recipes/newrelic/infrastructure/alerts/golden.yml
@@ -79,7 +79,8 @@ install:
             if [ -f /tmp/policy.json ]; then
               sudo rm -f /tmp/policy.json
             fi
-            POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[0] | select(.name=="{{.ALERT_POLICY_NAME}}") | select(.id != null) | .id | tonumber')
+            POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.policiesSearch.policies[] | select(.name=="{{.ALERT_POLICY_NAME}}") | .id')
+            POLICY_ID=$([[ $POLICY_ID =~ 'null' ]] && echo 0 || echo "${POLICY_ID//\"/""}")
             if [ -n "$POLICY_ID" ] && [ $POLICY_ID -gt 0 ] ; then
               curl -sX DELETE $NEW_RELIC_API_URL'/v2/alerts_policies/'$POLICY_ID'.json' -H 'Api-Key:{{.NEW_RELIC_API_KEY}}' -i > /dev/null
               continue
@@ -100,7 +101,8 @@ install:
               -L -H 'Content-Type: application/json' \
               -d @/tmp/policy.json
           )
-          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id | tonumber')
+          POLICY_ID=$(echo $POLICY_RESULT | /usr/local/bin/newrelic utils jq '.data.alertsPolicyCreate.id')
+          POLICY_ID=$([[ $POLICY_ID =~ 'null' ]] && echo 0 || echo "${POLICY_ID//\"/""}")
           if [ -f /tmp/policy.json ]; then
             rm -f /tmp/policy.json
           fi
@@ -129,7 +131,8 @@ install:
           fi
 
 
-          HIGH_CPU_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_CPU_CONDITION_NAME}}") | select(.id != null) | .id | tonumber')
+          HIGH_CPU_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[] | select(.name=="{{.ALERT_HIGH_CPU_CONDITION_NAME}}") | .id')
+          HIGH_CPU_CONDITION_ID=$([[ $HIGH_CPU_CONDITION_ID =~ 'null' ]] && echo 0 || echo "${HIGH_CPU_CONDITION_ID//\"/""}")
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -163,7 +166,8 @@ install:
           echo 'done'
 
 
-          HIGH_ERROR_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_ERROR_RATE_NAME}}") | select(.id != null) | .id | tonumber')
+          HIGH_ERROR_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[] | select(.name=="{{.ALERT_HIGH_ERROR_RATE_NAME}}") | .id')
+          HIGH_ERROR_CONDITION_ID=$([[ $HIGH_ERROR_CONDITION_ID =~ 'null' ]] && echo 0 || echo "${HIGH_ERROR_CONDITION_ID//\"/""}")
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -197,7 +201,8 @@ install:
           echo 'done'
 
 
-          HIGH_RESPONSE_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_HIGH_RESPONSE_TIME_NAME}}") | select(.id != null) | .id | tonumber')
+          HIGH_RESPONSE_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[] | select(.name=="{{.ALERT_HIGH_RESPONSE_TIME_NAME}}") | .id')
+          HIGH_RESPONSE_CONDITION_ID=$([[ $HIGH_RESPONSE_CONDITION_ID =~ 'null' ]] && echo 0 || echo "${HIGH_RESPONSE_CONDITION_ID//\"/""}")
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi
@@ -231,7 +236,8 @@ install:
           echo 'done'
 
 
-          LOW_THROUGHPUT_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0] | select(.name=="{{.ALERT_LOW_THROUGHPUT_NAME}}") | select(.id != null) | .id | tonumber')
+          LOW_THROUGHPUT_CONDITION_ID=$(echo $CONDITIONS_LOOKUP_RESULT | /usr/local/bin/newrelic utils jq '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[] | select(.name=="{{.ALERT_LOW_THROUGHPUT_NAME}}") | .id')
+          LOW_THROUGHPUT_CONDITION_ID=$([[ $LOW_THROUGHPUT_CONDITION_ID =~ 'null' ]] && echo 0 || echo "${LOW_THROUGHPUT_CONDITION_ID//\"/""}")
           if [ -f /tmp/condition.json ]; then
             sudo rm -f /tmp/condition.json
           fi


### PR DESCRIPTION
Removing `jq`'s `tonumber` function calls and replacing them with a `null` check for policies/conditions IDs. If the returned `id` is `null` we force it to a zero value. Otherwise, the non-null returned `id` will be removed of any possible double-quotes it may contain and then used as usual with the current flow.

The reference to the first element ([0]) of the returned data array in `jq` data processing calls was also removed as there is no guarantee that the policy name or condition name will always reside in the first element of that array. All array elements are returned and subsequently filtered based on the `select(.name="DATA_ITEM_NAME")` which will correctly get to the right array element/data.

Tested in Ubuntu/AWS Linux 2.

Some references:
https://issues.newrelic.com/browse/NR-592
https://issues.newrelic.com/browse/NR-15777