### PR TITLE
fix(build): check empty github workflow matrix

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -168,11 +168,10 @@ jobs:
             console.log("Output: ", output);
             return output;
 
-  # need to put checks in place in case matrix isn't set
   test-deploy-recipe:
     name: Test Deploy Recipe
     needs: [get-test-definition-files]
-    if: needs.get-test-definition-files.outputs.matrix != ''
+    if: ${{ needs.get-test-definition-files.outputs.matrix != '' && needs.get-test-definition-files.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix) }}


### PR DESCRIPTION
In GitHub Actions (GHA), there are some failed occurrences of the `Validate Recipe (Unit Test)` workflow. The error reported is: **Error when evaluating 'strategy' for job 'test-deploy-recipe'. .github/workflows/validation.yml (Line: 178, Col: 15): Matrix must define at least one vector** (screenshot shown below), which is related to the `matrix strategy` returning empty values. We are adding another check in an attempt to avoid executing the next workflow job if the previous job outputs an empty (matrix) value.

Ref:

https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions;
https://github.com/dorny/paths-filter/issues/66

Screenshot of the validation error:
![image](https://user-images.githubusercontent.com/102765645/171505147-a85e5bc0-a65b-47b8-a331-388ce62e8329.png)
