### PR TITLE
add_logtype_attribute_to_windows_log_yml

### DIFF
--- a/recipes/newrelic/infrastructure/logs/windows-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/windows-logs.yml
@@ -55,15 +55,20 @@ install:
                 - 4624
                 - 4625
                 - 4648
+              attributes:
+                logtype: windows_security
 
             - name: windows-application
               winlog:
                 channel: Application
+              attributes:
+                logtype: windows_application
 
             - name: newrelic-cli.log
               file: {{.NEW_RELIC_CLI_LOG_FILE_PATH}}
               attributes:
                 newrelic-cli: true
+                logtype: newrelic-cli
 
 postInstall:
   info: |2


### PR DESCRIPTION
Add logtype attribute to windows log.yml file for default intstall
Add logtype windows_security, windows_application, and newrelic_cli
Logtype use is best practice and being added to all log.yml's