### PR TITLE
fix(build): empty matrix validation workflow error

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -171,7 +171,7 @@ jobs:
   test-deploy-recipe:
     name: Test Deploy Recipe
     needs: [get-test-definition-files]
-    if: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix).include.length != 0 }}
+    if: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix).include[0] }} # Avoids empty matrix validation error
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix) }}


### PR DESCRIPTION
Check if previous job matrix results is empty before processing the `Test Deploy Recipes` job.