### PR TITLE
fix(infra): support older amazon linux versions

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -129,8 +129,8 @@ install:
             exit 15
           fi
         - |
-          if [ {{.AMAZON_LINUX_VERSION}} = "2018.03" ] ; then
-          	# Switching to 'yum/el/6' Enterprise Linux repo for old Amazon Linux AMI
+          if [[ {{.AMAZON_LINUX_VERSION}} != "2" && {{.AMAZON_LINUX_VERSION}} != "2022" ]] ; then
+          	# Switching to 'yum/el/6' Enterprise Linux repo for older Amazon Linux versions
             IS_INFRA_AVAILABLE=$(curl -Is {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/6/{{.ARCH}}/newrelic-infra.repo | grep " 2[0-9][0-9] " | wc -l)
           else
             IS_INFRA_AVAILABLE=$(curl -Is {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/{{.AMAZON_LINUX_VERSION}}/{{.ARCH}}/newrelic-infra.repo | grep " 2[0-9][0-9] " | wc -l)
@@ -178,8 +178,8 @@ install:
     install_infra:
       cmds:
         - |
-          if [ {{.AMAZON_LINUX_VERSION}} = "2018.03" ]; then
-            # Switching to 'yum/el/6' Enterprise Linux repo for old Amazon Linux AMI
+          if [[ {{.AMAZON_LINUX_VERSION}} != "2" && {{.AMAZON_LINUX_VERSION}} != "2022" ]] ; then
+            # Switching to 'yum/el/6' Enterprise Linux repo for older Amazon Linux versions
             REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/6/{{.ARCH}}/newrelic-infra.repo")
           else
             REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/{{.AMAZON_LINUX_VERSION}}/{{.ARCH}}/newrelic-infra.repo")


### PR DESCRIPTION
Logic was changed in order to adjust the repo URL to support older Amazon Linux versions, as originally done by the Amazon recipes. It means, versions different from Amazon Linux 2 and Amazon Linux 2022, will default to the old [yum/el/6](https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/) repo.

I tested installing the `infrastructure-agent` in these amazon linux versions shown below and it installed correctly:

- 2016.03
- 2017.03
- 2018.03
- 2
- 2022
- 2022 (arm)