### PR TITLE
chore(k8s): support for new suffix pods naming

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -434,25 +434,49 @@ install:
             $SUDO $KUBECTL apply -f newrelic-k8s.yml
           fi
 
-          # Wait on nrk8s-kubelet pod to be running
-          POD_NAME="nrk8s-kubelet"
+          # Check for '-scraper' suffixed pod name present, otherwise default to former pod naming
+          POD_NAME=$(test $($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep 'nrk8s-kubelet-node-scraper' | wc -l | sed 's/ //g') -gt 0 && echo 'nrk8s-kubelet-node-scraper' || echo 'nrk8s-kubelet')
 
-          echo "Running ${POD_NAME} status check attempt..."
-          MAX_RETRIES=150
-          TRIES=0
-          while [ $TRIES -lt $MAX_RETRIES ]; do
-            ((TRIES++))
-            IS_INFRA_POD_STARTED=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | grep -i "running" | wc -l | sed 's/ //g')
-            if [[ $IS_INFRA_POD_STARTED -gt 0 ]]; then
-              echo "${POD_NAME} pod started"
-              break
-            fi
-            if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
-              echo "${POD_NAME} pod is not starting" >&2
-              exit 33
-            fi
-            sleep 2
-          done
+          # Wait 2 mins max for at least 2 '-scraper' suffixed pods to be in a running state
+          if [[ "$POD_NAME" == "nrk8s-kubelet-node-scraper" ]]; then
+            echo "Running ${POD_NAME} status check attempt..."
+            MAX_RETRIES=60
+            TRIES=0
+            while [ $TRIES -lt $MAX_RETRIES ]; do
+              ((TRIES++))
+              INFRA_PODS_STARTED=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | grep -i "running" | wc -l | sed 's/ //g')
+              if [[ $INFRA_PODS_STARTED -gt 1 ]]; then
+                echo "${POD_NAME} pods started"
+                break
+              fi
+              if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                echo "${POD_NAME} pods not starting" >&2
+                exit 33
+              fi
+              sleep 2
+            done
+          # Wait on former 'nrk8s-kubelet' pod naming to be running
+          elif [[ "$POD_NAME" == "nrk8s-kubelet" ]]; then
+            echo "Running ${POD_NAME} status check attempt..."
+            MAX_RETRIES=150
+            TRIES=0
+            while [ $TRIES -lt $MAX_RETRIES ]; do
+              ((TRIES++))
+              IS_INFRA_POD_STARTED=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | grep -i "running" | wc -l | sed 's/ //g')
+              if [[ $IS_INFRA_POD_STARTED -gt 0 ]]; then
+                echo "${POD_NAME} pod started"
+                break
+              fi
+              if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                echo "${POD_NAME} pod is not starting" >&2
+                exit 33
+              fi
+              sleep 2
+            done
+          else
+            echo "Unable to check status for ${POD_NAME}" >&2
+            exit 33
+          fi
 
           # Show post install message
           echo ""


### PR DESCRIPTION
Support the new [pod suffix change](https://github.com/newrelic/nri-kubernetes/pull/429) for the Kubernetes integration. The Kubernetes recipe in the Open Install Library will need now to check for a `nrk8s-kubelet-node-scraper` instead of the former `nrk8s-kubelet` name to validate pods running status and the final success of the k8s integration install.