### PR TITLE
Fix variable name for API URL

### DIFF
--- a/test/deploy/linux/newrelic-cli/validate-recipe/roles/onafterstart/tasks/main.yml
+++ b/test/deploy/linux/newrelic-cli/validate-recipe/roles/onafterstart/tasks/main.yml
@@ -82,7 +82,7 @@
         src: gql-query.source.gpl
         dest: "{{ playbook_dir }}/gql-query.json"
     - name: Run NRQL via nerdgraph
-      shell: "curl -sX POST '{{ newrelic_api_url }}/graphql' \
+      shell: "curl -sX POST '{{ newrelic_api_url_to_use }}/graphql' \
       -H 'API-Key: {{ newrelic_personal_api_key }}' \
       -L -H 'Content-Type: application/json' \
       -d @{{ playbook_dir }}/gql-query.json"


### PR DESCRIPTION
After the curl fix (🎉), "Validate All" is now failing at "Run NRQL via nerdgraph" due to `newrelic_api_url` being undefined. Looks like we need to use `newrelic_api_url_to_use` instead.

[Link to error message](https://github.com/newrelic/open-install-library/runs/7013368436?check_suite_focus=true#step:6:628)



