### PR TITLE
add k3s/k0s support for the Kubernetes recipe

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -273,6 +273,10 @@ install:
               PIXIE_SUPPORTED=true
             fi
 
+            if echo ${K8S_VERSION} | grep "\+k[0,3]s.*" > /dev/null; then
+              PIXIE_SUPPORTED=true
+            fi 
+
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS & Minikube are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2


### PR DESCRIPTION
Updated the install logic to include a check for `k3s` and `k0s` clusters.  Previously, this was failing for users even though Pixie supports both versions.