### PR TITLE
add k3s and k0s support for K8s guided install

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -278,6 +278,10 @@ install:
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
             fi
 
+            if echo ${K8S_VERSION} | grep "\+k[0,3]s.*" > /dev/null; then
+              PIXIE_SUPPORTED=true
+            fi
+
             if $SUDO $KUBECTL get namespace olm 1>/dev/null 2>&1; then
               OLM_INSTALLED=true
             fi


### PR DESCRIPTION
Pixie supports `k3s` and `k0s` per their documentation, however, the guided install fails when detecting either one of these K8s flavors.  This update enables the guided install to proceed with `k3s` or `k0s` are detected.