### PR TITLE
Add logic to revert to kubectl install when helm 2 is detected

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -352,7 +352,6 @@ install:
                   echo "Helm not found."
                   echo "Reverting to kubectl install."
                   echo ""
-                  KUBECTL_INSTALL=true
 
           elif ! $SUDO helm version -c --short | grep v3 1> /dev/null 2>&1
           then
@@ -361,7 +360,6 @@ install:
                   helm version -c --short
                   echo "Reverting to kubectl install."
                   echo ""
-                  KUBECTL_INSTALL=true
           fi
 
           # Deploy the integration
@@ -370,6 +368,8 @@ install:
             echo ""
             echo "Using helm to install the Kubernetes integration"
             echo ""
+
+            KUBECTL_INSTALL=false
 
             $SUDO helm repo add newrelic https://helm-charts.newrelic.com
             $SUDO helm repo update
@@ -416,6 +416,8 @@ install:
             echo ""
             echo "Using kubectl to install the Kubernetes integration"
             echo ""
+
+            KUBECTL_INSTALL=true
 
             # Select k8s-config-generator service environment
             if [[ "${NEW_RELIC_REGION}" == "STAGING" ]]; then
@@ -495,7 +497,8 @@ install:
             sleep 2
           done
 
-          # Set the color variable
+
+          # Set the color variables for post install message
           green='\033[0;32m'
           clear='\033[0m'
 
@@ -503,16 +506,15 @@ install:
           echo ""
           echo "--------------------------"
           echo ""
-          echo "The Kubernetes Integration deployment is complete. You can check the progress by running:"
-          echo ""
-          echo "     kubectl get pods -o wide -n ${NR_CLI_NAMESPACE}"
-          echo ""
 
           if $KUBECTL_INSTALL; then
-            printf "** Store the generated ${green}$HOME/newrelic-k8s.yml${clear} file in a safe location in order to upgrade or remove the integration. **"
-            echo ""
+            printf "** Store the generated ${green}$HOME/newrelic-k8s.yml${clear} file in a safe location in order to upgrade or remove the integration. **\n"
           fi
 
+          echo ""
+          echo "You can check the status of the New Relic pods by running:"
+          echo ""
+          printf "     ${green}kubectl get pods -o wide -n ${NR_CLI_NAMESPACE}${clear}\n"
           echo ""
           echo "--------------------------"
           echo ""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -273,13 +273,13 @@ install:
               PIXIE_SUPPORTED=true
             fi
 
+            if echo ${K8S_VERSION} | grep "\+k[0,3]s.*" > /dev/null; then
+              PIXIE_SUPPORTED=true
+            fi
+
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS & Minikube are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
-            fi
-
-            if echo ${K8S_VERSION} | grep "\+k[0,3]s.*" > /dev/null; then
-              PIXIE_SUPPORTED=true
             fi
 
             if $SUDO $KUBECTL get namespace olm 1>/dev/null 2>&1; then

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -278,11 +278,7 @@ install:
             fi
 
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
-<<<<<<< HEAD
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS, Minikube, k3s, and k0s are supported." >&2
-=======
-              echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS & Minikube are supported." >&2
->>>>>>> main
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
             fi
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -30,8 +30,8 @@ successLinkConfig:
 
 preInstall:
   info: |2
-    The Kubernetes Integration installation will use Helm if available.
-    If Helm is not available a manifest will be generated and applied using kubectl.
+    The Kubernetes Integration installation will use Helm 3 if available.
+    If Helm 3 is not available a manifest will be generated and applied using kubectl.
 
   requireAtDiscovery: |
     SUDO=$(test ! -z "$SUDO_USER" && echo "sudo -u $SUDO_USER" || echo "")
@@ -343,8 +343,30 @@ install:
             fi
           fi
 
+
+          # Check for the presence of Helm.
+          # If Helm 3 is not found, revert to kubectl based install.
+          if ! $SUDO which helm 1>/dev/null 2>&1
+          then
+                  echo ""
+                  echo "Helm not found."
+                  echo "Reverting to kubectl install."
+                  echo ""
+                  KUBECTL_INSTALL=true
+
+          elif ! $SUDO helm version -c --short | grep v3 1> /dev/null 2>&1
+          then
+                  echo ""
+                  echo "Helm 3 not found.  You are using an unsupported version of helm."
+                  helm version -c --short
+                  echo "Reverting to kubectl install."
+                  echo ""
+                  KUBECTL_INSTALL=true
+          fi
+
           # Deploy the integration
-          if $SUDO which helm 1>/dev/null 2>&1; then
+          if $SUDO which helm 1>/dev/null 2>&1 && $SUDO helm version -c --short | grep v3 1> /dev/null 2>&1
+          then
             echo ""
             echo "Using helm to install the Kubernetes integration"
             echo ""
@@ -395,12 +417,19 @@ install:
             echo "Using kubectl to install the Kubernetes integration"
             echo ""
 
-            URL="https://k8s-config-generator.service.newrelic.com"
+            # Select k8s-config-generator service environment
+            if [[ "${NEW_RELIC_REGION}" == "STAGING" ]]; then
+              URL="https://k8s-config-generator.staging-service.newrelic.com"
+            else
+              URL="https://k8s-config-generator.service.newrelic.com"
+            fi
+
             if [[ "${NR_CLI_BETA}" == "true" ]]; then
               URL="${URL}/generate-beta"
             else
               URL="${URL}/generate"
             fi
+
             BODY="{\"global.cluster\":\"${NR_CLI_CLUSTERNAME}\""
             BODY="${BODY},\"global.namespace\":\"${NR_CLI_NAMESPACE}\""
             BODY="${BODY},\"newrelic-infrastructure.privileged\":\"${NR_CLI_PRIVILEGED}\""
@@ -413,6 +442,7 @@ install:
             if [[ "${NEW_RELIC_REGION}" == "STAGING" ]]; then
               BODY="${BODY},\"global.nrStaging\":true"
             fi
+
             if [[ "${NR_CLI_NEWRELIC_PIXIE}" == "true" && "${PIXIE_SUPPORTED}" == "true" ]]; then
               BODY="${BODY},\"newrelic-pixie.enabled\":true"
               BODY="${BODY},\"newrelic-pixie.apiKey\":\"${NR_CLI_PIXIE_API_KEY}\""
@@ -433,9 +463,16 @@ install:
                 fi
               fi
             fi
+
             BODY="${BODY}}"
-            curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > newrelic-k8s.yml
-            $SUDO $KUBECTL apply -f newrelic-k8s.yml
+            curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > ~/newrelic-k8s.yml
+
+            if [[ "${NR_CLI_PIXIE}" == "true" ]]; then
+              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/helm/crds/olm_crd.yaml
+              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml
+            fi
+
+            $SUDO $KUBECTL apply -f ~/newrelic-k8s.yml
           fi
 
           # Wait on nrk8s-kubelet pod to be running
@@ -458,13 +495,24 @@ install:
             sleep 2
           done
 
+          # Set the color variable
+          green='\033[0;32m'
+          clear='\033[0m'
+
           # Show post install message
           echo ""
-          echo "The Kubernetes Integration deployment is complete. You can check the progress by running"
+          echo "--------------------------"
+          echo ""
+          echo "The Kubernetes Integration deployment is complete. You can check the progress by running:"
           echo ""
           echo "     kubectl get pods -o wide -n ${NR_CLI_NAMESPACE}"
           echo ""
 
-          if ! $SUDO which helm 1>/dev/null 2>&1; then
-            echo "Store the generated newrelic-k8s.yml file in a safe location in order to upgrade or remove the integration."
+          if $KUBECTL_INSTALL; then
+            printf "** Store the generated ${green}$HOME/newrelic-k8s.yml${clear} file in a safe location in order to upgrade or remove the integration. **"
+            echo ""
           fi
+
+          echo ""
+          echo "--------------------------"
+          echo ""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -278,7 +278,7 @@ install:
             fi
 
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
-              echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS & Minikube are supported." >&2
+              echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS, Minikube, k3s, and k0s are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
             fi
 


### PR DESCRIPTION
This update adds logic that will detect the user's Helm client version.  If Helm 3 is found, Helm will be used to perform the install.  If Helm 2 is found (or Helm is not present at all), then the install will revert to using `kubectl` as the install client.  

In addition to detecting the Helm version, if `kubectl` is used for install and Pixie is selected for install, the guided install will now apply the Pixie CRDs prior to applying the New Relic manifest.  Previously, this did not happen and was generating errors.