### PR TITLE
fix(custom-attributes): re-add custom attributes to amazonlinux infra

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -154,7 +154,8 @@ install:
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
-
+            sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                        
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -166,6 +167,7 @@ install:
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:


### PR DESCRIPTION
Mismatch in infra recipe functionality, seems `NRIA_CUSTOM_ATTRIBUTES` envar functionality was inadvertently removed