### PR TITLE
feat(envars): consider NRIA_PASSTHROUGH_ENVIRONMENT 

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -156,6 +156,8 @@ install:
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                        
+            sed -i '/^passthrough_environment:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -168,6 +170,7 @@ install:
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
           echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_PASSTHROUGH_ENVIRONMENT}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -136,7 +136,9 @@ install:
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                        
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml        
+            sed -i '/^passthrough_environment:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/d' /etc/newrelic-infra.yml          
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -149,6 +151,7 @@ install:
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
           echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_PASSTHROUGH_ENVIRONMENT}}' >> /etc/newrelic-infra.yml
 
     setup_proxy:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -155,8 +155,9 @@ install:
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml            
-
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -169,6 +170,7 @@ install:
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
           echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_PASSTHROUGH_ENVIRONMENT}}' >> /etc/newrelic-infra.yml
 
 
     setup_proxy:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -136,7 +136,9 @@ install:
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                      
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml           
+            sed -i '/^passthrough_environment:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/d' /etc/newrelic-infra.yml          
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -149,7 +151,8 @@ install:
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
-          echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml          
+          echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_PASSTHROUGH_ENVIRONMENT}}' >> /etc/newrelic-infra.yml
 
 
     setup_proxy:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -144,6 +144,8 @@ install:
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
+            sed -i '/^passthrough_environment:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -156,6 +158,7 @@ install:
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> /etc/newrelic-infra.yml
           echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> /etc/newrelic-infra.yml
+          echo '{{.NRIA_PASSTHROUGH_ENVIRONMENT}}' >> /etc/newrelic-infra.yml
 
 
     setup_proxy:


### PR DESCRIPTION
Added functionality to all linux infrastructure recipes that consider `NRIA_PASSTHROUGH_ENVIRONMENT` variable from CLI and writing to `/etc/newrelic-infra.yml`

https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#integrations-variables

Comma-separated values will be parsed/written as an array in yaml.  If no values present, nothing will be added to `passthrough_environment:` in `/etc/newrelic-infra.yml`.  This means the last value 'wins' - omitting `NRIA_PASSTHROUGH_ENVIRONMENT` will delete any previously-set variables