### PR TITLE
feat(windows-envars): write NRIA_PASSTHROUGH_ENVIRONMENT

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -194,6 +194,8 @@ install:
             } | Set-Content $InfraConfig
 
             (Get-Content -raw $InfraConfig) -replace "(?m)^custom_attributes:(?s:.*?)(^\s.+:.+\n)+", "" | Set-Content $InfraConfig
+            (Get-Content -raw $InfraConfig) -replace "(?m)^passthrough_environment:(?s:.*?)(^\s\s-.+\n)+", "" | Set-Content $InfraConfig
+            (Get-Content -raw $InfraConfig) -replace "(?m)^\s*`r`n", "" | Set-Content $InfraConfig 
 
           } else {
             msiexec.exe /qn /i "$env:TEMP\newrelic-infra.msi" GENERATE_CONFIG=true LICENSE_KEY="$LICENSE_KEY" | Out-Null
@@ -214,6 +216,7 @@ install:
             Add-Content -Path $InfraConfig -Value "proxy: $env:HTTPS_PROXY" -Force
           }
           Add-Content -Path $InfraConfig -Value "{{.NRIA_CUSTOM_ATTRIBUTES}}" -Force
+          Add-Content -Path $InfraConfig -Value "{{.NRIA_PASSTHROUGH_ENVIRONMENT}}" -Force
           '
 
     start_infra:


### PR DESCRIPTION
Similar to #754, but targeting windows 

Added functionality to windows infrastructure recipes that consider NRIA_PASSTHROUGH_ENVIRONMENT variable from CLI and writing to `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`

i.e.
```$env:NRIA_PASSTHROUGH_ENVIRONMENT='some,useful,data';```

https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#integrations-variables

Comma-separated values will be parsed/written as an array in yaml. If no values present, nothing will be added to `passthrough_environment:` in `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`.  

If a value was previously added to the environment using `$env:NRIA_PASSTHROUGH_ENVIRONMENT`, omitting the command-line option will not remove these values a in the linux recipes.  You must first remove the value from Powershell's env
`Get-ChildItem Env:NRIA_PASSTHROUGH_ENVIRONMENT | REMOVE-ITEM`