### PR TITLE
Changes linux package name from newrelic-netcore20-agent to newrelic-dotnet-agent

### DIFF
--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -226,8 +226,10 @@ install:
           if [[ -z "$IS_YUM_INSTALLED" ]]
           then
             sudo DEBIAN_FRONTEND=noninteractive dpkg -r newrelic-netcore20-agent >/dev/null 2>&1 || true
+            sudo DEBIAN_FRONTEND=noninteractive dpkg -r newrelic-dotnet-agent >/dev/null 2>&1 || true
           else
             sudo yum remove newrelic-netcore20-agent -y >/dev/null 2>&1 || true
+            sudo yum remove newrelic-dotnet-agent -y >/dev/null 2>&1 || true
           fi
 
         - |
@@ -250,18 +252,18 @@ install:
             echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list > /dev/null
             wget -q -O- {{.NEW_RELIC_DOWNLOAD_URL}}548C16BF.gpg | sudo apt-key add -
             sudo apt-get -o Acquire::Check-Valid-Until=false update >/dev/null
-            sudo apt-get install newrelic-netcore20-agent -y -qq > /dev/null
+            sudo apt-get install newrelic-dotnet-agent -y -qq > /dev/null
           else
             sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm || true
-            cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-netcore20-agent.repo" > /dev/null
-          [newrelic-netcore20-agent-repo]
+            cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-dotnet-agent.repo" > /dev/null
+          [newrelic-dotnet-agent-repo]
           name=New Relic .NET Core packages for Enterprise Linux
           baseurl=http://yum.newrelic.com/pub/newrelic/el7/\$basearch
           enabled=1
           gpgcheck=1
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
           REPO
-            sudo yum install newrelic-netcore20-agent -q -y
+            sudo yum install newrelic-dotnet-agent -q -y
           fi
         - echo "New Relic .NET agent installed"
 
@@ -277,8 +279,8 @@ install:
           [Service]
           Environment="CORECLR_ENABLE_PROFILING=1"
           Environment="CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
-          Environment="CORECLR_NEWRELIC_HOME=/usr/local/newrelic-netcore20-agent"
-          Environment="CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so"
+          Environment="CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent"
+          Environment="CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so"
           Environment="NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}"
           Environment="NEW_RELIC_APP_NAME=${sn}"
           Environment="NEW_RELIC_APPLICATION_LOGGING_ENABLED=true"


### PR DESCRIPTION
## Description:
The .Net Agent is going to release the major version of the agent. Part of the major release, we are going to rename a lot of our installer names as well as package names to remove confusion as well as better reflect what .NET frameworks are supported in our new Agent. Because of this change, we need to update our recipes to use the new package name. This PR changes using linux package name from `newrelic-netcore20-agent` to `newrelic-dotnet-agent`.

~~Note: Since the linux packages with the new name will only be available after we release the major version agent, this PR should only be merged after the .NET team releases the major version to avoid breaking. This is also why this PR is labeled as DRAFT.~~