### PR TITLE
chore: update SUSE 12 SP5 AMI

### DIFF
--- a/test/definitions-eu/infra-agent/suse/suse125-infra.json
+++ b/test/definitions-eu/infra-agent/suse/suse125-infra.json
@@ -12,7 +12,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "suse-sles-12-sp5-*"
+        "ami_name": "suse-sles-12-sp5-v????????-hvm-*"
     }],
 
     "instrumentations": {

--- a/test/manual/definitions/infra-agent/suse125-infra.json
+++ b/test/manual/definitions/infra-agent/suse125-infra.json
@@ -1,0 +1,17 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+        "id": "infrasuse125",
+        "display_name": "InfraOpenSuse12Sp5Host",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t2.nano",
+        "ami_name": "suse-sles-12-sp5-v????????-hvm-*"
+    }]
+}


### PR DESCRIPTION
The latest image for SUSE Linux Enterprise Server 12 SP5 is "EC2 Optimized" and does not have `curl` installed, which is causing a regression test to fail. This PR changes the pattern this version of SUSE to filter out this and future EC2 Optimized images. I have also added a manual infra definition for this version of SUSE.