### PR TITLE
feat: replace windows log to use winevtlog

### DIFF
--- a/recipes/newrelic/infrastructure/logs/windows-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/windows-logs.yml
@@ -44,7 +44,7 @@ install:
         LOGS_CONTENT: |
           logs:
             - name: windows-security
-              winlog:
+              winevtlog:
                 channel: Security
                 collect-eventids:
                 - 4740
@@ -59,7 +59,7 @@ install:
                 logtype: windows_security
 
             - name: windows-application
-              winlog:
+              winevtlog:
                 channel: Application
               attributes:
                 logtype: windows_application

--- a/test/definitions/logging/w19-logs.json
+++ b/test/definitions/logging/w19-logs.json
@@ -1,0 +1,34 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+        "id": "infrawindows2019",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "is_windows": true,
+        "ami_name": "Windows_Server-2019-English-Full-HyperV-*",
+        "user_name": "Administrator"
+    }],
+
+    "instrumentations": {
+        "resources": [
+          {
+              "id": "nr_infra",
+              "resource_ids": ["host1"],
+              "provider": "newrelic",
+              "source_repository": "https://github.com/newrelic/open-install-library.git",
+              "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
+              "params": {
+                  "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/logs/windows-logs.yml",
+                  "validate_output": "New Relic installation complete"
+              }
+          }
+          ]
+      }
+}

--- a/test/manual/definitions/logging/w19-logs.json
+++ b/test/manual/definitions/logging/w19-logs.json
@@ -1,0 +1,18 @@
+{
+    "global_tags": {
+        "owning_team": "OpenSource",
+        "Environment": "development",
+        "Department": "Product",
+        "Product": "Virtuoso"
+    },
+
+    "resources": [{
+        "id": "infrawindows2019",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "is_windows": true,
+        "ami_name": "Windows_Server-2019-English-Full-HyperV-*",
+        "user_name": "Administrator"
+    }]
+}


### PR DESCRIPTION
Hi!

This change is related to https://github.com/newrelic/infrastructure-agent/pull/1125

Fluent-bit has a new input plugin for windows logs that come to "replace" winlog, by now we're updating the infrastructure-agent to accept this new plugin type and the next step will be to set it as the default plugin when installing logging for windows.

We thought on make this change transparent to the users by replacing winlog > winevtlog directly when generating the fluent-bit configuration, but the output generated by those plugins have different attribute names and so on, so we discard that option.

Regards!

https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog
https://fluentbit.io/announcements/v1.9.0/

Related to PR https://github.com/newrelic/open-install-library/pull/678 but created on the repo for regression tests to run.