### PR TITLE
Fix raw repo regex in unit test workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -217,8 +217,8 @@ jobs:
             jsonContent = jsonContent.replace(sourceRepositoryRegex, replacementString);
 
             // Update raw URLs with branch name
-            const replacementString2 = `$1$2${process.env.GITHUB_HEAD_REF}/$4`;
-            const sourceRepositoryRegex2 = /(.*)(\/raw.githubusercontent.com\/newrelic\/open-install-library\/)(main)(\/newrelic\/recipes\/)*./gi;
+            const replacementString2 = `$1${process.env.GITHUB_HEAD_REF}$3`;
+            const sourceRepositoryRegex2 = /(raw.githubusercontent.com\/newrelic\/open-install-library\/)(main)(\/newrelic\/recipes\/)*/gi;
             jsonContent = jsonContent.replace(sourceRepositoryRegex2, replacementString2);
 
             // Write file back to workspace


### PR DESCRIPTION
Fixes the `raw.githubusercontent.com` branch replacement regex to match each URL in a string of multiple URLs rather than just a single URL. This was fixed in the nonregression/-eu workflows but not ported to the validation workflow. 

Before: https://regexr.com/6qjgq
After: https://regexr.com/6qjh3