### PR TITLE
fix: adjust python detection to exclude cloud provider python script

### DIFF
--- a/recipes/newrelic/apm/python/linux.yml
+++ b/recipes/newrelic/apm/python/linux.yml
@@ -19,7 +19,7 @@ processMatch:
 
 preInstall:
   requireAtDiscovery: |
-  sudo ps aux | grep python | grep -v root | grep -v grep
+    sudo ps aux | grep python | grep -v root | grep -v grep
     IS_PYTHON_APP_RUNNING=$(sudo ps aux | grep python | grep -v root | grep -v grep | grep -v /usr/share/ | wc -l)
     if [ $IS_PYTHON_APP_RUNNING -eq 0 ] ; then
       # No detection when other python process are running

--- a/recipes/newrelic/apm/python/linux.yml
+++ b/recipes/newrelic/apm/python/linux.yml
@@ -19,7 +19,8 @@ processMatch:
 
 preInstall:
   requireAtDiscovery: |
-    IS_PYTHON_APP_RUNNING=$(sudo ps aux | grep python | grep -v grep | grep -v /usr/share/ | grep -v /usr/bin/ | grep -v /usr/local/bin/ | wc -l)
+  sudo ps aux | grep python | grep -v root | grep -v grep
+    IS_PYTHON_APP_RUNNING=$(sudo ps aux | grep python | grep -v root | grep -v grep | grep -v /usr/share/ | wc -l)
     if [ $IS_PYTHON_APP_RUNNING -eq 0 ] ; then
       # No detection when other python process are running
       exit 1

--- a/recipes/newrelic/apm/python/linux.yml
+++ b/recipes/newrelic/apm/python/linux.yml
@@ -19,7 +19,6 @@ processMatch:
 
 preInstall:
   requireAtDiscovery: |
-    sudo ps aux | grep python | grep -v root | grep -v grep
     IS_PYTHON_APP_RUNNING=$(sudo ps aux | grep python | grep -v root | grep -v grep | grep -v /usr/share/ | wc -l)
     if [ $IS_PYTHON_APP_RUNNING -eq 0 ] ; then
       # No detection when other python process are running


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-13775

On an Azure VM (debian 10.12), we were previously detecting python on some azure specific python programs:

```
azureuser@debian1012:~$ sudo ps aux | grep python | grep -v root | grep -v grep
azureuser@debian1012:~$ sudo ps aux | grep python| grep -v grep
root       670  0.0  1.7  26376 16888 ?        Ss   20:40   0:00 /usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal
root       713  0.0  2.6  30276 24708 ?        Ss   20:40   0:00 /usr/bin/python3 /usr/sbin/waagent -daemon
root       720  0.3  2.8 178708 26960 ?        Sl   20:40   0:02 python3 -u /usr/sbin/waagent -run-exthandlers
```