### PR TITLE
chore(debian): Allow recipe installation continue 

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -57,8 +57,18 @@ install:
     default:
       cmds:
         - task: assert_infra
+        - task: update_apt
         - task: input_assert
         - task: restart
+
+    update_apt:
+      cmds:
+        - |
+          # Get latest definitions and skip any failure because of deprecation
+          apt-get -o Acquire::Check-Valid-Until=false update -yq
+      silent: true
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     assert_infra:
       cmds:
@@ -83,7 +93,6 @@ install:
 
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"
           # Get latest definitions and skip any failure because of deprecation
-          sudo apt-get -o Acquire::Check-Valid-Until=false update -yq
           sudo apt-get install nri-apache -y
 
           if [ -f /etc/newrelic-infra/integrations.d/apache-config.yml ]; then

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -69,6 +69,7 @@ install:
         - task: assert_infra
         - task: assert_pre_req
         - task: collect_meta
+        - task: update_apt
         - task: input_assert
           vars:
             MAX_RETRIES: 3
@@ -100,6 +101,15 @@ install:
               exit ${code}
             fi
           done
+
+    update_apt:
+      cmds:
+        - |
+          # Get latest definitions and skip any failure because of deprecation
+          apt-get -o Acquire::Check-Valid-Until=false update -yq
+      silent: true
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     input_assert:
       cmds:
@@ -224,7 +234,6 @@ install:
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"
           # Get latest definitions and skip any failure because of deprecation
-          sudo apt-get -o Acquire::Check-Valid-Until=false update -yq
           sudo apt-get install nri-mysql -y
           if [ -f /etc/newrelic-infra/integrations.d/mysql-config.yml ]; then
             sudo rm /etc/newrelic-infra/integrations.d/mysql-config.yml;

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -50,6 +50,7 @@ install:
       cmds:
         - task: assert_infra
         - task: assert_pre_req
+        - task: update_apt
         - task: input_assert
           vars:
             MAX_RETRIES: 3
@@ -80,6 +81,15 @@ install:
               exit ${code}
             fi
           done
+
+    update_apt:
+      cmds:
+        - |
+          # Get latest definitions and skip any failure because of deprecation
+          apt-get -o Acquire::Check-Valid-Until=false update -yq
+      silent: true
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     input_assert:
       cmds:
@@ -194,7 +204,6 @@ install:
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"
           # Get latest definitions and skip any failure because of deprecation
-          sudo apt-get -o Acquire::Check-Valid-Until=false update -yq
           sudo apt-get install nri-postgresql -y
           if [ -f /etc/newrelic-infra/integrations.d/postgresql-config.yml ]; then
             sudo rm /etc/newrelic-infra/integrations.d/postgresql-config.yml;

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -57,6 +57,7 @@ install:
     default:
       cmds:
         - task: assert_infra
+        - task: update_apt
         - task: input_assert
           vars:
             MAX_RETRIES: 3
@@ -71,6 +72,15 @@ install:
             echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview" >&2
             exit 1
           fi
+
+    update_apt:
+      cmds:
+        - |
+          # Get latest definitions and skip any failure because of deprecation
+          apt-get -o Acquire::Check-Valid-Until=false update -yq
+      silent: true
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      ignore_error: true
 
     input_assert:
       cmds:
@@ -144,7 +154,6 @@ install:
           # Install the integration
           sudo mkdir -p "/etc/newrelic-infra/integrations.d"
           # Get latest definitions and skip any failure because of deprecation
-          sudo apt-get -o Acquire::Check-Valid-Until=false update -yq
           sudo apt-get install nri-redis -y
 
           if [ -f /etc/newrelic-infra/integrations.d/redis-config.yml ]; then


### PR DESCRIPTION
- Allow recipe install to continue when apt-get update fails
- Sometimes, the apt update fails due to the host having a bad configuration that's unrelated. We want to continue to attempt installation when that error occurs.