### PR TITLE
ohi(rabbitmq): remove rabbitmqctl install task

### DIFF
--- a/test/deploy/linux/rabbitmq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/rabbitmq/install/debian/roles/configure/tasks/main.yml
@@ -19,13 +19,6 @@
     state: latest
   become: true
 
-- name: Install rabbitmqctl
-  apt:
-    name: ['rabbitmq-ctl']
-    update_cache: yes
-    state: latest
-  become: true
-
 - name: Enable management plugin
   shell: rabbitmq-plugins enable rabbitmq_management
   become: true


### PR DESCRIPTION
This removes the `Install rabbitmqctl` task in file `test/deploy/linux/rabbitmq/install/debian/roles/configure/tasks/main.yml` which is causing the `ohi/linux/rabbitmq-debian.json` test to [fail](https://github.com/newrelic/open-install-library/runs/8017702242?check_suite_focus=true#step:7:440) with the `no package matching 'rabbitmq-ctl' is available` message.

The previous task, `Install rabbitmq` in that same `test/deploy/linux/rabbitmq/install/debian/roles/configure/tasks/main.yml` file, installs `rabbitmq-server` and as part of it, the `rabbitmqctl` cli tool gets installed as well.