### PR TITLE
update infra agent key path

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -201,7 +201,7 @@ install:
     add_gpg_key:
       cmds:
         - |
-          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/gpg/newrelic-infra.gpg | apt-key add -
+          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | apt-key add -
       silent: true
 
     add_nr_source:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -171,11 +171,11 @@ install:
             exit 131
           fi
           curl -s $REPO_URL -o /etc/zypp/repos.d/newrelic-infra.repo
-        - curl -s -L {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/gpg/newrelic-infra.gpg > newrelic-infra.gpg
-        - rpm --import newrelic-infra.gpg
+        - curl -s -L {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_rpm_key_current.gpg > newrelic_rpm_key_current.gpg
+        - rpm --import newrelic_rpm_key_current.gpg
         - zypper -n --quiet ref -r newrelic-infra
         - zypper -n --quiet install newrelic-infra
-        - rm newrelic-infra.gpg
+        - rm newrelic_rpm_key_current.gpg
       vars:
         SLES_VERSION:
           sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -188,7 +188,7 @@ install:
     add_gpg_key:
       cmds:
         - |
-          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/gpg/newrelic-infra.gpg | apt-key add -
+          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | apt-key add -
       silent: true
 
     add_nr_source:


### PR DESCRIPTION
As part of a new strategy to rotate packages GPG keys, the path of the current key will be changed. We still maintain the path of the previous key, but from now on, all the packages will be pointed to `infrastructure_agent/keys/` bucket path.

See https://download.newrelic.com/infrastructure_agent/keys/


Let us know if you need further information
