### PR TITLE
Adds a precheck script to .NET Linux installs to speed up detection

### DIFF
--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -22,7 +22,45 @@ processMatch: []
 
 preInstall:
   requireAtDiscovery: |
-    # Get .NET introspector tooling
+    # Check if .NET is installed
+    # There are three packages for .NET: dotnet-runtime, aspnetcore-runtime and dotnet-sdk
+    # Checking both debian and rpm based distros together
+    
+    set +e # disable fail on error
+    
+    dpkg -l dotnet-runtime* >/dev/null 2>&1
+    DPKG_DOTNET=$?
+    
+    dpkg -l aspnetcore-runtime* >/dev/null 2>&1
+    DPKG_ASPNETCORE=$?
+
+    dpkg -l dotnet-sdk* >/dev/null 2>&1
+    DPKG_DOTNET_SDK=$?
+    
+    yum -q list installed dotnet-runtime* >/dev/null 2>&1
+    YUM_DOTNET=$?
+    
+    yum -q list installed aspnetcore-runtime* >/dev/null 2>&1
+    YUM_ASPNETCORE=$?
+
+    yum -q list installed dotnet-sdk* >/dev/null 2>&1
+    YUM_DOTNET_SDK=$?
+    
+    set -e # enable fail on error
+
+    # if any are false, .NET is installed
+    if [[ $DPKG_DOTNET -ne 0 \
+      && $DPKG_ASPNETCORE -ne 0 \
+      && $DPKG_DOTNET_SDK -ne 0 \
+      && $YUM_DOTNET -ne 0 \
+      && $YUM_ASPNETCORE -ne 0 \
+      && $YUM_DOTNET_SDK -ne 0 ]]
+    then
+      # no cleanup since we didn't create any artifacts
+      exit 3
+    fi
+
+    # .NET is installed, get .NET introspector tooling
     TMP_DIR=$(mktemp -dq /tmp/newrelic.XXXXXX)
     curl -s https://download.newrelic.com/install/dotnet/introspector/latest/dotnet-is-linux-x64.gz -o ${TMP_DIR}/dotnet-is-linux-x64.gz >/dev/null
     zcat ${TMP_DIR}/dotnet-is-linux-x64.gz > ${TMP_DIR}/nri-lsi-dotnet

--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -27,37 +27,17 @@ preInstall:
     # Checking both debian and rpm based distros together
     
     set +e # disable fail on error
-    
-    dpkg -l dotnet-runtime* >/dev/null 2>&1
-    DPKG_DOTNET=$?
-    
-    dpkg -l aspnetcore-runtime* >/dev/null 2>&1
-    DPKG_ASPNETCORE=$?
 
-    dpkg -l dotnet-sdk* >/dev/null 2>&1
-    DPKG_DOTNET_SDK=$?
-    
-    yum -q list installed dotnet-runtime* >/dev/null 2>&1
-    YUM_DOTNET=$?
-    
-    yum -q list installed aspnetcore-runtime* >/dev/null 2>&1
-    YUM_ASPNETCORE=$?
+    DPKG_DOTNET=$(dpkg -l dotnet-runtime* aspnetcore-runtime* dotnet-sdk* 2>/dev/null | grep -E 'dotnet-runtime.*|aspnetcore-runtime.*|dotnet-sdk.*' | wc -l)
+    YUM_DOTNET=$(sudo yum -q list installed dotnet-runtime* aspnetcore-runtime* dotnet-sdk* 2>/dev/null | grep -E 'dotnet-runtime.*|aspnetcore-runtime.*|dotnet-sdk.*' | wc -l)
 
-    yum -q list installed dotnet-sdk* >/dev/null 2>&1
-    YUM_DOTNET_SDK=$?
-    
     set -e # enable fail on error
 
     # if any are false, .NET is installed
-    if [[ $DPKG_DOTNET -ne 0 \
-      && $DPKG_ASPNETCORE -ne 0 \
-      && $DPKG_DOTNET_SDK -ne 0 \
-      && $YUM_DOTNET -ne 0 \
-      && $YUM_ASPNETCORE -ne 0 \
-      && $YUM_DOTNET_SDK -ne 0 ]]
+    if [[ $DPKG_DOTNET -eq 0 && $YUM_DOTNET -eq 0  ]]
     then
-      # no cleanup since we didn't create any artifacts
-      exit 3
+        # no cleanup since we didn't create any artifacts
+        exit 3
     fi
 
     # .NET is installed, get .NET introspector tooling


### PR DESCRIPTION
- Updates preInstall-requireAtDiscovery to check if any of the three main .net packages are installed and if none are installed, exit out with status code 3.
- The new script will check both dpkg (Debian) and yum (RHEL-RPM) for the packages and record if the command was successful or not.
- Failed checks will report as a non-0 status code while success is 0.
- The if-then at the end of the check will examine all the status codes and if none are 0, we know that .NET was not installed.  If any are 0, we found .NET and should continue with the introspector.
- Tested locally on Ubuntu and RockyLinux (Centos)