### PR TITLE
Fix/infra agent started assertion removal

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -81,7 +81,6 @@ install:
         - task: setup_proxy
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -213,17 +212,6 @@ install:
           sh: command -v systemctl | wc -l
         IS_INITCTL:
           sh: command -v initctl | wc -l
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -63,7 +63,6 @@ install:
         - task: setup_proxy
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -194,17 +193,6 @@ install:
           sh: command -v systemctl | wc -l
         IS_INITCTL:
           sh: command -v initctl | wc -l
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -49,7 +49,6 @@ install:
         - task: setup_proxy
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -165,17 +164,6 @@ install:
       cmds:
         - |
           sudo -i -u $SUDO_USER brew services restart newrelic-infra-agent
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -68,7 +68,6 @@ install:
         - task: update_apt_nr_source
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -255,17 +254,6 @@ install:
           sh: command -v systemctl | wc -l
         IS_INITCTL:
           sh: command -v initctl | wc -l
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -64,7 +64,6 @@ install:
         - task: setup_proxy
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -198,17 +197,6 @@ install:
           sh: command -v systemctl | wc -l
         IS_INITCTL:
           sh: command -v initctl | wc -l
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -71,7 +71,6 @@ install:
         - task: update_apt_nr_source
         - task: install_infra
         - task: restart
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_pre_req:
@@ -236,17 +235,6 @@ install:
           sh: command -v systemctl | wc -l
         IS_INITCTL:
           sh: command -v initctl | wc -l
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          sleep 10
-          IS_INFRA_INSTALLED=$(ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
-            exit 31
-          fi
 
     assert_agent_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -47,7 +47,6 @@ install:
         - task: download_infra
         - task: install_infra
         - task: start_infra
-        - task: assert_agent_started
         - task: assert_agent_status_ok
 
     assert_required_permissions:
@@ -222,12 +221,6 @@ install:
       cmds:
         - powershell -command 'net start newrelic-infra'
         - echo "New Relic infrastructure agent for Windows installed and started"
-
-    assert_agent_started:
-      cmds:
-        - |
-          # Ensure agent has enough time to start
-          powershell -command 'Start-Sleep -s 10; $output = Get-Service "newrelic-infra"; if ( -not ($output -like "*newrelic-infra*") ) { Write-Error "The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic."; Exit 31; }'
 
     assert_agent_status_ok:
       cmds:


### PR DESCRIPTION
Removing `assert_agent_started` task from all infra recipes which is the culprit for a high number of infra errors:

```execution failed for infrastructure-agent-installer: exit status 31: The infrastructure agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic```

Using `assert_agent_status_ok` provides the same value as the task being removed and it a bit more robust as there's a longer window to assert agent's status :
assert_agent_started: 10 second sleep 
assert_agent_status_ok: 150 max attempts * 2 second sleep