### PR TITLE
fix(apt): add 60 second timeout to apt-get (failures due to locking)

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -182,7 +182,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
@@ -191,7 +191,7 @@ install:
       cmds:
         - |
           if [ {{.HAS_GPG}} -eq 0 ] ; then
-            apt-get install gnupg2 -y
+            apt-get -o DPkg::Lock::Timeout=60 install gnupg2 -y
           fi
       vars:
         HAS_GPG:
@@ -227,14 +227,14 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 
     install_infra:
       cmds:
         - |
-          apt-get install newrelic-infra -y -qq
+          apt-get -o DPkg::Lock::Timeout=60 install newrelic-infra -y -qq
       silent: true
 
     restart:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -169,7 +169,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
@@ -178,7 +178,7 @@ install:
       cmds:
         - |
           if [ {{.HAS_GPG}} -eq 0 ] ; then
-            apt-get install gnupg2 -y
+            apt-get -o DPkg::Lock::Timeout=60 install gnupg2 -y
           fi
       vars:
         HAS_GPG:
@@ -208,14 +208,14 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 
     install_infra:
       cmds:
         - |
-          apt-get install newrelic-infra -y -qq
+          apt-get -o DPkg::Lock::Timeout=60 install newrelic-infra -y -qq
       silent: true
 
     restart:


### PR DESCRIPTION
Added apt-get timeouts to alleviate some debian-based infra failures.  This PR should reduce or eliminate the following errors

```We encountered an issue during the installation: exit status 100: E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?.```