### PR TITLE
feat(infra): add process-based validation

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -238,7 +238,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -248,7 +248,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -216,6 +216,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -229,11 +235,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -219,7 +219,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -229,7 +229,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -197,6 +197,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -210,11 +216,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -190,7 +190,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -200,7 +200,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -168,6 +168,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -181,11 +187,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -258,6 +258,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -271,11 +277,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -280,7 +280,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -290,7 +290,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -201,6 +201,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -214,11 +220,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -223,7 +223,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -233,7 +233,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -239,6 +239,12 @@ install:
     assert_agent_status_ok:
       cmds:
         - |
+          infra_present(){
+            INFRA_PRESENT=$(ps aux | grep newrelic-infra$ | wc -l)
+            [[ $INFRA_PRESENT -gt 0 ]]
+            return
+          }
+
           MAX_RETRIES=150
           TRIES=0
           echo "Running agent status check attempt..."
@@ -252,11 +258,21 @@ install:
             else
               if [ "$statusCheckOutput" == "" ]; then
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
                 fi
               else
                 if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
+                  # Process-based validation attempt
+                  if infra_present; then
+                    echo "detected newrelic-infra process running"
+                    break
+                  fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33
                 fi

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -261,7 +261,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status endpoint not available" >&2
                   exit 32
@@ -271,7 +271,7 @@ install:
                   # Process-based validation attempt
                   if infra_present; then
                     echo "detected newrelic-infra process running"
-                    break
+                    exit 0
                   fi
                   echo "infra-agent status check not healthy: $statusCheckOutput" >&2
                   exit 33

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -226,6 +226,9 @@ install:
       cmds:
         - |
           powershell -command '
+            Function isInfraRunning { 
+              (Get-Service newrelic-infra -ErrorAction SilentlyContinue | Select-Object Status).Status -eq "Running" 
+            }
             $maxRetries = 150
             $tries = 0
             while ($tries -lt $maxRetries) {
@@ -240,11 +243,19 @@ install:
               }
               if ($statusCheckOutput -ieq "") {
                 if ($tries -eq $maxRetries) {
+                  if (isInfraRunning) {
+                    Write-Host "detected newrelic-infra service running"
+                    break
+                  }
                   Write-Host -ForegroundColor Red "infra-agent status endpoint not available";
                   exit 32;
                 }
               } else {
                 if ($tries -eq $maxRetries) {
+                  if (isInfraRunning) {
+                    Write-Host "detected newrelic-infra service running"
+                    break
+                  }
                   Write-Host -ForegroundColor Red "infra-agent status check not healthy: $statusCheckOutput";
                   exit 33;
                 }

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -245,7 +245,7 @@ install:
                 if ($tries -eq $maxRetries) {
                   if (isInfraRunning) {
                     Write-Host "detected newrelic-infra service running"
-                    break
+                    exit 0
                   }
                   Write-Host -ForegroundColor Red "infra-agent status endpoint not available";
                   exit 32;
@@ -254,7 +254,7 @@ install:
                 if ($tries -eq $maxRetries) {
                   if (isInfraRunning) {
                     Write-Host "detected newrelic-infra service running"
-                    break
+                    exit 0
                   }
                   Write-Host -ForegroundColor Red "infra-agent status check not healthy: $statusCheckOutput";
                   exit 33;


### PR DESCRIPTION
This is to address [NR-53396](https://issues.newrelic.com/browse/NR-53396) which is about adding a second `infrastructure-agent` validation in case it is running on a different port. 

Changes tested in RHEL, Ubuntu, Debian, AWS Linux, Windows.

Testing: https://issues.newrelic.com/browse/NR-55799 