### PR TITLE
chore: validate linux ohi installation

### DIFF
--- a/test/definitions/ohi/linux/apache-rhel.json
+++ b/test/definitions/ohi/linux/apache-rhel.json
@@ -32,7 +32,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/apache/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Apache Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/cassandra-debian.json
+++ b/test/definitions/ohi/linux/cassandra-debian.json
@@ -37,7 +37,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(Cassandra Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/consul-debian.json
+++ b/test/definitions/ohi/linux/consul-debian.json
@@ -30,14 +30,14 @@
     "instrumentations": {
       "resources": [
         {
-            "id": "nr_infra_haproxy",
+            "id": "nr_ohi_consul",
             "resource_ids": ["host1"],
             "provider": "newrelic",
             "source_repository": "https://github.com/newrelic/open-install-library.git",
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/consul/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Consul Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/consul-rhel.json
+++ b/test/definitions/ohi/linux/consul-rhel.json
@@ -29,14 +29,14 @@
     "instrumentations": {
       "resources": [
         {
-          "id": "nr_infra_hashicorp",
+          "id": "nr_ohi_consul",
           "resource_ids": ["host1"],
           "provider": "newrelic",
           "source_repository": "https://github.com/newrelic/open-install-library.git",
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/consul/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Consul Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/couchbase-debian.json
+++ b/test/definitions/ohi/linux/couchbase-debian.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Couchbase Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/couchbase-rhel.json
+++ b/test/definitions/ohi/linux/couchbase-rhel.json
@@ -36,7 +36,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Couchbase Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/docker-linux2.json
+++ b/test/definitions/ohi/linux/docker-linux2.json
@@ -31,7 +31,8 @@
         "source_repository": "https://github.com/newrelic/open-install-library.git",
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
         "params": {
-            "local_recipes": true
+            "local_recipes": true,
+            "validate_output": "New Relic installation complete"
         }
       }
     ]

--- a/test/definitions/ohi/linux/elasticsearch-debian.json
+++ b/test/definitions/ohi/linux/elasticsearch-debian.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Elasticsearch Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/elasticsearch-rhel.json
+++ b/test/definitions/ohi/linux/elasticsearch-rhel.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Elasticsearch Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/elasticsearch-suse.json
+++ b/test/definitions/ohi/linux/elasticsearch-suse.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/suse.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Elasticsearch Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/haproxy-debian.json
+++ b/test/definitions/ohi/linux/haproxy-debian.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(HAProxy Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/haproxy-rhel.json
+++ b/test/definitions/ohi/linux/haproxy-rhel.json
@@ -36,7 +36,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(HAProxy Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/memcached-debian.json
+++ b/test/definitions/ohi/linux/memcached-debian.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/memcached/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(Memcached Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/memcached-rhel.json
+++ b/test/definitions/ohi/linux/memcached-rhel.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(Memcached Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/mongodb-debian.json
+++ b/test/definitions/ohi/linux/mongodb-debian.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(MongoDB Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/mysql-debian.json
+++ b/test/definitions/ohi/linux/mysql-debian.json
@@ -36,7 +36,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mysql/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(MySQL Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/nagios-debian.json
+++ b/test/definitions/ohi/linux/nagios-debian.json
@@ -33,7 +33,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nagios/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Nagios Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/nagios-rhel.json
+++ b/test/definitions/ohi/linux/nagios-rhel.json
@@ -32,7 +32,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Nagios Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/nginx-debian.json
+++ b/test/definitions/ohi/linux/nginx-debian.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nginx/linux.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(NGINX Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/nginx-linux2-ami.json
+++ b/test/definitions/ohi/linux/nginx-linux2-ami.json
@@ -44,7 +44,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
               "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nginx/linux.yml",
-              "validate_output": "New Relic installation complete"
+              "validate_output": "(NGINX Integration)\\s+\\(installed\\)"
           }
       }
       ]

--- a/test/definitions/ohi/linux/nginx-linux2-svc.json
+++ b/test/definitions/ohi/linux/nginx-linux2-svc.json
@@ -36,7 +36,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
               "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nginx/linux.yml",
-              "validate_output": "New Relic installation complete"
+              "validate_output": "(NGINX Integration)\\s+\\(installed\\)"
           }
       }
       ]

--- a/test/definitions/ohi/linux/nginx-ubuntu.json
+++ b/test/definitions/ohi/linux/nginx-ubuntu.json
@@ -37,7 +37,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/nginx/linux.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(NGINX Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/postgres-debian-targeted-failure.json
+++ b/test/definitions/ohi/linux/postgres-debian-targeted-failure.json
@@ -26,7 +26,7 @@
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/postgres/debian.yml",
                 "recipe_targeted": "postgres-open-source-integration",
-                "validate_output": "(unsupported)"
+                "validate_output": "(PostgreSQL Integration)\\s+\\(unsupported\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/postgres-debian.json
+++ b/test/definitions/ohi/linux/postgres-debian.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/postgres/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(PostgreSQL Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/postgres-rhel.json
+++ b/test/definitions/ohi/linux/postgres-rhel.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(PostgreSQL Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/redis-debian.json
+++ b/test/definitions/ohi/linux/redis-debian.json
@@ -36,7 +36,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/redis/debian.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "(Redis Integration)\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/definitions/ohi/linux/redis-rhel.json
+++ b/test/definitions/ohi/linux/redis-rhel.json
@@ -40,7 +40,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/redis/rhel.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "(Redis Integration)\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/ohi/linux/varnish-debian.json
+++ b/test/definitions/ohi/linux/varnish-debian.json
@@ -41,7 +41,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/varnish/debian.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Varnish Cache Integration)\\s+\\(installed\\)"
           }
         }
       ]

--- a/test/definitions/ohi/linux/varnish-rhel.json
+++ b/test/definitions/ohi/linux/varnish-rhel.json
@@ -35,7 +35,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "(Varnish Cache Integration)\\s+\\(installed\\)"
           }
         }
       ]


### PR DESCRIPTION
Changes `validate_output` in `ohi/linux` test files to check for confirmation that specific integrations were installed