### PR TITLE
fix(sql): Skip offline database to prevent error

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -228,10 +228,7 @@ install:
             DROP LOGIN ${NR_CLI_DB_USERNAME}
           END
 
-          IF NOT EXISTS(select 1 from sys.syslogins where name = `"${NR_CLI_DB_USERNAME}`")
-          BEGIN
-            CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
-          END
+          CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
 
           GRANT CONNECT SQL, VIEW SERVER STATE, VIEW ANY DEFINITION TO ${NR_CLI_DB_USERNAME}
           DECLARE db_create_cursor CURSOR

--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -135,6 +135,9 @@ install:
           }
           $NR_SQL_USERNAME="$env:NR_CLI_SQL_USERNAME"
           $NR_SQL_PASSWORD="$env:NR_CLI_SQL_PASSWORD"
+          $NR_SQL_USERNAME="$env:NR_CLI_SQL_USERNAME"
+          $NR_ENABLE_BUFFER_METRICS="$env:NR_CLI_ENABLE_BUFFER_METRICS"
+          $NR_ENABLE_DATABASE_RESERVE_METRICS="$env:NR_CLI_ENABLE_RESERVE_METRICS"
 
           $OhiConfig = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\mssql-config.yml";
           # Remove any previous config
@@ -158,6 +161,14 @@ install:
             Add-Content -Path $OhiConfig -Value "      HOSTNAME`:` ${NR_CLI_DB_HOSTNAME}" -Force | Out-Null;
             Add-Content -Path $OhiConfig -Value "      USERNAME`:` ${NR_CLI_DB_USERNAME}" -Force | Out-Null;
             Add-Content -Path $OhiConfig -Value "      PASSWORD`:` `"${NR_CLI_DB_PASSWORD}`"" -Force | Out-Null;
+
+            if ($NR_ENABLE_BUFFER_METRICS -eq "0") {
+            Add-Content -Path $OhiConfig -Value "      ENABLE_BUFFER_METRICS`:` false" -Force | Out-Null;
+            }
+
+            if ($NR_ENABLE_DATABASE_RESERVE_METRICS -eq "0") {
+            Add-Content -Path $OhiConfig -Value "      ENABLE_DATABASE_RESERVE_METRICS`:` false" -Force | Out-Null;
+            }
 
             if ([string]::IsNullOrWhiteSpace($Port)) {
               Add-Content -Path $OhiConfig -Value "      INSTANCE`:` ${InstanceName}" -Force | Out-Null;
@@ -189,7 +200,7 @@ install:
           DECLARE @name SYSNAME
           DECLARE db_user_cursor CURSOR
           READ_ONLY FORWARD_ONLY
-          FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`")
+          FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`") and state != 6
           OPEN db_user_cursor
           FETCH NEXT FROM db_user_cursor INTO @name WHILE @@FETCH_STATUS = 0
           BEGIN
@@ -217,16 +228,19 @@ install:
             DROP LOGIN ${NR_CLI_DB_USERNAME}
           END
 
-          CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
+          IF NOT EXISTS(select 1 from sys.syslogins where name = `"${NR_CLI_DB_USERNAME}`")
+          BEGIN
+            CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
+          END
 
           GRANT CONNECT SQL, VIEW SERVER STATE, VIEW ANY DEFINITION TO ${NR_CLI_DB_USERNAME}
           DECLARE db_create_cursor CURSOR
           READ_ONLY FORWARD_ONLY
-          FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`")
+          FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`") and state !=6
           OPEN db_create_cursor
           FETCH NEXT FROM db_create_cursor INTO @name WHILE @@FETCH_STATUS = 0
           BEGIN
-              EXECUTE(`"USE [`" + @name + `"]; CREATE USER ${NR_CLI_DB_USERNAME} FOR LOGIN ${NR_CLI_DB_USERNAME};`" )
+              EXECUTE(`"USE [`" + @name + `"]; IF NOT EXISTS(SELECT name from sys.database_principals where name = `"`"${NR_CLI_DB_USERNAME}`"`") BEGIN CREATE USER ${NR_CLI_DB_USERNAME} FOR LOGIN ${NR_CLI_DB_USERNAME}; END`" )
               FETCH next FROM db_create_cursor INTO @name
           END
           CLOSE db_create_cursor


### PR DESCRIPTION
1. When there are offline databases, the recipe stops and returns in error. Fix this by skipping the offline databases to create the NR user.
2. Allow disable buffer and reserve metrics through env variables