### PR TITLE
feat(log-capture): enable log capture for linux infra agent recipes

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -71,6 +71,8 @@ install:
       sh: if [ {{.AMAZON_LINUX_VERSION}} = "2" ] || [ {{.AMAZON_LINUX_VERSION}} = "2022" ]; then echo "amazonlinux"; else echo "el"; fi
     ARCH:
       sh: uname -m
+    CAPTURE_CLI_LOGS: true
+
 
   tasks:
     default:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -53,6 +53,8 @@ preInstall:
 install:
   version: "3"
   silent: true
+  vars:
+    CAPTURE_CLI_LOGS: true
 
   tasks:
     default:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -51,9 +51,13 @@ preInstall:
       fi
       exit 0
 
+
 install:
   version: "3"
   silent: true
+  vars:
+    CAPTURE_CLI_LOGS: true
+
 
   tasks:
     default:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -56,6 +56,8 @@ preInstall:
 install:
   version: "3"
   silent: true
+  vars:
+    CAPTURE_CLI_LOGS: true
 
   tasks:
     default:


### PR DESCRIPTION
Adding `CAPTURE_CLI_LOGS` variable to all linux infra recipes.  Manually tested against ubuntu/centos/awslinux/suse

Testing with windows did not yield the same results, so it was excluded from this update.