### PR TITLE
feat(capture-logs): removed go-task vars in favor of recipe metadata 

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -71,12 +71,12 @@ install:
       sh: if [ {{.AMAZON_LINUX_VERSION}} = "2" ] || [ {{.AMAZON_LINUX_VERSION}} = "2022" ]; then echo "amazonlinux"; else echo "el"; fi
     ARCH:
       sh: uname -m
-    CAPTURE_CLI_LOGS: true
 
 
   tasks:
     default:
       cmds:
+        - task: write_recipe_metadata
         - task: assert_pre_req
         - task: cleanup
         - task: setup_license
@@ -84,6 +84,11 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -53,12 +53,11 @@ preInstall:
 install:
   version: "3"
   silent: true
-  vars:
-    CAPTURE_CLI_LOGS: true
 
   tasks:
     default:
       cmds:
+        - task: write_recipe_metadata
         - task: assert_pre_req
         - task: cleanup
         - task: setup_license
@@ -66,6 +65,11 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -53,12 +53,11 @@ preInstall:
 install:
   version: "3"
   silent: true
-  vars:
-    CAPTURE_CLI_LOGS: true
 
   tasks:
     default:
       cmds:
+        - task: write_recipe_metadata
         - task: assert_pre_req
         - task: cleanup
         - task: setup_license
@@ -71,6 +70,11 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -55,13 +55,11 @@ preInstall:
 install:
   version: "3"
   silent: true
-  vars:
-    CAPTURE_CLI_LOGS: true
-
 
   tasks:
     default:
       cmds:
+        - task: write_recipe_metadata
         - task: assert_pre_req
         - task: cleanup
         - task: setup_license
@@ -69,6 +67,11 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
 
     assert_pre_req:
       cmds:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -56,12 +56,11 @@ preInstall:
 install:
   version: "3"
   silent: true
-  vars:
-    CAPTURE_CLI_LOGS: true
 
   tasks:
     default:
       cmds:
+        - task: write_recipe_metadata
         - task: assert_pre_req
         - task: cleanup
         - task: setup_license
@@ -75,6 +74,10 @@ install:
         - task: restart
         - task: assert_agent_status_ok
 
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
     assert_pre_req:
       cmds:
         - |


### PR DESCRIPTION
Instead of using CAPTURE_CLI_LOGS to trigger which recipes should capture for potential log collection, use our recipe metadata functionality instead.

We're adding more metadata around our log capturing opt-in functionality, and having both of these flags within our recipe's `Metadata` collection is a cleaner implementation.

This library change should be released with the corresponding newrelic-cli change from PR: https://github.com/newrelic/newrelic-cli/pull/1386