### PR TITLE
chore: catch unsupported k8s version

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -129,21 +129,21 @@ install:
 
           if [[ $SERVER_MAJOR_VERSION == "" && $SERVER_MINOR_VERSION == "" ]]; then
             if echo $KUBECTL_VERSION | grep refused >/dev/null; then
-              echo "kubectl could not connect to the Kubernetes cluster. Check your kubectl configuration, make sure it can connect to your cluster and re-run this command." >&2
+              echo "Installation failed. kubectl could not connect to the Kubernetes cluster. Check your kubectl configuration, make sure it can connect to your cluster and re-run this command." >&2
               exit 131
             else
-              echo "Failed to determine the Kubernetes server version from ${KUBECTL_VERSION}" >&2
+              echo "Installation failed. Failed to determine the Kubernetes server version from ${KUBECTL_VERSION}" >&2
               exit 131
             fi
           fi
 
           if [[ "$CLIENT_MAJOR_VERSION" -lt 1 ]] || [[ "$CLIENT_MAJOR_VERSION" -eq 1 && "$CLIENT_MINOR_VERSION" -lt 10 ]]; then
-            echo "kubectl v1.10 or higher is required, found v${CLIENT_MAJOR_VERSION}.${CLIENT_MINOR_VERSION}" >&2
+            echo "Installation failed. kubectl v1.10 or higher is required, found v${CLIENT_MAJOR_VERSION}.${CLIENT_MINOR_VERSION}" >&2
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]]; then
-            echo "Kubernetes v1.16 or higher is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -eq 25 ]]; then
+            echo "Installation failed. Kubernetes v1.16 to v1.24 is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             exit 131
           fi
 
@@ -367,9 +367,13 @@ install:
                   echo ""
           fi
 
+          CLEANED_ARGS=""
+          USED_HELM=false
+
           # Deploy the integration
           if $SUDO which helm 1>/dev/null 2>&1 && $SUDO helm version -c --short | grep v3 1> /dev/null 2>&1
           then
+            USED_HELM=true
             echo ""
             echo "Using helm to install the Kubernetes integration"
             echo ""
@@ -424,7 +428,6 @@ install:
             # Add helm upgrade command as metadata.  Keys are obfuscated.
             if [[ $SEDTEST -eq 1 ]]; then
               CLEANED_ARGS=$(echo $ARGS | sed -E 's/licenseKey=[a-zA-Z0-9\-]+/licenseKey=XXXXX/g' | sed -E 's/deployKey=[a-zA-Z0-9\-]+/deployKey=XXXXX/g' | sed -E 's/apiKey=[a-zA-Z0-9\-]+/apiKey=XXXXX/g')
-              echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommand\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" > {{.NR_CLI_OUTPUT}}
             fi
 
             $SUDO helm upgrade $ARGS
@@ -503,6 +506,17 @@ install:
 
             $SUDO $KUBECTL apply -f $KUBECTL_YAML_DIR/newrelic-k8s.yml
           fi
+
+          HELM_COMMAND="helm not used"
+          HELM_VERSION="helm not used"
+
+          if $USED_HELM
+          then
+            HELM_COMMAND="$SUDO helm upgrade $CLEANED_ARGS"
+            HELM_VERSION="$($SUDO helm version -c --short)"
+          fi
+
+          echo "{\"Metadata\":{\"helmVersion\":\"$HELM_VERSION\", \"helmCommand\":\"$HELM_COMMAND\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
 
           # Check for 'nrk8s-kubelet-node-scraper' pod presence first, otherwise default to former pod name 'nrk8s-kubelet'
           POD_NAME=$(test $($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep 'nrk8s-kubelet-node-scraper' | wc -l | sed 's/ //g') -gt 0 && echo 'nrk8s-kubelet-node-scraper' || echo 'nrk8s-kubelet')


### PR DESCRIPTION
Catch unsupported 1.25 k8s version and updated error messages displayed to user about unsupported k8s/kubectl versions.