### PR TITLE
chore: adding manual deploy config to create an empty eks cluster

### DIFF
--- a/docs/kubernetes-eks.md
+++ b/docs/kubernetes-eks.md
@@ -1,18 +1,28 @@
 # Kubernetes EKS testing
 
-This guide describes how to provision an AWS EKS cluster using CloudFormation.
+This guide describes how to provision an AWS EKS cluster using the [demo-deployer](https://github.com/newrelic/demo-deployer), kubectl, eksctl. 
 
 ## Pre-requesite
 
 You'll need the following:
 * AWS account
-* an AWS specific region (us-east-1 for example)
+* an AWS specific region (us-east-1 for example) with at least 1 available VPC slot (by default AWS allows a maximum of 5 VPCs)
 
 ## Manual deployment using demo-deployer and kubectl, eksctl
 
 Using the demo-deployer, run a deployment using the following [deploy config file](../test/manual/definitions/kubernetes/eks-empty.json). Adjust any of the parameter as needed.
 
-Note, eksctl leverages AWS CloudFormation service to deploy an EKS cluster. Ensure you have at least 1 available VPC slot in the region you'll want to deploy, by default AWS allows 5 VPC maximum.
+Note, re-running the same deployment is idempotent in the way that subsequent execution will skip over any steps that were previously completed. Likewise for teardown, re-running the same deployment in teardown mode will only terminate the cluster the first time.
+
+### Teardown
+
+Re-run the demo-deployer command in teardown mode by adding `-t` to dispose of any resources associated with the deployment (EKS cluster, EC2 hosts, CloudFormation stacks, VPC)
+
+## Side effects
+
+* an EC2 instance will be created with kubectl and eksctl installed to interact with the K8s cluster.
+* eksctl leverages AWS CloudFormation service, with nested stacks.
+* eksctl will create a dedicated VPC and roles for the K8s cluster.
 
 ## Deploying SockShop
 

--- a/docs/kubernetes-eks.md
+++ b/docs/kubernetes-eks.md
@@ -10,7 +10,7 @@ You'll need the following:
 
 ## Manual deployment using demo-deployer and kubectl, eksctl
 
-Using the demo-deployer, run a deployment using the following [deploy config file](../test/manual/definitions/kubernetes/eks-empty.json). Adjust any of the parameter as needed.
+Using the demo-deployer, run a deployment using the following [deploy config file](../test/manual/definitions/kubernetes/eks-empty.json). Adjust any of the parameter as needed. You'll want to have the environment variable NEW_RELIC_TEAM_NAME set with your corresponding team name.
 
 Note, re-running the same deployment is idempotent in the way that subsequent execution will skip over any steps that were previously completed. Likewise for teardown, re-running the same deployment in teardown mode will only terminate the cluster the first time.
 

--- a/docs/kubernetes-eks.md
+++ b/docs/kubernetes-eks.md
@@ -7,81 +7,19 @@ This guide describes how to provision an AWS EKS cluster using CloudFormation.
 You'll need the following:
 * AWS account
 * an AWS specific region (us-east-1 for example)
-* In your region, create a key pair of type `pem` in the EC2 UI and keep both the name of the file you used, and the private key file store on your local machine
-* Ensure your `pem` key file has correct permission by running `sudo chmod 0400 myKeyPair.pem`
 
-## Provision new cluster with CloudFormation
+## Manual deployment using demo-deployer and kubectl, eksctl
 
-Follow the link https://fwd.aws/6dEQ7 to create a new cloud formation stack which will create the kubernetes cluster in a new VPC
+Using the demo-deployer, run a deployment using the following [deploy config file](../test/manual/definitions/kubernetes/eks-empty.json). Adjust any of the parameter as needed.
 
-The CloudFormation UI should be prefilled to load this existing template from an S3 URL https://s3.amazonaws.com/aws-quickstart/quickstart-amazon-eks/templates/amazon-eks-entrypoint-new-vpc.template.yaml
-
-* Check the AWS region is the one you selected to use in the top right corner of the UI
-* Click Next
-* (Optional) Change the Stack name with something you'll recognize later when you'll want to delete the cluster (by deleting the cloud formation stack)
-* Then adjust the configuration with the specific values below
-
-### Basic Configuration
-
-* For `Availability Zones` select only 2 zones from the drop down `b` with either `c` or `a`
-* In `Allowed external access CIDR` enter `0.0.0.0/0` to not restrict on any IP
-* In `SSH key name` enter your key pair file name (from the pre-requesite)
-
-### VPC network configuration
-
-* For `Number of Availability Zones` select `2`
-
-### Amazon EC2 configuration
-
-* In `Provision bastion host` select `Enabled`. You'll use this host later to SSH and perform `kubectl` commands against the created kubernetes cluster
-
-### Default EKS node group configuration
-
-* For `Instance type` select `t3.small`
-* For `Number of nodes` use `4`
-* For `Maximum number of nodes` use `5`
-
-### AWS Quick Start configuration
-
-* For `Quick Start S3 bucket Region` enter the same region than what you've selected in the pre-req (us-east-1 for example)
-
-### Next UI screens
-
-Once all previous inputs are entered, click `Next`
-On the next UI, you can review most of the parameters. Scroll to the bottom, acknowledge any disclaimers at the begining and click `Create stack`
-You'll then see a UI illustrating the status of the stack creation. You can click the refresh icon on the top right of the `Events` tab to see the most recent activities while the stack is been created.
-
-## Template execution
-
-Running the cloud formation template does take some time, maybe an hour, so be patient.
-
-Once completed, navigate to the EC2 UI, and find the bastion host, typically named `EKSBastion`, and copy the public IP.
-
-You can then SSH onto this host using this IP, for example: `ssh -i "myKeyPair.pem" ec2-user@18.219.179.205`
-
-If you need to copy a file to that remove instance, you can use the scp command, for example: `scp -i "myKeyPair.pem" /home/myusername/file.yml ec2-user@18.219.179.205:.`
-
-Once logged in, you can execute `kubectl` commands to access the cluster. Here are a few commands to check the cluster is running.
-
-```bash
-kubectl get nodes
-kubectl get pods --all-namespaces
-```
+Note, eksctl leverages AWS CloudFormation service to deploy an EKS cluster. Ensure you have at least 1 available VPC slot in the region you'll want to deploy, by default AWS allows 5 VPC maximum.
 
 ## Deploying SockShop
 
-If desired, you can install a demo application on the cluster using SockShop.
+If desired, you can install a demo application on the cluster using [SockShop](https://github.com/microservices-demo/microservices-demo/tree/master/deploy/kubernetes)
 Note, no traffic is generated with this deployment.
 
 ```
 git clone https://github.com/microservices-demo/microservices-demo.git
-cd microservices-demo/deploy/kubernetes
-kubectl create namespace sock-shop
-kubectl convert -f . | kubectl create -f -
+kubectl create -f microservices-demo/deploy/kubernetes/complete-demo.yaml 
 ```
-
-## Un-install newrelic instrumentation
-
-Assuming you've deployed newrelic instrumentation using the manifest file, you can un-install the newrelic instrumentation by running the command below (assuming you SSH into the bastion host).
-
-`kubectl delete -f <manifest.yaml>`

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,7 +1,8 @@
 # Kubernetes testing
 
 For manual or automated testing, we can use a minikube kubernetes cluster.
-To test with multi-node cluster see the [Kubernetes EKS testing](./kubernetes-eks.md) documentation.
+
+To test with a real multi-node cluster see the [Kubernetes EKS testing](./kubernetes-eks.md) documentation.
 
 ## Pre-requesite
 

--- a/test/deploy/linux/kubernetes/eks/roles/configure/tasks/installSockShop.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/configure/tasks/installSockShop.yml
@@ -1,0 +1,16 @@
+---
+- debug:
+    msg: Deploying SockShop Demo
+
+- name: Set default deploy_sockshop (default not create)
+  set_fact:
+    deploy_sockshop: "false"
+  when: deploy_sockshop is undefined
+
+- name: clone sockshop
+  shell: "git clone https://github.com/microservices-demo/microservices-demo.git"
+  when: deploy_sockshop|bool
+
+- name: install sockshop
+  shell: "kubectl create -f microservices-demo/deploy/kubernetes/complete-demo.yaml"
+  when: deploy_sockshop|bool

--- a/test/deploy/linux/kubernetes/eks/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/configure/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+# sockshop
+- name: Get kubectl exist
+  shell: kubectl get pods -n sock-shop | grep Running | wc -l
+  register: sockshop_exist
+  ignore_errors: true
+- include_tasks: installSockShop.yml
+  when: sockshop_exist.stdout|int == 0

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
@@ -1,0 +1,56 @@
+---
+- debug:
+    msg: Creating cluster
+
+# Kubernetes version
+- name: kubernetes version
+  set_fact:
+    kubernetes_version: "1.22"
+  when: kubernetes_version is not defined
+- name: display kubernetes_version
+  debug:
+    msg: "using kubernetes_version {{ kubernetes_version }}"
+
+# Region
+- name: aws region
+  set_fact:
+    aws_region: "us-east-1"
+  when: aws_region is not defined
+- name: display aws region
+  debug:
+    msg: "using region {{ aws_region }}"
+
+# cluster_node_vcpus
+- name: aws cluster_node_vcpus
+  set_fact:
+    cluster_node_vcpus: "2"
+  when: cluster_node_vcpus is not defined
+- name: display cluster_node_vcpus
+  debug:
+    msg: "using cluster_node_vcpus {{ cluster_node_vcpus }}"
+
+# cluster_node_memory
+- name: aws cluster_node_memory
+  set_fact:
+    cluster_node_memory: "8"
+  when: cluster_node_memory is not defined
+- name: display cluster_node_memory
+  debug:
+    msg: "using cluster_node_memory {{ cluster_node_memory }}"
+
+# Tags
+- name: Format tags into a CSV string
+  set_fact:
+    tags_string: "{{ tags_string | default('') }},{{item.key}}={{item.value}}"
+  loop: "{{ (tags|default({}))|dict2items }}"
+  when: tags is defined
+- name: trim tags
+  set_fact:
+    tags_string: "{{ tags_string | regex_replace('^,', '') }}"
+  when: tags_string is defined
+- name: display tags
+  debug:
+    msg: "using tags {{ tags_string }}"
+
+- name: Create cluster
+  shell: "eksctl create cluster --version {{ kubernetes_version }} --name {{ deployment_name }} --region {{ aws_region }} --instance-selector-vcpus {{ cluster_node_vcpus }} --instance-selector-memory {{ cluster_node_memory }} --tags {{ tags_string }}"

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
@@ -57,3 +57,5 @@
 
 - name: Create cluster
   shell: "eksctl create cluster --version {{ kubernetes_version }} --name {{ deployment_name }} --region {{ aws_region }} --instance-selector-vcpus {{ cluster_node_vcpus }} --instance-selector-memory {{ cluster_node_memory }} --tags {{ tags_string }}"
+  async: 1800
+  poll: 0

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
@@ -59,3 +59,12 @@
   shell: "eksctl create cluster --version {{ kubernetes_version }} --name {{ deployment_name }} --region {{ aws_region }} --instance-selector-vcpus {{ cluster_node_vcpus }} --instance-selector-memory {{ cluster_node_memory }} --tags {{ tags_string }}"
   async: 1800
   poll: 0
+  register: cluster_task
+
+- name: 'check on async task'
+  async_status:
+    jid: "{{ cluster_task.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  retries: 180
+  delay: 10

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
@@ -38,16 +38,19 @@
   debug:
     msg: "using cluster_node_memory {{ cluster_node_memory }}"
 
+- name: ensure tags are provided
+  fail:
+    msg: "tags should be provided when creating AWS resources. Please add global_tags/owning_team to your deploy config and ensure you use the latest version of the deployer."
+  when: tags is not defined
+
 # Tags
-- name: Format tags into a CSV string
+- name: Format tags into a CSV string key1=value1,key2=value2...
   set_fact:
     tags_string: "{{ tags_string | default('') }},{{item.key}}={{item.value}}"
   loop: "{{ (tags|default({}))|dict2items }}"
-  when: tags is defined
 - name: trim tags
   set_fact:
     tags_string: "{{ tags_string | regex_replace('^,', '') }}"
-  when: tags_string is defined
 - name: display tags
   debug:
     msg: "using tags {{ tags_string }}"

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/createCluster.yml
@@ -68,3 +68,4 @@
   until: job_result.finished
   retries: 180
   delay: 10
+  when: cluster_task.ansible_job_id is defined

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installEksctl.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installEksctl.yml
@@ -1,0 +1,21 @@
+---
+- debug:
+    msg: Installing eksctl
+
+- name: download eksctl
+  shell: "curl -O --silent --location 'https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz'"
+
+- name: unpacking eksctl
+  shell: "tar xzvf eksctl_Linux_amd64.tar.gz -C /tmp"
+
+- name: move eksctl
+  shell: "mv /tmp/eksctl /usr/local/bin"
+  become: yes
+
+- name: eksctl version
+  shell: "eksctl version"
+  register: eksctl_version_final
+
+- name: display eksctl version
+  debug:
+    msg: "using eksctl version {{ eksctl_version_final.stdout }}"

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installGit.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installGit.yml
@@ -1,0 +1,10 @@
+---
+- debug:
+    msg: Installing Git client
+
+- name: Install git
+  yum:
+    pkg:
+      - 'git'
+    state: present
+  become: true

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installKubectl.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/installKubectl.yml
@@ -1,0 +1,33 @@
+---
+- debug:
+    msg: Installing kubectl
+
+- name: kubectl version
+  shell: "curl -L -s https://dl.k8s.io/release/stable.txt"
+  register: kubectl_version_query
+  when: kubectl_version is not defined
+
+- name: set version
+  set_fact:
+    kubectl_version: "{{ kubectl_version_query.stdout }}"
+  when: kubectl_version is not defined
+
+- name: debug kubectl version
+  debug:
+    msg: "will use kubectl version {{ kubectl_version }}"
+
+- name: download kubectl
+  shell: "curl -LO 'https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl'"
+
+- name: install kubectl
+  shell: "sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl"
+  become: yes
+
+- name: kubectl version
+  shell: "kubectl version --short"
+  register: kubectl_version_final
+  ignore_errors: true
+
+- name: display kubectl version
+  debug:
+    msg: "using kubectl version {{ kubectl_version_final.stdout }}"

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/main.yml
@@ -2,6 +2,8 @@
 - debug:
     msg: Installing EKS and tool dependencies
 
+- include_tasks: installGit.yml
+
 # kubectl
 - name: Get kubectl exist
   shell: kubectl version --short | grep Client | wc -l

--- a/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/prepare/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- debug:
+    msg: Installing EKS and tool dependencies
+
+# kubectl
+- name: Get kubectl exist
+  shell: kubectl version --short | grep Client | wc -l
+  register: kubectl_exist
+  ignore_errors: true
+- include_tasks: installKubectl.yml
+  when: kubectl_exist.stdout|int == 0
+
+# eksctl
+- name: Get eksctl exist
+  shell: which eksctl | grep eksctl | wc -l
+  register: eksctl_exist
+- include_tasks: installEksctl.yml
+  when: eksctl_exist.stdout|int == 0
+
+- name: Get cluster exist
+  shell: kubectl version --short | grep Server | wc -l
+  register: cluster_exist
+  ignore_errors: true
+- include_tasks: createCluster.yml
+  when: cluster_exist.stdout|int == 0

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -11,7 +11,7 @@
   debug:
     msg: "using region {{ aws_region }}"
 
-- name: Create cluster
+- name: Delete cluster
   shell: "eksctl delete cluster --name {{ deployment_name }} --region {{ aws_region }}"
   async: 1800
   poll: 0

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -15,3 +15,13 @@
   shell: "eksctl delete cluster --name {{ deployment_name }} --region {{ aws_region }}"
   async: 1800
   poll: 0
+  register: cluster_task
+
+- name: 'check on async task'
+  async_status:
+    jid: "{{ cluster_task.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  retries: 180
+  delay: 10
+

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -1,0 +1,15 @@
+---
+- debug:
+    msg: Deleting cluster
+
+# Region
+- name: aws region
+  set_fact:
+    aws_region: "us-east-1"
+  when: aws_region is not defined
+- name: display aws region
+  debug:
+    msg: "using region {{ aws_region }}"
+
+- name: Create cluster
+  shell: "eksctl delete cluster --name {{ deployment_name }} --region {{ aws_region }}"

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -25,12 +25,4 @@
   retries: 180
   delay: 10
   when: cluster_task.ansible_job_id is defined
-
-- name: Checking the build status 1
-  async_status:
-    jid: "{{ job1.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  retries: 10
-  delay: 1
-  when: job1.ansible_job_id is defined
+  

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -13,3 +13,5 @@
 
 - name: Create cluster
   shell: "eksctl delete cluster --name {{ deployment_name }} --region {{ aws_region }}"
+  async: 1800
+  poll: 0

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/deleteCluster.yml
@@ -24,4 +24,13 @@
   until: job_result.finished
   retries: 180
   delay: 10
+  when: cluster_task.ansible_job_id is defined
 
+- name: Checking the build status 1
+  async_status:
+    jid: "{{ job1.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  retries: 10
+  delay: 1
+  when: job1.ansible_job_id is defined

--- a/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/eks/roles/teardown/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- debug:
+    msg: Deleting cluster
+
+# kubectl
+- name: Get kubectl exist
+  shell: kubectl version --short | grep Client | wc -l
+  register: kubectl_exist
+  ignore_errors: true
+
+- name: Get cluster exist
+  shell: kubectl version --short | grep Server | wc -l
+  register: cluster_exist
+  ignore_errors: true
+- include_tasks: deleteCluster.yml
+  when: kubectl_exist.stdout|int == 1 and cluster_exist.stdout|int >= 1

--- a/test/manual/definitions/kubernetes/eks-empty.json
+++ b/test/manual/definitions/kubernetes/eks-empty.json
@@ -1,0 +1,35 @@
+{
+  "global_tags": {
+      "owning_team": "virtuoso",
+      "Environment": "development",
+      "Department": "Product",
+      "Product": "newrelic"
+  },
+
+  "services": [
+      {
+          "id": "eks1",
+          "source_repository": "https://github.com/newrelic/open-install-library.git",
+          "deploy_script_path": "test/deploy/linux/kubernetes/eks/roles",
+          "port": 9999,
+          "destinations": [
+              "khost1"
+          ],
+          "params": {
+            "kubectl_version": "v1.22.14",
+            "kubernetes_version": "1.22",
+            "aws_region": "us-west-2"
+          }
+      }
+  ],
+
+  "resources": [
+      {
+          "id": "khost1",
+          "provider": "aws",
+          "type": "ec2",
+          "size": "t3.micro",
+          "instance_role": "EksInstanceRole"
+      }
+  ]
+}

--- a/test/manual/definitions/kubernetes/eks-empty.json
+++ b/test/manual/definitions/kubernetes/eks-empty.json
@@ -1,6 +1,6 @@
 {
   "global_tags": {
-      "owning_team": "virtuoso",
+      "owning_team": "myteamname",
       "Environment": "development",
       "Department": "Product",
       "Product": "newrelic"
@@ -18,7 +18,8 @@
           "params": {
             "kubectl_version": "v1.22.14",
             "kubernetes_version": "1.22",
-            "aws_region": "us-west-2"
+            "aws_region": "us-west-2",
+            "deploy_sockshop": false
           }
       }
   ],

--- a/test/manual/definitions/kubernetes/eks-empty.json
+++ b/test/manual/definitions/kubernetes/eks-empty.json
@@ -1,6 +1,6 @@
 {
   "global_tags": {
-      "owning_team": "myteamname",
+      "owning_team": "[env:NEW_RELIC_TEAM_NAME]",
       "Environment": "development",
       "Department": "Product",
       "Product": "newrelic"

--- a/test/manual/definitions/kubernetes/minikube-empty.json
+++ b/test/manual/definitions/kubernetes/minikube-empty.json
@@ -7,7 +7,7 @@
     },
   
     "resources": [{
-      "id": "k8mini",
+      "id": "minikctl1",
       "provider": "aws",
       "type": "ec2",
       "size": "t3.xlarge",
@@ -20,7 +20,7 @@
       "source_repository": "https://github.com/newrelic/open-install-library.git",
       "deploy_script_path": "test/deploy/linux/kubernetes/minikube/roles",
       "port": 9999,
-      "destinations": ["k8mini"]
+      "destinations": ["minikctl1"]
     }
   ]
 }


### PR DESCRIPTION
This PR is dependent on this demo-deployer PR to add the capability to associate an instance profile to an EC2 instance, so the host can have the proper permission to create an EKS cluster.
https://github.com/newrelic/demo-deployer/pull/104

JIRA https://issues.newrelic.com/browse/NR-67454