### PR TITLE
fix: error when writing to existing file

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -497,6 +497,7 @@ install:
             fi
 
             BODY="${BODY}}"
+            rm -f $KUBECTL_YAML_DIR/newrelic-k8s.yml
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then


### PR DESCRIPTION
This pr fixes this error [caused by this line](https://github.com/newrelic/open-install-library/blob/main/recipes/newrelic/infrastructure/kubernetes.yml#L500):

```
execution failed for kubernetes-open-source-integration: exit status 1: open /tmp/newrelic-k8s.yml: permission denied
```

If this script is re-ran by the user, this error happens because it can't overwrite the existing file. This pr ensures that we remove the file if it exists and then write to it. 