### PR TITLE
chore: SLES 15.4 test

### DIFF
--- a/test/definitions-eu/infra-agent/suse/suse154-infra.json
+++ b/test/definitions-eu/infra-agent/suse/suse154-infra.json
@@ -1,0 +1,32 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+
+    "resources": [{
+        "id": "host1",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.nano",
+        "ami_name": "suse-sles-15-sp4-v????????-hvm-*"
+    }],
+
+    "instrumentations": {
+      "resources": [
+        {
+            "id": "nr_infra",
+            "resource_ids": ["host1"],
+            "provider": "newrelic",
+            "source_repository": "https://github.com/newrelic/open-install-library",
+            "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+            "params": {
+                "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/suse.yml",
+                "validate_output": "New Relic installation complete"
+            }
+        }
+        ]
+    }
+}

--- a/test/definitions-eu/infra-agent/suse/suse154-infra.json
+++ b/test/definitions-eu/infra-agent/suse/suse154-infra.json
@@ -24,7 +24,7 @@
             "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
             "params": {
                 "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/suse.yml",
-                "validate_output": "New Relic installation complete"
+                "validate_output": "Infrastructure Agent\\s+\\(installed\\)"
             }
         }
         ]

--- a/test/manual/definitions/infra-agent/suse154-infra.json
+++ b/test/manual/definitions/infra-agent/suse154-infra.json
@@ -1,0 +1,16 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+
+    "resources": [{
+        "id": "infrasuse154",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.nano",
+        "ami_name": "suse-sles-15-sp4-v????????-hvm-*"
+    }]
+}


### PR DESCRIPTION
The infrastructure agent team released a new version, 1.34.0, that includes support for `SLES 15.4`. With this PR, we are adding test definitions for it.

Refs:
Jira: [NR-70284](https://issues.newrelic.com/browse/NR-70284), Infra-agent: [1.34.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.34.0)