### PR TITLE
Add option to allow user to uninstall a previously installed kubernetes integration 

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -393,6 +393,30 @@ install:
 
             KUBECTL_INSTALL=false
 
+            # find if nri bundle already installed, ask customer if they wanna uninstall, and then move forward 
+
+            GREEN='\033[0;32m'
+            NC='\033[0m'
+            if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
+              while :; do 
+                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first(recommended)? Y/N? ${NC} "
+                read ans 
+                echo ""
+                UNINSTALL_ANSWER=$(echo "${ans^^}" | cut -c1-1)
+                if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
+                  echo "attempting install over existing thing"
+                  break 
+                fi 
+                if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then
+                  RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
+                  RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
+                  $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
+                  break 
+                fi 
+                echo -e "Please type Y or N only."
+              done 
+            fi
+
             $SUDO helm repo add newrelic https://helm-charts.newrelic.com
             $SUDO helm repo update
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -398,10 +398,13 @@ install:
             NC='\033[0m'
             if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
               while :; do 
-                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended) Y/N? ${NC} "
+                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended, default: Y) Y/N? ${NC} "
                 read ans 
                 echo ""
                 UNINSTALL_ANSWER=$(echo "${ans^^}" | cut -c1-1)
+                if [[ -z "$UNINSTALL_ANSWER" ]]; then
+                  UNINSTALL_ANSWER="Y"
+                fi
                 if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
                   echo "Attempting install over existing integration."
                   break 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -393,13 +393,12 @@ install:
 
             KUBECTL_INSTALL=false
 
-            # find if nri bundle already installed, ask customer if they wanna uninstall, and then move forward 
-
+            # Check if nri-bundle already installed, ask customer if they want uninstall before re-installation, and then move forward.
             GREEN='\033[0;32m'
             NC='\033[0m'
             if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
               while :; do 
-                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first(recommended)? Y/N? ${NC} "
+                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended) Y/N? ${NC} "
                 read ans 
                 echo ""
                 UNINSTALL_ANSWER=$(echo "${ans^^}" | cut -c1-1)
@@ -412,7 +411,7 @@ install:
                   RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
                   $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
                   break 
-                fi 
+                fi
                 echo -e "Please type Y or N only."
               done 
             fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -403,7 +403,7 @@ install:
                 echo ""
                 UNINSTALL_ANSWER=$(echo "${ans^^}" | cut -c1-1)
                 if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
-                  echo "attempting install over existing thing"
+                  echo "Attempting install over existing integration."
                   break 
                 fi 
                 if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then


### PR DESCRIPTION
i tested:  
- no existing k8s integration prior => prompt is skipped 
- passing in a weird answer to script => all answers that start w/ y or n will be interpreted as a yes or no, no answer (as in just hit enter) defaults as a yes, and weird answers get prompted w/ the question again. 
- passing weird answer to script and then acceptable answer => uninstall skips or attempts based on acceptable answer 
- saying no while existing k8s integration under different namespace => install attempts, but errors out as expected
- saying no while existing k8s integration under same namespace => install attempts, doesn't error out (expected, used to work this way before too depending on some specifics.) 
- saying yes while existing k8s integration under different namespace  => uninstall completes, install then succeeds
- saying yes while existing k8s integration under same namespace => uninstall completes, install then succeeds
- completely different helm release in other namespace => uninstall completes correct uninstall, leaves alone irrelevant release, install then succeeds 