### PR TITLE
feat(k8s): add uninstall option

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -393,6 +393,36 @@ install:
 
             KUBECTL_INSTALL=false
 
+            # Check if nri-bundle already installed, ask customer if they want uninstall before re-installation, and then move forward.
+            GREEN='\033[0;32m'
+            NC='\033[0m'
+            if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
+              while :; do 
+                echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended, default: Y) Y/N? ${NC} "
+                if [[ "{{.NEW_RELIC_ASSUME_YES}}" == "true" ]]; then
+                  UNINSTALL_ANSWER="Y"
+                else
+                  read ans 
+                  echo ""
+                  UNINSTALL_ANSWER=$(echo "${ans^^}" | cut -c1-1)
+                fi
+                if [[ -z "$UNINSTALL_ANSWER" ]]; then
+                  UNINSTALL_ANSWER="Y"
+                fi
+                if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
+                  echo "Attempting install over existing integration."
+                  break 
+                fi 
+                if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then
+                  RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
+                  RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
+                  $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
+                  break 
+                fi
+                echo -e "Please type Y or N only."
+              done 
+            fi
+
             $SUDO helm repo add newrelic https://helm-charts.newrelic.com
             $SUDO helm repo update
 


### PR DESCRIPTION
Branched off of `cs/uninstall-option` to test failing golden signal test on PR.  
Seems there was a mismatch in tests on main and the kubernetes branch was behind.  Was able to rebase main and golden signals was no longer detected (which is correct)

Also wrapped the functionality added by @csongnr to respect `-y`/`--assumeYes` flags on guided install