### PR TITLE
Fix: add sudo to removing newrelic k8s yaml file

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -531,7 +531,7 @@ install:
             fi
 
             BODY="${BODY}}"
-            rm -f $KUBECTL_YAML_DIR/newrelic-k8s.yml
+            $SUDO rm -f $KUBECTL_YAML_DIR/newrelic-k8s.yml
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then


### PR DESCRIPTION
Users are getting `execution failed for kubernetes-open-source-integration: exit status 1: rm: cannot remove '/tmp/newrelic-k8s.yml': Operation not permitted` error since we've added [this pr](https://github.com/newrelic/open-install-library/pull/829). Adding sudo to fix this. 