### PR TITLE
Move tests with OHI validation timeout to separate workflow

### DIFF
--- a/.github/workflows/ohi-validation-timeout.yml
+++ b/.github/workflows/ohi-validation-timeout.yml
@@ -1,11 +1,6 @@
-name: Non Regression Testing
+name: OHI Validation Timeout
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 9 * * 1-5"
-  push:
-    branches: [ main ]
+on: [ workflow_dispatch ]
 
 jobs:
   log-context:
@@ -69,12 +64,11 @@ jobs:
               );
               return Array.prototype.concat(...files);
             }
-
             const definitionsDir = "test/definitions";
             const testDefinitions = await getFiles(definitionsDir);
 
             const outputTestFilesMap = testDefinitions
-              .filter((testDefinitionFile) => !isOHIValidationTimeout(testDefinitionFile))
+              .filter(isOHIValidationTimeout)
               .map((testDefinitionFile) => {
                 return {
                   testDefinitionFile,
@@ -85,6 +79,7 @@ jobs:
               include: outputTestFilesMap,
             };
             console.log(output);
+
             return output;
 
   test-deploy-recipe:
@@ -194,94 +189,3 @@ jobs:
       - name: Report any error
         if: steps.deployerRun.outputs.exit_status != 0
         run: exit 1
-
-  slack-notify:
-    runs-on: ubuntu-latest
-    needs: [test-deploy-recipe]
-    if: always()
-    steps:
-      - name: Build Result Slack Notification
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: GitHub Actions
-          status: custom
-          fields: commit,repo,ref,author,eventName,message,workflow
-          custom_payload: |
-            {
-              username: "GitHub Actions",
-              icon_emoji: ":octocat:",
-              attachments: [{
-                color: ${{
-                  needs.test-deploy-recipe.result == 'success'
-                }} === true ? '#43cc11' : '#e05d44',
-                blocks: [
-                  {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: `Build for ${process.env.AS_REPO}`
-                    }
-                  },
-                  {
-                    type: "section",
-                    fields: [
-                      {
-                        type: "mrkdwn",
-                        text: `*Commit:*\n${process.env.AS_COMMIT}`
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: `*Author:*\n${process.env.AS_AUTHOR}`
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: `*Branch:*\n${process.env.AS_REF}`
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: `*Message:*\n${process.env.AS_MESSAGE}`
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: `*Type:*\n${process.env.AS_EVENT_NAME}`
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: "*PR:*\n${{ github.event.pull_request.html_url }}"
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: `*Workflow:*\n${ process.env.AS_WORKFLOW }`
-                      }
-                    ]
-                  },
-                  {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: [
-                        "*Result:*",
-                        `• ${ ${{ needs.test-deploy-recipe.result == 'success' }} === true ? '✅' : '❌' } Non-regression testing of all recipes: ${{ needs.test-deploy-recipe.result }}`
-                      ].join('\n')
-                    }
-                  },
-                  {
-                    type: "context",
-                    elements: [
-                      {
-                        type: "image",
-                        image_url: "https://avatars2.githubusercontent.com/in/15368",
-                        alt_text: "Github Actions"
-                      },
-                      {
-                        type: "mrkdwn",
-                        text: "This message was created automatically by GitHub Actions."
-                      }
-                    ]
-                  }
-                ]
-              }]
-            }
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/scripts/ohiValidationTimeout.js
+++ b/.github/workflows/scripts/ohiValidationTimeout.js
@@ -1,0 +1,35 @@
+// These OHI are timing out in validation, causing installations to report as incomplete
+const ohiValidationTimeoutFiles = [
+  "test/definitions/ohi/linux/cassandra-debian.json",
+  "test/definitions/ohi/linux/consul-debian.json",
+  "test/definitions/ohi/linux/consul-rhel.json",
+  "test/definitions/ohi/linux/couchbase-debian.json",
+  "test/definitions/ohi/linux/couchbase-rhel.json",
+  "test/definitions/ohi/linux/elasticsearch-debian.json",
+  "test/definitions/ohi/linux/elasticsearch-rhel.json",
+  "test/definitions/ohi/linux/elasticsearch-suse.json",
+  "test/definitions/ohi/linux/haproxy-debian.json",
+  "test/definitions/ohi/linux/haproxy-rhel.json",
+  "test/definitions/ohi/linux/memcached-debian.json",
+  "test/definitions/ohi/linux/memcached-rhel.json",
+  "test/definitions/ohi/linux/mongodb-debian.json",
+  "test/definitions/ohi/linux/mysql-debian.json",
+  "test/definitions/ohi/linux/nagios-debian.json",
+  "test/definitions/ohi/linux/nagios-rhel.json",
+  "test/definitions/ohi/linux/nginx-debian.json",
+  "test/definitions/ohi/linux/nginx-linux2-ami.json",
+  "test/definitions/ohi/linux/postgres-debian.json",
+  "test/definitions/ohi/linux/postgres-rhel.json",
+  "test/definitions/ohi/linux/redis-debian.json",
+  "test/definitions/ohi/linux/varnish-debian.json",
+  "test/definitions/ohi/windows/ms-sql-server2019Standard.json",
+];
+
+const ohiLookup = ohiValidationTimeoutFiles.reduce(
+  (lookup, file) => lookup.set(file, true),
+  new Map()
+);
+
+const isOHIValidationTimeout = (file) => ohiLookup.get(file) !== undefined;
+
+module.exports = { isOHIValidationTimeout };


### PR DESCRIPTION
Creates a separate workflow (`ohi-validation-timeout.yml`) for the OHI tests in the nonregression workflow which are failing due to a validation timeout and filters those same tests out of the nonregression workflow:

```
const outputTestFilesMap = testDefinitions
  .filter((testDefinitionFile) => !isOHIValidationTimeout(testDefinitionFile))
```

For any other tests that need to be added to the workflow, add the path to the test (starting from the project root) to the array in `.github/workflows/scripts/ohiValidationTimeout.js`.

Other changes are due to autoformatting