### PR TITLE
fix: update helm upgrade command to catch errors

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -480,7 +480,11 @@ install:
 
             echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
-            $SUDO helm upgrade $ARGS
+            if [[ $($SUDO helm upgrade $ARGS) ]]; then
+            else
+              echo “ERROR $? returned from: $SUDO helm upgrade $CLEANED_ARGS”
+              exit 131
+            fi
           else
             echo ""
             echo "Using kubectl to install the Kubernetes integration"


### PR DESCRIPTION
Update helm upgrade command to catch errors and return `UNSUPPORTED` on error. 