### PR TITLE
Add support for Kubernetes v1.26

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -160,8 +160,8 @@ install:
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 25 ]]; then
-            echo "Installation failed. Kubernetes v1.16 to v1.25 is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 26 ]]; then
+            echo "Installation failed. Kubernetes v1.16 to v1.26 is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 131
           fi
@@ -481,6 +481,13 @@ install:
               ARGS="${ARGS} --devel"
             fi
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
+
+            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 23 ]]; then
+              ARGS="${ARGS} --set kube-state-metrics.image.tag=v2.6.0"
+            else
+              ARGS="${ARGS} --set kube-state-metrics.image.tag=v2.7.0"
+            fi
+
             ARGS="${ARGS} --set prometheus.enabled=${NR_CLI_PROMETHEUS}"
             ARGS="${ARGS} --set newrelic-prometheus-agent.enabled=${NR_CLI_PROMETHEUS_AGENT}"
             ARGS="${ARGS} --set newrelic-prometheus-agent.config.kubernetes.integrations_filter.enabled=${NR_CLI_CURATED}"
@@ -550,6 +557,13 @@ install:
             BODY="${BODY},\"newrelic-infrastructure.privileged\":\"${NR_CLI_PRIVILEGED}\""
             BODY="${BODY},\"global.lowDataMode\":\"${NR_CLI_LOW_DATA_MODE}\""
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
+
+            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 23 ]]; then
+              BODY="${BODY},\"kube-state-metrics.image.tag\":\"v2.6.0\""
+            else
+              BODY="${BODY},\"kube-state-metrics.image.tag\":\"v2.7.0\""
+            fi
+
             BODY="${BODY},\"prometheus.enabled\":\"${NR_CLI_PROMETHEUS}\""
             BODY="${BODY},\"newrelic-prometheus-agent.enabled\":\"${NR_CLI_PROMETHEUS_AGENT}\""
             BODY="${BODY},\"newrelic-prometheus-agent.config.kubernetes.integrations_filter.enabled\":\"${NR_CLI_CURATED}\""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -482,7 +482,7 @@ install:
             fi
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
-            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 23 ]]; then
+            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then
               ARGS="${ARGS} --set kube-state-metrics.image.tag=v2.6.0"
             else
               ARGS="${ARGS} --set kube-state-metrics.image.tag=v2.7.0"
@@ -558,7 +558,7 @@ install:
             BODY="${BODY},\"global.lowDataMode\":\"${NR_CLI_LOW_DATA_MODE}\""
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
-            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 23 ]]; then
+            if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then
               BODY="${BODY},\"kube-state-metrics.image.tag\":\"v2.6.0\""
             else
               BODY="${BODY},\"kube-state-metrics.image.tag\":\"v2.7.0\""


### PR DESCRIPTION
This PR adds support for Kubernetes v1.26. More specifically, this does the followings:
- Lifts up the integration for k8s v1.26 .
- Detects k8s version. For k8s >= v1.25, install KSM from the v2.7.0 image, otherwise install the v2.6.0 image. This is because k8s v1.26 can only work KSM image v2.7.0,  v1.23<= k8s <= v1.25 can work with either KSM image v2.6.0 or v2.7.0, k8s < v1.23 can only work with KSM image v2.6.0.

I have tested the recipe with a minikube cluster with the following test scenarios:
1. Helm is installed + minikube cluster with k8s v1.26
2. Helm is installed + minikube cluster with k8s v1.24
3. Helm is NOT installed + minikube cluster with k8s v1.26
4. Helm is NOT installed + minikube cluster with k8s v1.24

