### PR TITLE
fix(gcp): added timeout to 2s to GCP detection

### DIFF
--- a/recipes/newrelic/infrastructure/cloud/gcp-linux.yml
+++ b/recipes/newrelic/infrastructure/cloud/gcp-linux.yml
@@ -18,7 +18,7 @@ processMatch: []
 
 preInstall:
   requireAtDiscovery: |
-      code=$(curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/id -w %{response_code} -so '/dev/null')
+      code=$(curl -H "Metadata-Flavor: Google" --connect-timeout 2 --max-time 2 'http://169.254.169.254/computeMetadata/v1/instance/id' -w %{response_code} -so '/dev/null')
       if [ $code == "200" ]; then
         exit 132
       fi


### PR DESCRIPTION
It was missing, which means the default of 'forever' is chosen. Most of the time it was 60 seconds. 

This is kinda a blind fix, hope we have some tests for this 😆 