### PR TITLE
(chore): add 'fix-missing' (-m) to apt-get update commands

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -187,7 +187,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
@@ -232,7 +232,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -173,7 +173,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
@@ -212,7 +212,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -173,7 +173,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       silent: true
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
@@ -212,7 +212,7 @@ install:
       cmds:
         - |
           # Get latest definitions and skip any failure because of deprecation
-          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yqm
+          apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Check-Valid-Until=false update -yq
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 


### PR DESCRIPTION
Adding `-m` to  apt-get updates in debian family recipes in an attempt to remedy failed infrastructure installations caused by:

`Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`

In many of the instances of this error, it appears users are performing this and re-running installations successfully.  Adding to our existing `apt-get update` commands in order to prevent customers from multiple installation attempts
