### PR TITLE
fix: windows custom attributes

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -213,7 +213,12 @@ install:
 
             Add-Content -Path $InfraConfig -Value "proxy: $env:HTTPS_PROXY" -Force
           }
-          Add-Content -Path $InfraConfig -Value "{{.NRIA_CUSTOM_ATTRIBUTES}}" -Force
+
+          $customAttributes=@"
+          {{.NRIA_CUSTOM_ATTRIBUTES}}
+          "@
+
+          Add-Content -Path $InfraConfig -Value $customAttributes -Force
           '
 
     start_infra:


### PR DESCRIPTION
Custom attributes is a multi-line string provided by the newrelic-cli. When this variable is injected into the recipe, it causes a syntax error because the string is interpreted as a cmdlet. Instead, we should capture this variable in a multi-line string declaration, before using it.