### PR TITLE
feat(apm): php nr_deployed_by

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -502,6 +502,10 @@ install:
                 sed -i 's,;newrelic.daemon.proxy = "",newrelic.daemon.proxy = \"'"$HTTPS_PROXY"'\",g' $ini_full_name
               fi
 
+              TAGS='{{.NEW_RELIC_CLI_TAGS}}'
+              if [ -n "$TAGS" ]; then
+                sed -i "s/;newrelic.labels = \"\"/newrelic.labels = \"${TAGS}\"/" $ini_full_name
+              fi
               #
               # Determine the target directory that the symlink is pointing to.
               #

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -431,6 +431,11 @@ install:
             if [ ! -z "$HTTPS_PROXY" ]; then
               sed -i 's,;newrelic.daemon.proxy = "",newrelic.daemon.proxy = \"'"$HTTPS_PROXY"'\",g' $ini_full_name
             fi
+
+            TAGS='{{.NEW_RELIC_CLI_TAGS}}'
+            if [ -n "$TAGS" ]; then
+              sed -i "s/;newrelic.labels = \"\"/newrelic.labels = \"${TAGS}\"/" $ini_full_name
+            fi
           done;
 
     restart_services:


### PR DESCRIPTION
Retrieves the tags and values the CLI exposes (via `{{.NEW_RELIC_CLI_TAGS}}`, including the `nr_deployed_by` (and any other tags passed by the installation) and adds them to the `newrelic.labels` configuration option in the `newrelic.ini` file of the PHP APM. This allows the display of those tags in NR1 for that APM.

Pre-requisite: https://github.com/newrelic/newrelic-cli/pull/1431