### PR TITLE
Collect More Error Messages from K8s Recipe

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -463,12 +463,13 @@ install:
 
             if [[ $($SUDO helm repo add newrelic https://helm-charts.newrelic.com) ]]; then
             else
-              echo “ERROR $? returned from: $SUDO helm repo add newrelic https://helm-charts.newrelic.com”
+              echo “ERROR $? returned from: $SUDO helm repo add newrelic https://helm-charts.newrelic.com ”
               exit 131
             fi
 
             if [[ $($SUDO helm repo update) ]] ; then
             else
+              echo “ERROR $? returned from: $SUDO helm repo update”
               exit 131
             fi
 
@@ -616,6 +617,7 @@ install:
 
             if [[ $($SUDO $KUBECTL apply -f $KUBECTL_YAML_DIR/newrelic-k8s.yml) ]]; then
             else
+              echo “ERROR $? returned from: $SUDO $KUBECTL apply -f $KUBECTL_YAML_DIR/newrelic-k8s.yml”
               exit 131
             fi
           fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -463,6 +463,7 @@ install:
 
             if [[ $($SUDO helm repo add newrelic https://helm-charts.newrelic.com) ]]; then
             else
+              echo “ERROR $? returned from: $SUDO helm repo add newrelic https://helm-charts.newrelic.com”
               exit 131
             fi
 


### PR DESCRIPTION
# Description

A customer encounter the error message while install K8s integration
```
Error: looks like "https://helm-charts.newrelic.com/" is not a valid chart repository or cannot be reached: Get "https://newrelic.github.io/helm-charts/index.yaml": Forbidden
```

# Changes
For debugging purpose, I add code to collect more error info at several places before error cause exit.
