### PR TITLE
Add pixie debug info

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -269,7 +269,7 @@ install:
           if [[ "$NAMESPACE_EXISTS" != "true" && "$CAN_CREATE_NAMESPACE" != "yes" ]]; then
             echo "The ${NR_CLI_NAMESPACE} namespace does not exist and you don't have permissions to create a new namespace." >&2
             echo "Use an existing namespace or obtain permissions to create a new namespace." >&2
-            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 1
           fi
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -174,6 +174,10 @@ install:
             exit 131
           fi
 
+          # Due to nr cli limitation, we can only send the last echo message to backend.
+          # FINAL_MESSAGE is used to collect all necessary debug info we need.
+          FINAL_MESSAGE=""
+
           # Determine the cluster name if not provided
           CLUSTER=$($SUDO $KUBECTL config current-context 2>/dev/null || echo "unknown")
 
@@ -265,7 +269,7 @@ install:
           if [[ "$NAMESPACE_EXISTS" != "true" && "$CAN_CREATE_NAMESPACE" != "yes" ]]; then
             echo "The ${NR_CLI_NAMESPACE} namespace does not exist and you don't have permissions to create a new namespace." >&2
             echo "Use an existing namespace or obtain permissions to create a new namespace." >&2
-            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 1
           fi
 
@@ -323,6 +327,7 @@ install:
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS, Minikube, k3s, and k0s are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
+              FINAL_MESSAGE="Pixie is unsupported due to k8s version - ${K8S_VERSION}; ${FINAL_MESSAGE}"
             fi
 
             if $SUDO $KUBECTL get namespace olm 1>/dev/null 2>&1; then
@@ -446,7 +451,7 @@ install:
             GREEN='\033[0;32m'
             NC='\033[0m'
             if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
-              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"Yes\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"Yes\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               while :; do
                 echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended, default: Y) Y/N? ${NC} "
                 if [[ "{{.NEW_RELIC_ASSUME_YES}}" == "true" ]]; then
@@ -461,20 +466,20 @@ install:
                 fi
                 if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
                   echo "Attempting install over existing integration."
-                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"No\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"No\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   break
                 fi
                 if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then
                   RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
                   RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
-                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
                   break
                 fi
                 echo -e "Please type Y or N only."
               done
             else
-              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"No\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"No\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
             fi
 
             if [[ $($SUDO helm repo add newrelic https://helm-charts.newrelic.com) ]]; then
@@ -548,7 +553,7 @@ install:
               CLEANED_ARGS=$(echo $ARGS | sed -E 's/licenseKey=[a-zA-Z0-9\-]+/licenseKey=XXXXX/g' | sed -E 's/deployKey=[a-zA-Z0-9\-]+/deployKey=XXXXX/g' | sed -E 's/apiKey=[a-zA-Z0-9\-]+/apiKey=XXXXX/g')
             fi
 
-            echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+            echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
             if [[ $($SUDO helm upgrade $ARGS) ]]; then
             else
@@ -673,13 +678,13 @@ install:
             fi
             if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
               echo "${POD_NAME} pod is not starting" >&2
-              echo "{\"Metadata\":{\"InstallationError\":\"${POD_NAME} pod is not starting\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+              echo "{\"Metadata\":{\"InstallationError\":\"${POD_NAME} pod is not starting\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
               exit 33
             fi
             sleep 2
           done
 
-          echo "{\"Metadata\":{\"helmVersion\":\"$HELM_VERSION\", \"helmCommand\":\"$HELM_COMMAND\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+          echo "{\"Metadata\":{\"helmVersion\":\"$HELM_VERSION\", \"helmCommand\":\"$HELM_COMMAND\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
 
           # Set the color variables for post install message
           green='\033[0;32m'

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -175,8 +175,8 @@ install:
           fi
 
           # Due to nr cli limitation, we can only send the last echo message to backend.
-          # FINAL_MESSAGE is used to collect all necessary debug info we need.
-          FINAL_MESSAGE=""
+          # DEBUG_MESSAGE is used to collect all necessary debug info we need.
+          DEBUG_MESSAGE=""
 
           # Determine the cluster name if not provided
           CLUSTER=$($SUDO $KUBECTL config current-context 2>/dev/null || echo "unknown")
@@ -269,7 +269,7 @@ install:
           if [[ "$NAMESPACE_EXISTS" != "true" && "$CAN_CREATE_NAMESPACE" != "yes" ]]; then
             echo "The ${NR_CLI_NAMESPACE} namespace does not exist and you don't have permissions to create a new namespace." >&2
             echo "Use an existing namespace or obtain permissions to create a new namespace." >&2
-            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+            echo "{\"Metadata\":{\"InstallationError\":\"${NR_CLI_NAMESPACE} Namespace does not exist and you don't have permissions to create a new namespace\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 1
           fi
 
@@ -327,7 +327,7 @@ install:
             if [[ "$PIXIE_SUPPORTED" != "true" ]]; then
               echo "This type of Kubernetes cluster is not supported by Pixie: GKE, EKS, AKS, Minikube, k3s, and k0s are supported." >&2
               echo -e "\033[0;31mTurning off Pixie for this installation\033[0m" >&2
-              FINAL_MESSAGE="Pixie is unsupported due to k8s version - ${K8S_VERSION}; ${FINAL_MESSAGE}"
+              DEBUG_MESSAGE="Pixie is unsupported due to k8s version - ${K8S_VERSION}; ${DEBUG_MESSAGE}"
             fi
 
             if $SUDO $KUBECTL get namespace olm 1>/dev/null 2>&1; then
@@ -451,7 +451,7 @@ install:
             GREEN='\033[0;32m'
             NC='\033[0m'
             if $SUDO helm list --all-namespaces | grep nri-bundle > /dev/null 2>&1; then
-              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"Yes\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               while :; do
                 echo -e -n "${GREEN}Detected a previously installed New Relic Kubernetes integration on cluster, uninstall first? (Uninstallation is recommended, default: Y) Y/N? ${NC} "
                 if [[ "{{.NEW_RELIC_ASSUME_YES}}" == "true" ]]; then
@@ -466,20 +466,20 @@ install:
                 fi
                 if [[ "$UNINSTALL_ANSWER" == "N" ]]; then
                   echo "Attempting install over existing integration."
-                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"No\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   break
                 fi
                 if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then
                   RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
                   RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
-                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                  echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
                   break
                 fi
                 echo -e "Please type Y or N only."
               done
             else
-              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"No\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo "{\"Metadata\":{\"previousNriBundleDetected\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
             fi
 
             if [[ $($SUDO helm repo add newrelic https://helm-charts.newrelic.com) ]]; then
@@ -553,7 +553,7 @@ install:
               CLEANED_ARGS=$(echo $ARGS | sed -E 's/licenseKey=[a-zA-Z0-9\-]+/licenseKey=XXXXX/g' | sed -E 's/deployKey=[a-zA-Z0-9\-]+/deployKey=XXXXX/g' | sed -E 's/apiKey=[a-zA-Z0-9\-]+/apiKey=XXXXX/g')
             fi
 
-            echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+            echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
             if [[ $($SUDO helm upgrade $ARGS) ]]; then
             else
@@ -678,13 +678,13 @@ install:
             fi
             if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
               echo "${POD_NAME} pod is not starting" >&2
-              echo "{\"Metadata\":{\"InstallationError\":\"${POD_NAME} pod is not starting\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+              echo "{\"Metadata\":{\"InstallationError\":\"${POD_NAME} pod is not starting\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
               exit 33
             fi
             sleep 2
           done
 
-          echo "{\"Metadata\":{\"helmVersion\":\"$HELM_VERSION\", \"helmCommand\":\"$HELM_COMMAND\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"FinalMessage\":\"$FinalMessage\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+          echo "{\"Metadata\":{\"helmVersion\":\"$HELM_VERSION\", \"helmCommand\":\"$HELM_COMMAND\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
 
           # Set the color variables for post install message
           green='\033[0;32m'


### PR DESCRIPTION
# Description

A customer complains that his k8s cluster version is not supported by Pixie. So we need to collect exact which k8s version he has for debugging purpose.

# Changes

Due to nr cli limitation, we can only send the last echo message to backend. DEBUG_MESSAGE is used to collect all necessary debug info we need, not only for this Pixie issue, but for future issues. 
This DEBUG_MESSAGE is output as Metadata whenever the script exit

# Tests Have Been Done

I have run the follow commands locally to test the new changes does not break the existing installation recipe

newrelic profiles add --profile jerry --apiKey -r us
newrelic profiles default --profile jerry

NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_CLUSTERNAME=k8scluster117 NR_CLI_NAMESPACE=newrelic NR_CLI_PRIVILEGED=true NR_CLI_LOW_DATA_MODE=true NR_CLI_KSM=true NR_CLI_KUBE_EVENTS=true NR_CLI_PROMETHEUS_AGENT=true NR_CLI_PROMETHEUS_AGENT_LOW_DATA_MODE=true NR_CLI_CURATED=false NR_CLI_NEWRELIC_PIXIE=true NR_CLI_PIXIE_API_KEY= NR_CLI_PIXIE=true NR_CLI_PIXIE_DEPLOY_KEY= NEW_RELIC_API_KEY= NEW_RELIC_ACCOUNT_ID=3808497 /usr/local/bin/newrelic install -c /Users/xqi/Documents/GitHub/open-install-library/recipes/newrelic/infrastructure/kubernetes.yml

![image](https://user-images.githubusercontent.com/125097052/223868881-45c4129b-d3c3-4666-96a7-fb447a60ef4b.png)
