### PR TITLE
Let Error Message Return for Helm Upgrade Install

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -563,7 +563,7 @@ install:
             ERROR=$($SUDO helm upgrade $ARGS)
             if [[ $? != 0 ]]; then
               if [[ "${ERROR}" != "" ]]; then
-                echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
+                echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
               else 
                 echo "helm (version $HELM_VERSION) repo upgrade installation failed."
               fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -561,8 +561,12 @@ install:
             echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
             ERROR=$($SUDO helm upgrade $ARGS)
-            if [[ $? != 0 && "${ERROR}" != "" ]]; then
-              echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
+            if [[ $? != 0 ]]; then
+              if [[ "${ERROR}" != "" ]]; then
+                echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
+              else 
+                echo "helm (version $HELM_VERSION) repo upgrade installation failed."
+              fi
               exit 131
             fi
           else

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -560,9 +560,9 @@ install:
 
             echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
-            if [[ $($SUDO helm upgrade $ARGS) ]]; then
-            else
-              echo “ERROR $? returned from: $SUDO helm upgrade $CLEANED_ARGS”
+            ERROR=$($SUDO helm upgrade $ARGS)
+            if [[ $? != 0 && "${ERROR}" != "" ]]; then
+              echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
               exit 131
             fi
           else


### PR DESCRIPTION
# Description
In installation recipe, only the last echo message is sent to backend.

This [line of code](https://github.com/newrelic/open-install-library/blob/63ff51e93a8ffec8f68577b14e3fa753a2dcc8b8/recipes/newrelic/infrastructure/kubernetes.yml#L555) actually rewrites the error message so we do not get what exact error message is.

# Changes

modify this part of code to send the actually error message together with the helm version to backend

# Tests 
I test the modified script with the following commands on K8s 1.17 and 1.26 with and without nri-bundle preinstalled.

All the testing installation succeeded

```
xqi@TFXCKKXMP9 newrelic-cli_0.65.1_Darwin_arm64 % NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_CLUSTERNAME=k8scluster117 NR_CLI_NAMESPACE=newrelic NR_CLI_PRIVILEGED=true NR_CLI_LOW_DATA_MODE=true NR_CLI_KSM=true NR_CLI_KUBE_EVENTS=true NR_CLI_PROMETHEUS_AGENT=true NR_CLI_PROMETHEUS_AGENT_LOW_DATA_MODE=true NR_CLI_CURATED=false NR_CLI_NEWRELIC_PIXIE=true NR_CLI_PIXIE_API_KEY=XXX NR_CLI_PIXIE=true NR_CLI_PIXIE_DEPLOY_KEY=XXX NEW_RELIC_API_KEY=XXX NEW_RELIC_ACCOUNT_ID=XXX ./newrelic install -c /Users/xqi/Documents/GitHub/open-install-library/recipes/newrelic/infrastructure/kubernetes.yml
```
I also printout the $? value with and without nri-bundle preinstalled. In both cases, the value is 0

