### PR TITLE
fix(php): rolled tmp file creation into assert_pre_req task

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -126,10 +126,9 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_shared
+        - task: assert_pre_req
         - task: user_input
         - task: verify_continue
-        - task: assert_pre_req
         - task: clean_slate
         - task: detect_services
         - task: update_apt
@@ -144,12 +143,58 @@ install:
         - task: send_transaction
         - task: cleanup_temp_files
 
-    create_shared:
+    assert_pre_req:
       cmds:
         - |
+          if [ -z "$SUDO_USER" ]; then
+            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent must be run under sudo.{{.NOCOLOR}}" >> /dev/stderr
+            exit 7
+          fi
+        - |
+          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+          then
+            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'.{{.NOCOLOR}}" >> /dev/stderr
+            exit 20
+          fi
+        - |
+          # Map of tool names to the associated error code
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:131 apt-get:131"
+
+          for tuple in $required_tools_and_error_codes; do
+            tool=$(echo ${tuple} |cut -d':' -f1)
+            code=$(echo ${tuple} |cut -d':' -f2)
+
+            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+            then
+              echo -e "{{.RED}}This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed.{{.NOCOLOR}}" >> /dev/stderr
+              exit ${code}
+            fi
+          done
+        - |
+          # check if /tmp is mounted noexec
+          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+          if [ ! -z "${tmp_is_noexec}" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+            exit 131
+          fi
+        - |
+          # need directory for extra repositories to exist
+          if [ ! -d "/etc/apt/sources.list.d/" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires the directory /etc/apt/sources.list.d to exist."
+            exit 131
+          fi
+        - |
+          # check if we have permissions to manipulate /tmp          
           rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
-          mkdir -p {{.TMP_INSTALL_DIR}}
-          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
+          RM_STATUS=$?
+          mkdir -p {{.TMP_INSTALL_DIR}} 2>/dev/null
+          MKDIR_STATUS=$?
+          if [ $RM_STATUS -ne 0 ] || [ $MKDIR_STATUS -ne 0 ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires write permissions to /tmp. "
+            exit 131
+          fi          
 
     user_input:
       cmds:
@@ -219,48 +264,6 @@ install:
             done
           fi
 
-    assert_pre_req:
-      cmds:
-        - |
-          if [ -z "$SUDO_USER" ]; then
-            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent must be run under sudo.{{.NOCOLOR}}" >> /dev/stderr
-            exit 7
-          fi
-        - |
-          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
-          then
-            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'.{{.NOCOLOR}}" >> /dev/stderr
-            exit 20
-          fi
-        - |
-          # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:131 apt-get:131"
-
-          for tuple in $required_tools_and_error_codes; do
-            tool=$(echo ${tuple} |cut -d':' -f1)
-            code=$(echo ${tuple} |cut -d':' -f2)
-
-            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
-            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
-            then
-              echo -e "{{.RED}}This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed.{{.NOCOLOR}}" >> /dev/stderr
-              exit ${code}
-            fi
-          done
-        - |
-          # check if /tmp is mounted noexec
-          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
-          if [ ! -z "${tmp_is_noexec}" ]; then
-            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
-            exit 131
-          fi
-        - |
-          # need directory for extra repositories to exist
-          if [ ! -d "/etc/apt/sources.list.d/" ]; then
-            echo "This installation recipe for the New Relic PHP Agent on Linux requires the directory /etc/apt/sources.list.d to exist."
-            exit 131
-          fi
 
     clean_slate:
       cmds:

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -118,10 +118,9 @@ install:
   tasks:
     default:
       cmds:
-        - task: create_shared
+        - task: assert_pre_req
         - task: user_input
         - task: verify_continue
-        - task: assert_pre_req
         - task: clean_slate
         - task: detect_services
         - task: add_gnupg2_curl_if_required
@@ -132,12 +131,52 @@ install:
         - task: send_transaction
         - task: cleanup_temp_files
 
-    create_shared:
+    assert_pre_req:
       cmds:
         - |
+          if [ -z "$SUDO_USER" ]; then
+            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent must be run under sudo.{{.NOCOLOR}}" >> /dev/stderr
+            exit 7
+          fi
+        - |
+          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
+          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
+          then
+            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'.{{.NOCOLOR}}" >> /dev/stderr
+            exit 20
+          fi
+        - |
+          # Map of tool names to the associated error code
+          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:22 yum:22"
+
+          for tuple in $required_tools_and_error_codes; do
+            tool=$(echo ${tuple} |cut -d':' -f1)
+            code=$(echo ${tuple} |cut -d':' -f2)
+
+            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
+            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
+            then
+              echo -e "{{.RED}}This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed.{{.NOCOLOR}}" >> /dev/stderr
+              exit ${code}
+            fi
+          done
+        - |
+          # check if /tmp is mounted noexec
+          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
+          if [ ! -z "${tmp_is_noexec}" ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
+            exit 131
+          fi
+        - |
+          # check if we have permissions to manipulate /tmp          
           rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
-          mkdir -p {{.TMP_INSTALL_DIR}}
-          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
+          RM_STATUS=$?
+          mkdir -p {{.TMP_INSTALL_DIR}} 2>/dev/null
+          MKDIR_STATUS=$?
+          if [ $RM_STATUS -ne 0 ] || [ $MKDIR_STATUS -ne 0 ]; then
+            echo "This installation recipe for the New Relic PHP Agent on Linux requires write permissions to /tmp. "
+            exit 131
+          fi          
 
     user_input:
       cmds:
@@ -207,42 +246,6 @@ install:
             done
           fi
 
-    assert_pre_req:
-      cmds:
-        - |
-          if [ -z "$SUDO_USER" ]; then
-            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent must be run under sudo.{{.NOCOLOR}}" >> /dev/stderr
-            exit 7
-          fi
-        - |
-          IS_SYSTEMCTL_INSTALLED=$(which systemctl | wc -l)
-          if [ "$IS_SYSTEMCTL_INSTALLED" -eq 0 ]
-          then
-            echo -e "{{.RED}}This installation recipe for the New Relic PHP agent only supports services managed by 'systemd'.{{.NOCOLOR}}" >> /dev/stderr
-            exit 20
-          fi
-        - |
-          # Map of tool names to the associated error code
-          required_tools_and_error_codes="grep:10 sed:11 awk:12 egrep:10 curl:22 mount:131 php:22 yum:22"
-
-          for tuple in $required_tools_and_error_codes; do
-            tool=$(echo ${tuple} |cut -d':' -f1)
-            code=$(echo ${tuple} |cut -d':' -f2)
-
-            IS_TOOL_INSTALLED=$(which ${tool} | wc -l)
-            if [ "$IS_TOOL_INSTALLED" -eq 0 ]
-            then
-              echo -e "{{.RED}}This installation recipe for the New Relic PHP Agent on Linux requires '${tool}' to be installed.{{.NOCOLOR}}" >> /dev/stderr
-              exit ${code}
-            fi
-          done
-        - |
-          # check if /tmp is mounted noexec
-          tmp_is_noexec=$(mount| egrep ".*on /tmp.*,noexec,.*$")
-          if [ ! -z "${tmp_is_noexec}" ]; then
-            echo "This installation recipe for the New Relic PHP Agent on Linux requires /tmp to not be mounted noexec."
-            exit 131
-          fi
 
     clean_slate:
       cmds:

--- a/test/definitions/apm/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/php-apache-fpm-wordpress-ubuntu18.json
@@ -1,0 +1,46 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "php-a-f-w-u18",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "services": [
+    {
+      "id": "wordpress",
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/php/apache-fpm-wordpress/debian/roles",
+      "port": 80,
+      "destinations": [
+        "php-a-f-w-u18"
+      ]
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "instrumentation1",
+        "resource_ids": [
+          "php-a-f-w-u18"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml",
+          "validate_output": "New Relic installation complete"
+        }
+      }
+    ]
+  }
+}

--- a/test/definitions/apm/php-nginx-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/php-nginx-fpm-wordpress-linux2.json
@@ -1,0 +1,46 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "php-n-f-w-l2",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "amazonlinux-2-base*",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "wordpress",
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/php/nginx-fpm-wordpress/redhat/roles",
+      "port": 80,
+      "destinations": [
+        "php-n-f-w-l2"
+      ]
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "instrumentation1",
+        "resource_ids": [
+          "php-n-f-w-l2"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml",
+          "validate_output": "New Relic installation complete"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Moved our /tmp/newrelic-php-agent directory removal/creation to assert_pre_req in order to:
1 - check permissions for rm and mkdir on /tmp
2- return 131 (UNSUPPORTED) if permissions aren't high enough to manipulate said tmp location