### PR TITLE
PHP recipe application name

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -208,19 +208,22 @@ install:
             read -r APPLICATION_RESTART
             APPLICATION_RESTART=${APPLICATION_RESTART:-y}
 
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_RESTART" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
           # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
-            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$NEW_RELIC_APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "y" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
     verify_continue:
       cmds:
         - |
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            read -r APPLICATION_NAME < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            read -r APPLICATION_RESTART < <(tail -n 1 "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}")
           else
             APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
             APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
@@ -230,7 +233,8 @@ install:
             if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
               rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
             fi
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_RESTART" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
@@ -486,7 +490,7 @@ install:
           # files.
           #
 
-          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
+          read -r APPLICATION_NAME < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           INI_DIRS=($WEB_INI_DIR $CLI_INI_DIR)
           for dirs in $INI_DIRS; do
             for ini in $dirs; do
@@ -529,7 +533,7 @@ install:
                 APPLICATION_NAME=${APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
               fi
 
-              sed -i "s/newrelic.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
+              sed -i "s/newrelic.appname = \"[^\"]*\"/newrelic.appname = \"${APPLICATION_NAME}\"/" $ini_full_name
               if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
                 sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
                 sed -i 's/;newrelic.loglevel = "info"/newrelic.loglevel = "verbosedebug"/' $ini_full_name
@@ -595,7 +599,7 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
+          read -r APPLICATION_RESTART < <(tail -n 1 "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}")
           if [ "$APPLICATION_RESTART" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -105,14 +105,6 @@ preInstall:
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
-inputVars:
-  - name: "NEW_RELIC_APPLICATION_NAME"
-    prompt: "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name)"
-    default: "PHP Application"
-  - name: "NEW_RELIC_APPLICATION_RESTART"
-    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
-    default: "y"
-
 install:
   version: "3"
   silent: true
@@ -135,9 +127,9 @@ install:
     default:
       cmds:
         - task: assert_pre_req
+        - task: user_input
         - task: verify_continue
         - task: clean_slate
-        - task: create_shared
         - task: detect_services
         - task: update_apt
         - task: add_gnupg2_if_required
@@ -204,12 +196,46 @@ install:
             exit 131
           fi          
 
+    user_input:
+      cmds:
+        - |
+          # Interactive install with NEW_RELIC_APPLICATION_NAME envar unset, prompts user input
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && -z "$NEW_RELIC_APPLICATION_NAME" ]]; then
+            printf "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name) "
+            read -r APPLICATION_NAME
+
+            printf "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+            read -r APPLICATION_RESTART
+            APPLICATION_RESTART=${APPLICATION_RESTART:-y}
+
+            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
+          # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
+            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
     verify_continue:
       cmds:
         - |
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
+            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          else
+            APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
+            APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
+
+            # Remove '{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}' and re-create it again with
+            # new values to make them available in next tasks.
+            if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
+              rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
+            fi
+            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
-          echo -e "* The following application name was selected: {{.NEW_RELIC_APPLICATION_NAME}}"
-          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]; then
+          echo -e "* The following application name was selected: $APPLICATION_NAME"
+          if [ "$APPLICATION_RESTART" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation will restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
           else
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation will not automatically restart the apache, php-fpm, or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
@@ -238,6 +264,7 @@ install:
             done
           fi
 
+
     clean_slate:
       cmds:
         - |
@@ -247,13 +274,6 @@ install:
           #
           killall -q newrelic-daemon || true
           rm -rf /var/log/newrelic 2>/dev/null
-
-    create_shared:
-      cmds:
-        - |
-          rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
-          mkdir -p {{.TMP_INSTALL_DIR}}
-          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
 
     detect_services:
       cmds:
@@ -466,6 +486,7 @@ install:
           # files.
           #
 
+          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
           INI_DIRS=($WEB_INI_DIR $CLI_INI_DIR)
           for dirs in $INI_DIRS; do
             for ini in $dirs; do
@@ -498,11 +519,15 @@ install:
                 continue
               fi
 
-              ESCAPED_APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
-              # '\' replacement needs to be first so as to not replace the escaping '\'s added later
-              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
-              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
-              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
+              # Default aplication name, if APPLICATION_NAME have not been set so far
+              if [ -z "$APPLICATION_NAME" ]; then
+                APPLICATION_NAME="PHP Application"
+              else
+                # '\' replacement needs to be first so as to not replace the escaping '\'s added later
+                APPLICATION_NAME=${APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
+                APPLICATION_NAME=${APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
+                APPLICATION_NAME=${APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
+              fi
 
               sed -i "s/newrelic.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
               if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -570,7 +595,8 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
+          if [ "$APPLICATION_RESTART" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
             echo -e "{{.YELLOW}}Restarting $process as privileged user $user_name{{.GRAY}}"

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -504,7 +504,7 @@ install:
               ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
               ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
 
-              sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
+              sed -i "s/newrelic.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
               if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
                 sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
                 sed -i 's/;newrelic.loglevel = "info"/newrelic.loglevel = "verbosedebug"/' $ini_full_name

--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -105,6 +105,14 @@ preInstall:
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
+inputVars:
+  - name: "NEW_RELIC_APPLICATION_NAME"
+    prompt: "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name)"
+    default: "PHP Application"
+  - name: "NEW_RELIC_APPLICATION_RESTART"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+    default: "y"
+
 install:
   version: "3"
   silent: true
@@ -127,9 +135,9 @@ install:
     default:
       cmds:
         - task: assert_pre_req
-        - task: user_input
         - task: verify_continue
         - task: clean_slate
+        - task: create_shared
         - task: detect_services
         - task: update_apt
         - task: add_gnupg2_if_required
@@ -196,46 +204,12 @@ install:
             exit 131
           fi          
 
-    user_input:
-      cmds:
-        - |
-          # Interactive install with NEW_RELIC_APPLICATION_NAME envar unset, prompts user input
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && -z "$NEW_RELIC_APPLICATION_NAME" ]]; then
-            printf "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name) "
-            read -r APPLICATION_NAME
-
-            printf "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
-            read -r APPLICATION_RESTART
-            APPLICATION_RESTART=${APPLICATION_RESTART:-y}
-
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
-          # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
-            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
     verify_continue:
       cmds:
         - |
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          else
-            APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
-            APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
-
-            # Remove '{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}' and re-create it again with
-            # new values to make them available in next tasks.
-            if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
-              rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
-            fi
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
-          echo -e "* The following application name was selected: $APPLICATION_NAME"
-          if [ "$APPLICATION_RESTART" = "y" ]; then
+          echo -e "* The following application name was selected: {{.NEW_RELIC_APPLICATION_NAME}}"
+          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation will restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
           else
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation will not automatically restart the apache, php-fpm, or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
@@ -264,7 +238,6 @@ install:
             done
           fi
 
-
     clean_slate:
       cmds:
         - |
@@ -274,6 +247,13 @@ install:
           #
           killall -q newrelic-daemon || true
           rm -rf /var/log/newrelic 2>/dev/null
+
+    create_shared:
+      cmds:
+        - |
+          rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
+          mkdir -p {{.TMP_INSTALL_DIR}}
+          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
 
     detect_services:
       cmds:
@@ -486,7 +466,6 @@ install:
           # files.
           #
 
-          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
           INI_DIRS=($WEB_INI_DIR $CLI_INI_DIR)
           for dirs in $INI_DIRS; do
             for ini in $dirs; do
@@ -519,17 +498,13 @@ install:
                 continue
               fi
 
-              # Default aplication name, if APPLICATION_NAME have not been set so far
-              if [ -z "$APPLICATION_NAME" ]; then
-                APPLICATION_NAME="PHP Application"
-              else
-                # '\' replacement needs to be first so as to not replace the escaping '\'s added later
-                APPLICATION_NAME=${APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
-                APPLICATION_NAME=${APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
-                APPLICATION_NAME=${APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
-              fi
+              ESCAPED_APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
+              # '\' replacement needs to be first so as to not replace the escaping '\'s added later
+              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
+              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
+              ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
 
-              sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${APPLICATION_NAME}\"/" $ini_full_name
+              sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
               if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
                 sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
                 sed -i 's/;newrelic.loglevel = "info"/newrelic.loglevel = "verbosedebug"/' $ini_full_name
@@ -595,8 +570,7 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
-          if [ "$APPLICATION_RESTART" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]  && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
             echo -e "{{.YELLOW}}Restarting $process as privileged user $user_name{{.GRAY}}"

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -434,7 +434,7 @@ install:
             ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
 
 
-            sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
+            sed -i "s/newrelic\.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
             fi

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -97,6 +97,14 @@ preInstall:
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
+inputVars:
+  - name: "NEW_RELIC_APPLICATION_NAME"
+    prompt: "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name)"
+    default: "PHP Application"
+  - name: "NEW_RELIC_APPLICATION_RESTART"
+    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+    default: "y"
+
 install:
   version: "3"
   silent: true
@@ -111,17 +119,14 @@ install:
     NOCOLOR: '\033[0m'
     YELLOW: '\033[0;33m'
     ARROW: '\033[0;36m===> \033[0;97m'
-    NEW_RELIC_APPLICATION_NAME: '{{.NEW_RELIC_APPLICATION_NAME}}'
-    NEW_RELIC_APPLICATION_RESTART: 'y'
-    USER_INPUT: 'user_input.txt'
 
   tasks:
     default:
       cmds:
         - task: assert_pre_req
-        - task: user_input
         - task: verify_continue
         - task: clean_slate
+        - task: create_shared
         - task: detect_services
         - task: add_gnupg2_curl_if_required
         - task: install_tarball
@@ -178,46 +183,12 @@ install:
             exit 131
           fi          
 
-    user_input:
-      cmds:
-        - |
-          # Interactive install with NEW_RELIC_APPLICATION_NAME envar unset, prompts user input
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && -z "$NEW_RELIC_APPLICATION_NAME" ]]; then
-            printf "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name) "
-            read -r APPLICATION_NAME
-
-            printf "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
-            read -r APPLICATION_RESTART
-            APPLICATION_RESTART=${APPLICATION_RESTART:-y}
-
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
-          # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
-            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
     verify_continue:
       cmds:
         - |
-          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          else
-            APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
-            APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
-
-            # Remove '{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}' and re-create it again with
-            # new values to make them available in next tasks.
-            if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
-              rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
-            fi
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
-          fi
-
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
-          echo -e "* The following application name was selected: $APPLICATION_NAME"
-          if [ "$APPLICATION_RESTART" = "y" ]; then
+          echo -e "* The following application name was selected: {{.NEW_RELIC_APPLICATION_NAME}}"
+          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation WILL restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
           else
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the apache, php-fpm, or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
@@ -246,7 +217,6 @@ install:
             done
           fi
 
-
     clean_slate:
       cmds:
         - |
@@ -256,6 +226,13 @@ install:
           #
           killall -q newrelic-daemon || true
           rm -rf /var/log/newrelic 2>/dev/null
+
+    create_shared:
+      cmds:
+        - |
+          rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
+          mkdir -p {{.TMP_INSTALL_DIR}}
+          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
 
     detect_services:
       cmds:
@@ -444,24 +421,20 @@ install:
           # Loop through all the directories where the installation placed `newrelic.ini`
           # files.
           #
-          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
           for ini in $WEB_INI_DIR $CLI_INI_DIR; do
             ini_full_name="${ini}/newrelic.ini"
             if [ ! -f "$ini_full_name" ]; then
               continue
             fi
 
-            # Default aplication name, if APPLICATION_NAME have not been set so far
-            if [ -z "$APPLICATION_NAME" ]; then
-              APPLICATION_NAME="PHP Application"
-            else
-              # '\' replacement needs to be first so as to not replace the escaping '\'s added later
-              APPLICATION_NAME=${APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
-              APPLICATION_NAME=${APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
-              APPLICATION_NAME=${APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
-            fi
+            ESCAPED_APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
+            # '\' replacement needs to be first so as to not replace the escaping '\'s added later
+            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
+            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
+            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
 
-            sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${APPLICATION_NAME}\"/" $ini_full_name
+
+            sed -i "s/newrelic.appname = \"PHP Application\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
             fi
@@ -486,8 +459,7 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
-          if [ "$APPLICATION_RESTART" = "y" ] && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ] && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
             echo -e "{{.YELLOW}}Restarting $process as privileged user $user_name{{.GRAY}}"

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -190,19 +190,22 @@ install:
             read -r APPLICATION_RESTART
             APPLICATION_RESTART=${APPLICATION_RESTART:-y}
 
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_RESTART" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
           # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
-            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$NEW_RELIC_APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "y" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
     verify_continue:
       cmds:
         - |
           if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
-            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            read -r APPLICATION_NAME < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            read -r APPLICATION_RESTART < <(tail -n 1 "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}")
           else
             APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
             APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
@@ -212,7 +215,8 @@ install:
             if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
               rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
             fi
-            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_NAME" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+            echo "$APPLICATION_RESTART" >> "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           fi
 
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
@@ -444,7 +448,7 @@ install:
           # Loop through all the directories where the installation placed `newrelic.ini`
           # files.
           #
-          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
+          read -r APPLICATION_NAME < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
           for ini in $WEB_INI_DIR $CLI_INI_DIR; do
             ini_full_name="${ini}/newrelic.ini"
             if [ ! -f "$ini_full_name" ]; then
@@ -462,7 +466,7 @@ install:
             fi
 
 
-            sed -i "s/newrelic\.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
+            sed -i "s/newrelic\.appname = \"[^\"]*\"/newrelic.appname = \"${APPLICATION_NAME}\"/" $ini_full_name
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               sed -i 's/;newrelic.daemon.collector_host = ""/newrelic.daemon.collector_host = "staging-collector.newrelic.com"/' $ini_full_name
             fi
@@ -487,7 +491,7 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
+          read -r APPLICATION_RESTART < <(tail -n 1 "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}")
           if [ "$APPLICATION_RESTART" = "y" ] && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"

--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -97,14 +97,6 @@ preInstall:
 
 validationNrql: "SELECT count(*) from Transaction WHERE host like '{{.HOSTNAME}}%' facet entityGuid since 10 minutes ago"
 
-inputVars:
-  - name: "NEW_RELIC_APPLICATION_NAME"
-    prompt: "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name)"
-    default: "PHP Application"
-  - name: "NEW_RELIC_APPLICATION_RESTART"
-    prompt: "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
-    default: "y"
-
 install:
   version: "3"
   silent: true
@@ -119,14 +111,17 @@ install:
     NOCOLOR: '\033[0m'
     YELLOW: '\033[0;33m'
     ARROW: '\033[0;36m===> \033[0;97m'
+    NEW_RELIC_APPLICATION_NAME: '{{.NEW_RELIC_APPLICATION_NAME}}'
+    NEW_RELIC_APPLICATION_RESTART: 'y'
+    USER_INPUT: 'user_input.txt'
 
   tasks:
     default:
       cmds:
         - task: assert_pre_req
+        - task: user_input
         - task: verify_continue
         - task: clean_slate
-        - task: create_shared
         - task: detect_services
         - task: add_gnupg2_curl_if_required
         - task: install_tarball
@@ -183,12 +178,46 @@ install:
             exit 131
           fi          
 
+    user_input:
+      cmds:
+        - |
+          # Interactive install with NEW_RELIC_APPLICATION_NAME envar unset, prompts user input
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && -z "$NEW_RELIC_APPLICATION_NAME" ]]; then
+            printf "What is the name of your PHP application? (Double-quote (\") is not a valid character in the name) "
+            read -r APPLICATION_NAME
+
+            printf "Restart the PHP web service after PHP agent installation? Selecting 'y' will automatically restart php-fpm, nginx, or apache depending on the service that is detected. Selecting 'n' will require you to manually restart the process when prompted. (y/n)"
+            read -r APPLICATION_RESTART
+            APPLICATION_RESTART=${APPLICATION_RESTART:-y}
+
+            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
+          # Interactive install with NEW_RELIC_APPLICATION_NAME envar set, uses envar and also defaults to service restart
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" && ! -z $NEW_RELIC_APPLICATION_NAME ]]; then
+            echo "$NEW_RELIC_APPLICATION_NAME y" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
     verify_continue:
       cmds:
         - |
+          if [[ "{{.NEW_RELIC_ASSUME_YES}}" != "true" ]]; then
+            read -r APPLICATION_NAME APPLICATION_RESTART < "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          else
+            APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
+            APPLICATION_RESTART="{{.NEW_RELIC_APPLICATION_RESTART}}"
+
+            # Remove '{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}' and re-create it again with
+            # new values to make them available in next tasks.
+            if [ -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" ]; then
+              rm -f "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" 2>/dev/null
+            fi
+            echo "$APPLICATION_NAME $APPLICATION_RESTART" > "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}"
+          fi
+
           echo -e "{{.WHITE}}Confirmation:  The following options were selected.  If you wish to change an option, please select 'n' at the prompt and restart the installation."
-          echo -e "* The following application name was selected: {{.NEW_RELIC_APPLICATION_NAME}}"
-          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ]; then
+          echo -e "* The following application name was selected: $APPLICATION_NAME"
+          if [ "$APPLICATION_RESTART" = "y" ]; then
             echo -e "{{.YELLOW}}* Automatic process restart was selected.  This installation WILL restart the php-fpm or nginx process depending on the application architecture detected.{{.NOCOLOR}}"
           else
             echo -e "{{.YELLOW}}* Manual process restart was selected.  This installation WILL NOT automatically restart the apache, php-fpm, or nginx process depending on the application architecture detected.  You will be prompted to restart manually in order to complete a successful installation of the PHP agent.{{.NOCOLOR}}"
@@ -217,6 +246,7 @@ install:
             done
           fi
 
+
     clean_slate:
       cmds:
         - |
@@ -226,13 +256,6 @@ install:
           #
           killall -q newrelic-daemon || true
           rm -rf /var/log/newrelic 2>/dev/null
-
-    create_shared:
-      cmds:
-        - |
-          rm -rf {{.TMP_INSTALL_DIR}} 2>/dev/null
-          mkdir -p {{.TMP_INSTALL_DIR}}
-          echo -e "{{.WHITE}}Temporary directory {{.TMP_INSTALL_DIR}} created{{.NOCOLOR}}"
 
     detect_services:
       cmds:
@@ -421,17 +444,22 @@ install:
           # Loop through all the directories where the installation placed `newrelic.ini`
           # files.
           #
+          APPLICATION_NAME=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f1 | xargs echo -n)
           for ini in $WEB_INI_DIR $CLI_INI_DIR; do
             ini_full_name="${ini}/newrelic.ini"
             if [ ! -f "$ini_full_name" ]; then
               continue
             fi
 
-            ESCAPED_APPLICATION_NAME="{{.NEW_RELIC_APPLICATION_NAME}}"
-            # '\' replacement needs to be first so as to not replace the escaping '\'s added later
-            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
-            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
-            ESCAPED_APPLICATION_NAME=${ESCAPED_APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
+            # Default aplication name, if APPLICATION_NAME have not been set so far
+            if [ -z "$APPLICATION_NAME" ]; then
+              APPLICATION_NAME="PHP Application"
+            else
+              # '\' replacement needs to be first so as to not replace the escaping '\'s added later
+              APPLICATION_NAME=${APPLICATION_NAME//\\/\\} # Replace every occurrence of '\' with "\\"
+              APPLICATION_NAME=${APPLICATION_NAME//\//\/} # Replace every occurrence of '/' with "\/"
+              APPLICATION_NAME=${APPLICATION_NAME//\&/\&} # Replace every occurrence of '&' with "\&"
+            fi
 
 
             sed -i "s/newrelic\.appname = \"[^\"]*\"/newrelic.appname = \"${ESCAPED_APPLICATION_NAME}\"/" $ini_full_name
@@ -459,7 +487,8 @@ install:
           # Case: apache only or nginx only, they respective service needs to be restarted.
           # This means only restart the first process in processes_to_restart.txt.
           #
-          if [ "{{.NEW_RELIC_APPLICATION_RESTART}}" = "y" ] && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
+          APPLICATION_RESTART=$(cat "{{.TMP_INSTALL_DIR}}/{{.USER_INPUT}}" | cut -d' ' -f2 | xargs echo -n)
+          if [ "$APPLICATION_RESTART" = "y" ] && [ -f "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt" ]; then
             cd {{.TMP_INSTALL_DIR}}
             read -r process user_name < "{{.TMP_INSTALL_DIR}}/processes_to_restart.txt"
             echo -e "{{.YELLOW}}Restarting $process as privileged user $user_name{{.GRAY}}"

--- a/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????.1",
+        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????.1",
+        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????.1",
+        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
         "user_name": "ubuntu"
     }],
 


### PR DESCRIPTION
Handles whitespace in the application name by writing the application name and restart value to separate lines in the temporary file. 

Also includes a change for the application name regex to detect for any value of `newrelic.appname` and not just "PHP Application", which fixes the long-standing behavior in redhat.yml which did not allow for multiple changes of `newrelic.appname`