### PR TITLE
Fix helm repo add error msg

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -489,7 +489,7 @@ install:
             if [[ $? != 0 ]]; then
               if [[ "${ERROR}" !=  "" ]]; then
                 echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
-              else 
+              else
                 echo "helm (version $HELM_VERSION) repo add failed."
               fi
               exit 131

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -486,8 +486,12 @@ install:
 
             HELM_VERSION="$($SUDO helm version -c --short)"
             ERROR=$($SUDO helm repo add newrelic https://helm-charts.newrelic.com)
-            if [[ "${ERROR}" != "" && "${ERROR}" != "\"newrelic\" already exists with the same configuration, skipping" ]]; then
-              echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
+            if [[ $? != 0 ]]; then
+              if [[ "${ERROR}" !=  "" ]]; then
+                echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
+              else 
+                echo "helm (version $HELM_VERSION) repo add failed."
+              fi
               exit 131
             fi
 


### PR DESCRIPTION
# Description
In installation recipe, when customer does not have repo newrelic installed, the script will exit due to a bug introduced in https://github.com/newrelic/open-install-library/pull/879
The error message is like `helm (version v3.11.2+g912ebc1) repo add failed due to: "newrelic" has been added to your repositories`
which should not lead to exist.

# Changes

modify the code to exit only when the helm repo add command results in non zero code

# Tests 
I test the modified script with the following commands on K8s 1.17 and 1.26 with and without nri-bundle preinstalled.

All the testing installation succeeded

```
xqi@TFXCKKXMP9 newrelic-cli_0.65.1_Darwin_arm64 % NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_CLUSTERNAME=k8scluster117 NR_CLI_NAMESPACE=newrelic NR_CLI_PRIVILEGED=true NR_CLI_LOW_DATA_MODE=true NR_CLI_KSM=true NR_CLI_KUBE_EVENTS=true NR_CLI_PROMETHEUS_AGENT=true NR_CLI_PROMETHEUS_AGENT_LOW_DATA_MODE=true NR_CLI_CURATED=false NR_CLI_NEWRELIC_PIXIE=true NR_CLI_PIXIE_API_KEY=XXX NR_CLI_PIXIE=true NR_CLI_PIXIE_DEPLOY_KEY=XXX NEW_RELIC_API_KEY=XXX NEW_RELIC_ACCOUNT_ID=XXX ./newrelic install -c /Users/xqi/Documents/GitHub/open-install-library/recipes/newrelic/infrastructure/kubernetes.yml
```
I also printout the $? value with and without newrelic repo pre-existed.  in both cases, the value is 0.

