### PR TITLE
Collect Nri Bundle Version And Failed Pod Info

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -690,6 +690,9 @@ install:
             fi
             if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
               echo "${POD_NAME} pod is not starting" >&2
+              POD_STATUS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $3}')
+              POD_RESTARTS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $4}')
+              DEBUG_MESSAGE="${POD_NAME} status - ${POD_STATUS}; ${POD_NAME} restarts - ${POD_RESTARTS}; ${DEBUG_MESSAGE}"
               echo "{\"Metadata\":{\"InstallationError\":\"${POD_NAME} pod is not starting\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
               exit 33
             fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -475,7 +475,7 @@ install:
                   RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
                   RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
                   BUNDLE_VERSION=$(helm list --all-namespaces | grep nri-bundle | awk '{print $9}')
-                  DEBUG_MESSAGE="nri-bundle version - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
+                  DEBUG_MESSAGE="nri-bundle version to uninstall - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
                   echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
                   break
@@ -690,6 +690,8 @@ install:
             fi
             if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
               echo "${POD_NAME} pod is not starting" >&2
+              BUNDLE_VERSION=$(helm list --all-namespaces | grep nri-bundle | awk '{print $9}')
+              DEBUG_MESSAGE="nri-bundle version to install - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
               POD_STATUS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $3}')
               POD_RESTARTS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $4}')
               DEBUG_MESSAGE="${POD_NAME} status - ${POD_STATUS}; ${POD_NAME} restarts - ${POD_RESTARTS}; ${DEBUG_MESSAGE}"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -691,7 +691,7 @@ install:
             if [ "$TRIES" -eq "$MAX_RETRIES" ]; then
               echo "${POD_NAME} pod is not starting" >&2
               BUNDLE_VERSION=$(helm list --all-namespaces | grep nri-bundle | awk '{print $9}')
-              DEBUG_MESSAGE="nri-bundle version to install - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
+              DEBUG_MESSAGE="nri-bundle version - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
               POD_STATUS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $3}')
               POD_RESTARTS=$($SUDO $KUBECTL get pods -o wide -n $NR_CLI_NAMESPACE | grep ${POD_NAME} | awk '{print $4}')
               DEBUG_MESSAGE="${POD_NAME} status - ${POD_STATUS}; ${POD_NAME} restarts - ${POD_RESTARTS}; ${DEBUG_MESSAGE}"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -474,6 +474,8 @@ install:
                 if [[ "$UNINSTALL_ANSWER" == "Y" ]]; then
                   RELEASE_NAME=$(helm list --all-namespaces | grep nri-bundle | awk '{print $1}')
                   RELEASE_NAMESPACE=$(helm list --all-namespaces | grep nri-bundle | awk '{print $2}')
+                  BUNDLE_VERSION=$(helm list --all-namespaces | grep nri-bundle | awk '{print $9}')
+                  DEBUG_MESSAGE="nri-bundle version - ${BUNDLE_VERSION}; ${DEBUG_MESSAGE}"
                   echo "{\"Metadata\":{\"uninstallNriBundleAnswer\":\"Yes\", \"helmUninstallCommand\":\"$SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                   $SUDO helm uninstall $RELEASE_NAME -n $RELEASE_NAMESPACE
                   break


### PR DESCRIPTION
# Description
- As new nri-bundles are released, we need to know which bundle version causes which issues. 
- When we see the error message like `execution failed for kubernetes-open-source-integration: exit status 33: {"Metadata":{"InstallationError":"nrk8s-kubelet pod is not starting", "K8sClientVersion":"1.26", "K8sServerVersion":"1.26"}}`, we need to know the exact pod status and how many restarts it has been went through.

# Changes

In this PR, I add the code to collect the nri-bundle version, failing pod status and restarts as part of the debugging info.
Any suggestion for other debug info to be collected are welcome

# Tests Have Been Done
I have run the follow commands locally to test the new changes does not break the existing installation recipe

NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_CLUSTERNAME=k8scluster117 NR_CLI_NAMESPACE=newrelic NR_CLI_PRIVILEGED=true NR_CLI_LOW_DATA_MODE=true NR_CLI_KSM=true NR_CLI_KUBE_EVENTS=true NR_CLI_PROMETHEUS_AGENT=true NR_CLI_PROMETHEUS_AGENT_LOW_DATA_MODE=true NR_CLI_CURATED=false NR_CLI_NEWRELIC_PIXIE=true NR_CLI_PIXIE_API_KEY=XXX NR_CLI_PIXIE=true NR_CLI_PIXIE_DEPLOY_KEY=XXX NEW_RELIC_API_KEY=XXX NEW_RELIC_ACCOUNT_ID=XXX /usr/local/bin/newrelic install -c /Users/xqi/Documents/GitHub/open-install-library/recipes/newrelic/infrastructure/kubernetes.yml

Here is an example of returned debug message

![Screenshot 2023-03-28 at 10 45 43 AM](https://user-images.githubusercontent.com/125097052/228324347-f244591a-cdc4-4737-8fb8-df7a3924d191.png)
