### PR TITLE
feat(ohi): infrastructure agent key validation

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -89,6 +89,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     write_recipe_metadata:
       cmds:
@@ -270,6 +271,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -64,6 +64,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     write_recipe_metadata:
       cmds:
@@ -252,6 +253,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -50,6 +50,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     assert_pre_req:
       cmds:
@@ -210,6 +211,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -70,6 +70,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     write_recipe_metadata:
       cmds:
@@ -334,6 +335,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -53,7 +53,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
@@ -45,7 +45,7 @@ logMatch:
     attributes:
       logtype: nginx-error
 
-validationNrql: "SELECT count(*) from NginxSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NginxSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -67,6 +67,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     write_recipe_metadata:
       cmds:
@@ -250,6 +251,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -73,6 +73,7 @@ install:
         - task: install_infra
         - task: restart
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     write_recipe_metadata:
       cmds:
@@ -310,6 +311,16 @@ install:
 
             sleep 2
           done
+
+    get_infra_key:
+      cmds:
+        - |
+          INFRA_KEY=$(curl http://localhost:18003/v1/status/entity -s | tr -d {}\" | sed -e 's/^.*key://')
+          if [ ! -z "$INFRA_KEY" ]; then
+            echo "{\"Metadata\":{\"INFRA_KEY\":\"$INFRA_KEY\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+          else
+            echo "empty infrastructure agent key"
+          fi
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -47,6 +47,7 @@ install:
         - task: install_infra
         - task: start_infra
         - task: assert_agent_status_ok
+        - task: get_infra_key
 
     assert_required_permissions:
       cmds:
@@ -150,7 +151,7 @@ install:
           if ($env:HTTPS_PROXY) {
             $WebClient.Proxy = New-Object System.Net.WebProxy($env:HTTPS_PROXY, $true)
           }
-          
+
           try {
             $WebClient.DownloadFile("{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/windows/newrelic-infra.msi", "$env:TEMP\newrelic-infra.msi")
           }
@@ -235,8 +236,8 @@ install:
       cmds:
         - |
           powershell -command '
-            Function isInfraRunning { 
-              (Get-Service newrelic-infra -ErrorAction SilentlyContinue | Select-Object Status).Status -eq "Running" 
+            Function isInfraRunning {
+              (Get-Service newrelic-infra -ErrorAction SilentlyContinue | Select-Object Status).Status -eq "Running"
             }
             $maxRetries = 150
             $tries = 0
@@ -282,15 +283,39 @@ install:
           $version = (Get-WmiObject -class Win32_OperatingSystem).Caption
           $metadata = @"
           {
-            "Metadata": 
+            "Metadata":
             {
                 "version": "$version"
             }
-          } 
+          }
           "@
-          try { 
-            $metadata | Set-Content {{.NR_CLI_OUTPUT}} 
+          try {
+            $metadata | Set-Content {{.NR_CLI_OUTPUT}}
           } catch {}
+          '
+
+    get_infra_key:
+      cmds:
+        - |
+          powershell -command '
+            $INFRA_KEY=Invoke-WebRequest -UseBasicParsing -Method Get -Uri http://localhost:18003/v1/status/entity | Select-Object -ExpandProperty Content;
+            $INFRA_KEY -match "i-.+[a-z0-9A-Z]";
+            $INFRA_KEY=$Matches[0];
+            if ($INFRA_KEY) {
+              $metadata = @"
+                {
+                  "Metadata":
+                  {
+                      "INFRA_KEY": "$INFRA_KEY"
+                  }
+                }
+              "@
+              try {
+                $metadata | Set-Content {{.NR_CLI_OUTPUT}}
+              } catch {}
+            } else {
+              Write-Host "empty infrastructure agent key"
+            }
           '
 
 postInstall:

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -47,7 +47,6 @@ install:
         - task: install_infra
         - task: start_infra
         - task: assert_agent_status_ok
-        - task: get_infra_key
 
     assert_required_permissions:
       cmds:
@@ -292,30 +291,6 @@ install:
           try {
             $metadata | Set-Content {{.NR_CLI_OUTPUT}}
           } catch {}
-          '
-
-    get_infra_key:
-      cmds:
-        - |
-          powershell -command '
-            $INFRA_KEY=Invoke-WebRequest -UseBasicParsing -Method Get -Uri http://localhost:18003/v1/status/entity | Select-Object -ExpandProperty Content;
-            $INFRA_KEY -match "i-.+[a-z0-9A-Z]";
-            $INFRA_KEY=$Matches[0];
-            if ($INFRA_KEY) {
-              $metadata = @"
-                {
-                  "Metadata":
-                  {
-                      "INFRA_KEY": "$INFRA_KEY"
-                  }
-                }
-              "@
-              try {
-                $metadata | Set-Content {{.NR_CLI_OUTPUT}}
-              } catch {}
-            } else {
-              Write-Host "empty infrastructure agent key"
-            }
           '
 
 postInstall:


### PR DESCRIPTION
This PR does the following:

- Enables the `infrastructure-agent-installer` to send new `INFRA_KEY` metadata after it is successfully installed on a host. The `newrelic-cli` receives this data and makes it available to the rest of the recipes to be installed after the `infrastructure-agent`.
- Updates the `validationNrql` to contain a `WHERE` clause that relies on the `INFRA_KEY`, for example:
```WHERE reportingAgent = '{{.INFRA_KEY}}'```

Changes has been so far scoped to: infra agents (except Windows), MySQL and NGINX for RHEL, pending on additional tests and team feedback.

Related: https://github.com/newrelic/newrelic-cli/pull/1440