### PR TITLE
Fix The CustomResourceDefinition Installation Error

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -658,8 +658,8 @@ install:
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then
-              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/helm/crds/olm_crd.yaml
-              $SUDO $KUBECTL apply -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml
+              $SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/helm/crds/olm_crd.yaml 2>/dev/null
+              $SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml 2>/dev/null
             fi
 
             # Clean up old nri-metadata-injection jobs if they exist

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -661,11 +661,13 @@ install:
               # only keep stderr in ERROR with 2>&1 >/dev/null; if the ERROR include any other than AlreadyExist, collect the ERROR in the DEBUG_MESSAGE
               ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/helm/crds/olm_crd.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
               if [[ "${ERROR}" != "" ]]; then
-                  DEBUG_MESSAGE="OLM CRD creation failed - ${ERROR}; ${DEBUG_MESSAGE}"
+                echo "{\"Metadata\":{\"InstallationError\":\"OLM CRD creation failed - ${ERROR}\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+                exit 33
               fi
                ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/crd/base/px.dev_viziers.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
               if [[ "${ERROR}" != "" ]]; then
-                  DEBUG_MESSAGE="OLM CRD creation failed - ${ERROR}; ${DEBUG_MESSAGE}"
+                echo "{\"Metadata\":{\"InstallationError\":\"PX DEV VIZIERS creation failed - ${ERROR}\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
+                exit 33
               fi
             fi
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -664,7 +664,7 @@ install:
                 echo "{\"Metadata\":{\"InstallationError\":\"OLM CRD creation failed - ${ERROR}\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
                 exit 33
               fi
-               ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/crd/base/px.dev_viziers.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
+              ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/crd/base/px.dev_viziers.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
               if [[ "${ERROR}" != "" ]]; then
                 echo "{\"Metadata\":{\"InstallationError\":\"PX DEV VIZIERS creation failed - ${ERROR}\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}
                 exit 33

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -449,7 +449,6 @@ install:
             echo ""
 
             KUBECTL_INSTALL=false
-
             # Check if nri-bundle already installed, ask customer if they want uninstall before re-installation, and then move forward.
             GREEN='\033[0;32m'
             NC='\033[0m'
@@ -658,8 +657,15 @@ install:
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then
-              $SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/helm/crds/olm_crd.yaml 2>/dev/null
-              $SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/main/k8s/operator/crd/base/px.dev_viziers.yaml 2>/dev/null
+              # only keep stderr with 2>&1 >/dev/null; if the error include any other than AlreadyExist, collect the error in the DEBUG_MESSAGE
+              ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/helm/crds/olm_crd.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
+              if [[ "${ERROR}" != "" ]]; then
+                  DEBUG_MESSAGE="OLM CRD creation failed - ${ERROR}; ${DEBUG_MESSAGE}"
+              fi
+               ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/crd/base/px.dev_viziers.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
+              if [[ "${ERROR}" != "" ]]; then
+                  DEBUG_MESSAGE="OLM CRD creation failed - ${ERROR}; ${DEBUG_MESSAGE}"
+              fi
             fi
 
             # Clean up old nri-metadata-injection jobs if they exist

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -657,7 +657,7 @@ install:
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then
-              # only keep stderr with 2>&1 >/dev/null; if the error include any other than AlreadyExist, collect the error in the DEBUG_MESSAGE
+              # only keep stderr in ERROR with 2>&1 >/dev/null; if the ERROR include any other than AlreadyExist, collect the ERROR in the DEBUG_MESSAGE
               ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/helm/crds/olm_crd.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
               if [[ "${ERROR}" != "" ]]; then
                   DEBUG_MESSAGE="OLM CRD creation failed - ${ERROR}; ${DEBUG_MESSAGE}"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -449,6 +449,7 @@ install:
             echo ""
 
             KUBECTL_INSTALL=false
+
             # Check if nri-bundle already installed, ask customer if they want uninstall before re-installation, and then move forward.
             GREEN='\033[0;32m'
             NC='\033[0m'

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -658,7 +658,7 @@ install:
             curl -s -H "Content-Type: application/json" -d "${BODY}" "${URL}" > $KUBECTL_YAML_DIR/newrelic-k8s.yml
 
             if [[ "${NR_CLI_PIXIE}" == "true" ]]; then
-              # only keep stderr in ERROR with 2>&1 >/dev/null; if the ERROR include any other than AlreadyExist, collect the ERROR in the DEBUG_MESSAGE
+              # only keep stderr in ERROR with 2>&1 >/dev/null; if the ERROR include any other than AlreadyExist, exit with the ERROR message
               ERROR=$($SUDO $KUBECTL create -f https://raw.githubusercontent.com/pixie-io/pixie/release/operator/v0.1.0/k8s/operator/helm/crds/olm_crd.yaml 2>&1 >/dev/null | grep -v AlreadyExists)
               if [[ "${ERROR}" != "" ]]; then
                 echo "{\"Metadata\":{\"InstallationError\":\"OLM CRD creation failed - ${ERROR}\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}}


### PR DESCRIPTION
# Description

Customers recently got the following errors after March 24th.

```
execution failed for kubernetes-open-source-integration: exit status 1: The CustomResourceDefinition "clusterserviceversions.operators.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```
# Code changes

We think the issue is same as [this issue](https://github.com/operator-framework/operator-lifecycle-manager/issues/2767) and follow[ the fix ](https://github.com/operator-framework/operator-lifecycle-manager/pull/2771)to make this PR. 

# Tests
Test 2>&1 >/dev/null only keeping stderr in ERROR

```
xqi@TFXCKKXMP9 Chapter09 % ERROR=$(k create -f gs-ping-deployment.yaml 2>&1 >/dev/null)
xqi@TFXCKKXMP9 Chapter09 % echo $ERROR                                                 

xqi@TFXCKKXMP9 Chapter09 % ERROR=$(k create -f gs-ping-deployment.yaml 2>&1 >/dev/null)
xqi@TFXCKKXMP9 Chapter09 % echo $ERROR                                                 
Error from server (AlreadyExists): error when creating "gs-ping-deployment.yaml": deployments.apps "gs-ping" already exists
xqi@TFXCKKXMP9 Chapter09 % 
```
