### PR TITLE
feat(ohi): infrastructure entity key validation

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -32,7 +32,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from ApacheSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from ApacheSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -41,7 +41,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from ApacheSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from ApacheSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -36,7 +36,7 @@ logMatch:
   - name: cassandra-debug
     file: /var/log/cassandra/debug.log*
 
-validationNrql: "SELECT count(*) from CassandraSample SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from CassandraSample SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -40,7 +40,7 @@ logMatch:
   - name: cassandra-debug
     file: /var/log/cassandra/debug.log*
 
-validationNrql: "SELECT count(*) from CassandraSample SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from CassandraSample SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/consul/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/debian.yml
@@ -27,7 +27,7 @@ processMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from ConsulAgentSample FACET entityGuid SINCE 20 minutes ago"
+validationNrql: "SELECT count(*) from ConsulAgentSample FACET entityGuid SINCE 20 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 # Prompts for input from the user. These variables then become
 # available to go-task in the form of {{.VAR_NAME}}

--- a/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/consul/rhel.yml
@@ -30,7 +30,7 @@ processMatch:
 
 # Matches partial list of the Log forwarding parameters
 
-validationNrql: "SELECT count(*) from ConsulAgentSample FACET entityGuid SINCE 20 minutes ago"
+validationNrql: "SELECT count(*) from ConsulAgentSample FACET entityGuid SINCE 20 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_HOSTNAME"

--- a/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/debian.yml
@@ -31,7 +31,7 @@ logMatch:
   - name: Couchbase General
     file: /opt/couchbase/var/lib/couchbase/logs/couchdb.log
 
-validationNrql: "SELECT count(*) from CouchbaseNodeSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from CouchbaseNodeSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/couchbase/rhel.yml
@@ -35,7 +35,7 @@ logMatch:
   - name: Couchbase General
     file: /opt/couchbase/var/lib/couchbase/logs/couchdb.log
 
-validationNrql: "SELECT count(*) from CouchbaseNodeSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from CouchbaseNodeSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/debian.yml
@@ -30,7 +30,7 @@ logMatch:
   - name: elasticsearch
     file: /var/log/elasticsearch/elasticsearch*.log
 
-validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/rhel.yml
@@ -33,7 +33,7 @@ logMatch:
   - name: elasticsearch
     file: /var/log/elasticsearch/elasticsearch*.log
 
-validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/elasticsearch/suse.yml
@@ -27,7 +27,7 @@ logMatch:
   - name: elasticsearch
     file: /var/log/elasticsearch/elasticsearch*.log
 
-validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from ElasticsearchClusterSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/debian.yml
@@ -29,7 +29,7 @@ logMatch:
   - name: haproxy
     file: /var/log/haproxy.log
 
-validationNrql: "SELECT count(*) from HAProxyBackendSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from HAProxyBackendSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/haproxy/rhel.yml
@@ -33,7 +33,7 @@ logMatch:
   - name: haproxy
     file: /var/log/haproxy.log
 
-validationNrql: "SELECT count(*) from HAProxyBackendSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from HAProxyBackendSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_DB_USERNAME"

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -35,7 +35,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
+validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/debian.yml
@@ -35,7 +35,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/memcached/rhel.yml
@@ -35,7 +35,7 @@ processMatch:
 #   - name: memcached
 #     file: /var/log/memcached/*access_log
 
-validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MemcachedSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/debian.yml
@@ -34,7 +34,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MongoDatabaseSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MongoDatabaseSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mongodb/rhel.yml
@@ -33,7 +33,7 @@ logMatch:
   - name: MongoDB log
     file: /var/log/mongodb/mongod.log
 
-validationNrql: "SELECT count(*) from MongoDatabaseSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MongoDatabaseSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -54,7 +54,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/suse.yml
@@ -36,7 +36,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from MysqlSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -32,7 +32,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from NagiosServiceCheckSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NagiosServiceCheckSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -30,7 +30,7 @@ logMatch:
   - name: nagios
     file: /usr/local/nagios/var/nagios.log
 
-validationNrql: "SELECT count(*) from NagiosServiceCheckSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NagiosServiceCheckSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -32,7 +32,7 @@ logMatch:
     attributes:
       logtype: nginx-error
 
-validationNrql: "SELECT count(*) from NginxSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from NginxSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/debian.yml
@@ -29,7 +29,7 @@ logMatch:
   - name: postgresql
     file: /var/log/postgresql/postgresql*.log
 
-validationNrql: "SELECT count(*) from PostgresqlDatabaseSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from PostgresqlDatabaseSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/postgres/rhel.yml
@@ -36,7 +36,7 @@ logMatch:
   - name: postgresql
     file: /var/log/postgresql/postgresql*.log
 
-validationNrql: "SELECT count(*) from PostgresqlDatabaseSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from PostgresqlDatabaseSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/debian.yml
@@ -32,7 +32,7 @@ logMatch:
   - name: Logs
     file: /var/log/rabbitmq/*.log
 
-validationNrql: "SELECT count(*) from RabbitmqVhostSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from RabbitmqVhostSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/rabbitmq/rhel.yml
@@ -36,7 +36,7 @@ logMatch:
   - name: rabbitmq
     file: /var/log/rabbitmq/*.log
 
-validationNrql: "SELECT count(*) from RabbitmqNodeSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from RabbitmqNodeSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -39,7 +39,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from RedisSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from RedisSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/rhel.yml
@@ -43,7 +43,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from RedisSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from RedisSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 successLinkConfig:
   type: EXPLORER

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -29,7 +29,7 @@ logMatch:
   - name: Logs
     file: /var/log/varnish/varnishcna.log
 
-validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -35,7 +35,7 @@ logMatch:
 
 # NRQL the newrelic-cli will use to validate the agent/integration this recipe
 # installed is successfully sending data to New Relic
-validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 minutes ago"
+validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 minutes ago WHERE reportingAgent = '{{.INFRA_KEY}}'"
 
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"


### PR DESCRIPTION
This PR enables all Linux OHIs to complete their NRQL validation via the Infrastructure Agent's Entity Key which is consumed by the `newrelic-cli` from this agent and made available subsequently for the rest of OHIs to be installed on a host.