### PR TITLE
Simplify Helm ERROR Handling Logic

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -488,16 +488,12 @@ install:
             fi
 
             HELM_VERSION="$($SUDO helm version -c --short)"
-            ERROR=$($SUDO helm repo add newrelic https://helm-charts.newrelic.com)
-            if [[ $? != 0 ]]; then
-              if [[ "${ERROR}" !=  "" ]]; then
-                echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
-              else
-                echo "helm (version $HELM_VERSION) repo add failed."
-              fi
+            # With 2>&1 >/dev/null, ERROR only keeps the error message if $? is non-zero and is empty if $? is zero
+            ERROR=$($SUDO helm repo add newrelic https://helm-charts.newrelic.com 2>&1 >/dev/null)
+            if [[ "${ERROR}" !=  "" ]]; then
+              echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
               exit 131
             fi
-
             if [[ $($SUDO helm repo update) ]] ; then
             else
               exit 131
@@ -570,15 +566,13 @@ install:
 
             echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
-            ERROR=$($SUDO helm upgrade $ARGS)
-            if [[ $? != 0 ]]; then
-              if [[ "${ERROR}" != "" ]]; then
-                echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
-              else 
-                echo "helm (version $HELM_VERSION) repo upgrade installation failed."
-              fi
+            # With 2>&1 >/dev/null, ERROR only keeps the error message if $? is non-zero and is empty if $? is zero
+            ERROR=$($SUDO helm upgrade $ARGS 2>&1 >/dev/null)
+            if [[ "${ERROR}" != "" ]]; then
+              echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
               exit 131
             fi
+            echo $?
           else
             echo ""
             echo "Using kubectl to install the Kubernetes integration"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -572,7 +572,6 @@ install:
               echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
               exit 131
             fi
-            echo $?
           else
             echo ""
             echo "Using kubectl to install the Kubernetes integration"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -494,6 +494,7 @@ install:
               echo "helm (version $HELM_VERSION) repo add failed due to: $ERROR"
               exit 131
             fi
+
             if [[ $($SUDO helm repo update) ]] ; then
             else
               exit 131


### PR DESCRIPTION
# Description

 Recently, I find 2>&1 >/dev/null can be used to simplify the existing helm error handling logic

# Code Changes
 
   So I make the corresponding changes to use 2>&1 >/dev/null in handling helm related errors

# Tests
The following proved that With 2>&1 >/dev/null, ERROR only keeps the error message if `$?` is non-zero and is empty if `$?` is zero
```
xqi@TFXCKKXMP9 Downloads % helm repo add newrelic https://helm-charts.newrelic.com                 
"newrelic" already exists with the same configuration, skipping
xqi@TFXCKKXMP9 Downloads % echo $?                                                                 
0
xqi@TFXCKKXMP9 Downloads % helm repo add newrelic https://helm-charts.newrelic.com 2>&1 >/dev/null 
xqi@TFXCKKXMP9 Downloads % helm repo add newrelic https://helm-charts.newrelic.comm 2>&1 >/dev/null
Error: repository name (newrelic) already exists, please specify a different name
```

Also, I run the following with/without k8s integration preinstalled to make sure no error is introduced

```
NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_CLUSTERNAME=k8scluster126 NR_CLI_NAMESPACE=newrelic NR_CLI_PRIVILEGED=true NR_CLI_LOW_DATA_MODE=true NR_CLI_KSM=true NR_CLI_KUBE_EVENTS=true NR_CLI_PROMETHEUS_AGENT=true NR_CLI_PROMETHEUS_AGENT_LOW_DATA_MODE=true NR_CLI_CURATED=false NR_CLI_NEWRELIC_PIXIE=true NR_CLI_PIXIE_API_KEY=XXX NR_CLI_PIXIE=true NR_CLI_PIXIE_DEPLOY_KEY=XXX NEW_RELIC_API_KEY=XXX NEW_RELIC_ACCOUNT_ID=XXX newrelic install -c /Users/xqi/Documents/GitHub/INSTALLATION/open-install-library/recipes/newrelic/infrastructure/kubernetes.yml
```