### PR TITLE
fix: adding metadata output to collect nginx information

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
@@ -113,7 +113,7 @@ install:
       cmds:
         - |
           stub_location=$(sudo nginx -T 2>&1 | grep -ozP "(?s:.*\s)\Klocation(?s).*stub_status" | grep -aoP "\/([^\s]+)")
-
+          echo "{\"Metadata\":{\"stub_location\":\"$stub_location\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
           port=""
           curledPorts=""
           sudo nginx -T | grep listen | while read -r line ; do
@@ -137,6 +137,7 @@ install:
 
           # Set Defaults
           NR_CLI_STUB_STATUS_URL="http://127.0.0.1:${port}${stub_location}"
+          echo "{\"Metadata\":{\"stub_status_url\":\"$NR_CLI_STUB_STATUS_URL\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null                            
 
           STATUS_RESPONSE=$(curl $NR_CLI_STUB_STATUS_URL -s | iconv -f utf-8 -t utf-8 -c)
           if [ ! $(echo $STATUS_RESPONSE | grep "Active connections:" | wc -l) -eq 0 ] ; then


### PR DESCRIPTION
Using metadata functionality to capture `stub_location` and `stub_status_url` values that could be triggering exit status 3
<img width="1876" alt="Screen Shot 2023-04-20 at 9 17 33 AM" src="https://user-images.githubusercontent.com/90725916/233394532-1b1975b1-d152-46fd-900f-dbc0318e2ac3.png">
