### PR TITLE
chore(apache): Alias env vars

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/apache/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/debian.yml
@@ -42,8 +42,8 @@ preInstall:
       - Apache status module endpoint (default server-status) available
   requireAtDiscovery: |
     # Set Defaults
-    NR_CLI_STATUS_URL=${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}
-    STUB_STATUS_ENABLED=$(curl $NR_CLI_STATUS_URL -s | grep -i "idle" | wc -l)
+    NEW_RELIC_APACHE_STATUS_URL=${NEW_RELIC_APACHE_STATUS_URL:-${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}}
+    STUB_STATUS_ENABLED=$(curl $NEW_RELIC_APACHE_STATUS_URL -s | grep -i "idle" | wc -l)
     if [ $STUB_STATUS_ENABLED -eq 0 ] ; then
       exit 132
     fi
@@ -83,9 +83,9 @@ install:
       cmds:
         - |
           # Set Defaults
-          NR_CLI_STATUS_URL=${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}
+          NEW_RELIC_APACHE_STATUS_URL=${NEW_RELIC_APACHE_STATUS_URL:-${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}}
 
-          STUB_STATUS_ENABLED=$(curl $NR_CLI_STATUS_URL -s | grep -i "idle" | wc -l)
+          STUB_STATUS_ENABLED=$(curl $NEW_RELIC_APACHE_STATUS_URL -s | grep -i "idle" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then
             printf "\nStatus page is not returning expected data. Apache2 must be correctly configured for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration#config for more info.\n" >&2
             exit 2
@@ -104,7 +104,7 @@ install:
             - name: nri-apache
               env:
                 METRICS: true
-                STATUS_URL: $NR_CLI_STATUS_URL
+                STATUS_URL: $NEW_RELIC_APACHE_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -119,7 +119,7 @@ install:
             - name: nri-apache
               env:
                 INVENTORY: true
-                STATUS_URL: $NR_CLI_STATUS_URL
+                STATUS_URL: $NEW_RELIC_APACHE_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -51,8 +51,8 @@ preInstall:
       - Apache status module endpoint (default server-status) available
   requireAtDiscovery: |
     # Set Defaults
-    NR_CLI_STATUS_URL=${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}
-    STUB_STATUS_ENABLED=$(curl $NR_CLI_STATUS_URL -s | grep -i "idle" | wc -l)
+    NEW_RELIC_APACHE_STATUS_URL=${NEW_RELIC_APACHE_STATUS_URL:-${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}}
+    STUB_STATUS_ENABLED=$(curl $NEW_RELIC_APACHE_STATUS_URL -s | grep -i "idle" | wc -l)
     if [ $STUB_STATUS_ENABLED -gt 0 ] ; then
       # Supported case
       exit 0
@@ -93,8 +93,8 @@ install:
       cmds:
         - |
           # Set Defaults
-          NR_CLI_STATUS_URL=${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}
-          STUB_STATUS_ENABLED=$(curl $NR_CLI_STATUS_URL -s | grep -i "idle" | wc -l)
+          NEW_RELIC_APACHE_STATUS_URL=${NEW_RELIC_APACHE_STATUS_URL:-${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}}
+          STUB_STATUS_ENABLED=$(curl $NEW_RELIC_APACHE_STATUS_URL -s | grep -i "idle" | wc -l)
           if [ $STUB_STATUS_ENABLED -eq 0 ] ; then
             if [ -f /etc/httpd/conf.d/server-status.conf ]; then
               printf "\nThe status page is not returning expected data. Apache must be configured with the server-status module for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration#config for more info.\n" >&2
@@ -139,8 +139,8 @@ install:
           EOT
             sudo systemctl restart httpd
             sleep 5
-            NR_CLI_STATUS_URL=${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}
-            STUB_STATUS_ENABLED=$(curl $NR_CLI_STATUS_URL -s | grep -i "idle" | wc -l)
+            NEW_RELIC_APACHE_STATUS_URL=${NEW_RELIC_APACHE_STATUS_URL:-${NR_CLI_STATUS_URL:-'http://127.0.0.1/server-status?auto'}}
+            STUB_STATUS_ENABLED=$(curl $NEW_RELIC_APACHE_STATUS_URL -s | grep -i "idle" | wc -l)
             if [ $STUB_STATUS_ENABLED -eq 0 ] ; then
               printf "\nThe status page is not returning any data. Apache must be configured with the server-status module for New Relic to collect data. \n - See https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration#config for more info.\n" >&2
               exit 131
@@ -160,7 +160,7 @@ install:
             - name: nri-apache
               env:
                 METRICS: true
-                STATUS_URL: $NR_CLI_STATUS_URL
+                STATUS_URL: $NEW_RELIC_APACHE_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the
@@ -175,7 +175,7 @@ install:
             - name: nri-apache
               env:
                 INVENTORY: true
-                STATUS_URL: $NR_CLI_STATUS_URL
+                STATUS_URL: $NEW_RELIC_APACHE_STATUS_URL
 
                 # New users should leave this property as 'true', to identify the
                 # monitored entities as 'remote'. Setting this property to 'false' (the


### PR DESCRIPTION
Adds a backwards-compatible alias `NEW_RELIC_APACHE_STATUS_URL` for `NR_CLI_STATUS_URL`