### PR TITLE
chore(mssql): Alias env vars

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -38,15 +38,15 @@ preInstall:
         exit 2
       }
 
-      $NR_CLI_DB_HOSTNAME=   "$env:NR_CLI_DB_HOSTNAME"
-      if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_HOSTNAME)) {$NR_CLI_DB_HOSTNAME = hostname}
+      $NEW_RELIC_MSSQL_DB_HOSTNAME = "$env:NEW_RELIC_MSSQL_DB_HOSTNAME ?? $env:NR_CLI_DB_HOSTNAME"
+      if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_HOSTNAME)) {$NEW_RELIC_MSSQL_DB_HOSTNAME = hostname}
 
-      $NR_CLI_DB_PORT = "$env:NR_CLI_DB_PORT"
-      if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_PORT)) {$NR_CLI_DB_PORT = "1433"}
+      $NEW_RELIC_MSSQL_DB_PORT = "$env:NEW_RELIC_MSSQL_DB_PORT ?? $env:NR_CLI_DB_PORT"
+      if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_PORT)) {$NEW_RELIC_MSSQL_DB_PORT = "1433"}
 
       # Loop on each instance names to see if we can connect
       foreach ($instance in $instances) {
-        $connection = "${NR_CLI_DB_HOSTNAME}\${instance},${NR_CLI_DB_PORT}"
+        $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance},${NEW_RELIC_MSSQL_DB_PORT}"
         $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
         If ($name.Length -ge 3) {
           $actualName = $name[2].ToString().Trim();
@@ -59,7 +59,7 @@ preInstall:
           }
         }
 
-        $connection = "${NR_CLI_DB_HOSTNAME}\${instance}"
+        $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance}"
         $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
         If ($name.Length -ge 3) {
           $actualName = $name[2].ToString().Trim();
@@ -119,24 +119,24 @@ install:
           $MAX_RETRIES=3
 
           # Check Env Vars
-          $NR_CLI_DB_HOSTNAME=   "$env:NR_CLI_DB_HOSTNAME"
-          if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_HOSTNAME)) {$NR_CLI_DB_HOSTNAME = hostname}
+          $NEW_RELIC_MSSQL_DB_HOSTNAME = "$env:NEW_RELIC_MSSQL_DB_HOSTNAME ?? $env:NR_CLI_DB_HOSTNAME"
+          if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_HOSTNAME)) {$NEW_RELIC_MSSQL_DB_HOSTNAME = hostname}
 
-          $NR_CLI_DB_PORT = "$env:NR_CLI_DB_PORT"
-          if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_PORT)) {$NR_CLI_DB_PORT = "1433"}
+          $NEW_RELIC_MSSQL_DB_PORT = "$env:NEW_RELIC_MSSQL_DB_PORT ?? $env:NR_CLI_DB_PORT"
+          if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_PORT)) {$NEW_RELIC_MSSQL_DB_PORT = "1433"}
 
-          $NR_CLI_DB_USERNAME=   "$env:NR_CLI_DB_USERNAME"
-          if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_USERNAME)) {$NR_CLI_DB_USERNAME = "newrelic"}
+          $NEW_RELIC_MSSQL_DB_USERNAME = "$env:NEW_RELIC_MSSQL_DB_USERNAME ?? $env:NR_CLI_DB_USERNAME"
+          if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_USERNAME)) {$NEW_RELIC_MSSQL_DB_USERNAME = "newrelic"}
 
-          $NR_CLI_DB_PASSWORD=   "$env:NR_CLI_DB_PASSWORD"
-          if ([string]::IsNullOrWhiteSpace($NR_CLI_DB_PASSWORD)) {
+          $NEW_RELIC_MSSQL_DB_PASSWORD = "$env:NEW_RELIC_MSSQL_DB_PASSWORD ?? $env:NR_CLI_DB_PASSWORD"
+          if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_PASSWORD)) {
             Add-Type -AssemblyName System.Web;
-            $NR_CLI_DB_PASSWORD = [System.Web.Security.Membership]::GeneratePassword(20,2).replace("-","");
+            $NEW_RELIC_MSSQL_DB_PASSWORD = [System.Web.Security.Membership]::GeneratePassword(20,2).replace("-","");
           }
-          $NR_SQL_PASSWORD="$env:NR_CLI_SQL_PASSWORD"
-          $NR_SQL_USERNAME="$env:NR_CLI_SQL_USERNAME"
-          $NR_ENABLE_BUFFER_METRICS="$env:NR_CLI_ENABLE_BUFFER_METRICS"
-          $NR_ENABLE_DATABASE_RESERVE_METRICS="$env:NR_CLI_ENABLE_RESERVE_METRICS"
+          $NR_SQL_PASSWORD="$env:NEW_RELIC_MSSQL_SQL_PASSWORD ?? $env:NR_CLI_SQL_PASSWORD"
+          $NR_SQL_USERNAME="$env:NEW_RELIC_MSSQL_SQL_USERNAME ?? $env:NR_CLI_SQL_USERNAME"
+          $NR_ENABLE_BUFFER_METRICS="$env:NEW_RELIC_MSSQL_ENABLE_BUFFER_METRICS ?? $env:NR_CLI_SQL_ENABLE_BUFFER_METRICS"
+          $NR_ENABLE_DATABASE_RESERVE_METRICS="$env:NEW_RELIC_MSSQL_ENABLE_RESERVE_METRICS ?? $env:NR_CLI_SQL_ENABLE_RESERVE_METRICS"
 
           $OhiConfig = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\mssql-config.yml";
           $CreateConfig=1
@@ -162,9 +162,9 @@ install:
 
             Add-Content -Path $OhiConfig -Value "  - name`:` nri-mssql" -Force | Out-Null;
             Add-Content -Path $OhiConfig -Value "    env`:` " -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      HOSTNAME`:` ${NR_CLI_DB_HOSTNAME}" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      USERNAME`:` ${NR_CLI_DB_USERNAME}" -Force | Out-Null;
-            Add-Content -Path $OhiConfig -Value "      PASSWORD`:` `"${NR_CLI_DB_PASSWORD}`"" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      HOSTNAME`:` ${NEW_RELIC_MSSQL_DB_HOSTNAME}" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      USERNAME`:` ${NEW_RELIC_MSSQL_DB_USERNAME}" -Force | Out-Null;
+            Add-Content -Path $OhiConfig -Value "      PASSWORD`:` `"${NEW_RELIC_MSSQL_DB_PASSWORD}`"" -Force | Out-Null;
 
             if ($NR_ENABLE_BUFFER_METRICS -eq "0") {
             Add-Content -Path $OhiConfig -Value "      ENABLE_BUFFER_METRICS`:` false" -Force | Out-Null;
@@ -194,9 +194,9 @@ install:
             )
 
             if ([string]::IsNullOrWhiteSpace($Port)) {
-              $connection = "${NR_CLI_DB_HOSTNAME}\${instance}"
+              $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance}"
             } else {
-              $connection = "${NR_CLI_DB_HOSTNAME}\${instance},${Port}"
+              $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance},${Port}"
             }
 
             $SQL=@"
@@ -209,7 +209,7 @@ install:
           FETCH NEXT FROM db_user_cursor INTO @name WHILE @@FETCH_STATUS = 0
           BEGIN
             BEGIN TRY
-              EXECUTE(`"USE [`" + @name + `"]; IF EXISTS(select top 1 name from sys.syslogins where name = `"`"${NR_CLI_DB_USERNAME}`"`") DROP USER ${NR_CLI_DB_USERNAME};`" )
+              EXECUTE(`"USE [`" + @name + `"]; IF EXISTS(select top 1 name from sys.syslogins where name = `"`"${NEW_RELIC_MSSQL_DB_USERNAME}`"`") DROP USER ${NEW_RELIC_MSSQL_DB_USERNAME};`" )
             END TRY
             BEGIN CATCH
             END CATCH
@@ -218,12 +218,12 @@ install:
           CLOSE db_user_cursor
           DEALLOCATE db_user_cursor
 
-          IF EXISTS(select top 1 name from sys.syslogins where name = `"${NR_CLI_DB_USERNAME}`")
+          IF EXISTS(select top 1 name from sys.syslogins where name = `"${NEW_RELIC_MSSQL_DB_USERNAME}`")
           BEGIN
             DECLARE @session_id INT
             DECLARE db_login_cursor CURSOR
             READ_ONLY FORWARD_ONLY
-            FOR SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = `"${NR_CLI_DB_USERNAME}`"
+            FOR SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = `"${NEW_RELIC_MSSQL_DB_USERNAME}`"
             OPEN db_login_cursor
             FETCH NEXT FROM db_login_cursor  INTO @session_id WHILE @@FETCH_STATUS = 0
             BEGIN
@@ -233,12 +233,12 @@ install:
             CLOSE db_login_cursor
             DEALLOCATE db_login_cursor
 
-            DROP LOGIN ${NR_CLI_DB_USERNAME}
+            DROP LOGIN ${NEW_RELIC_MSSQL_DB_USERNAME}
           END
 
-          CREATE LOGIN ${NR_CLI_DB_USERNAME} WITH PASSWORD = `"${NR_CLI_DB_PASSWORD}`"
+          CREATE LOGIN ${NEW_RELIC_MSSQL_DB_USERNAME} WITH PASSWORD = `"${NEW_RELIC_MSSQL_DB_PASSWORD}`"
 
-          GRANT CONNECT SQL, VIEW SERVER STATE, VIEW ANY DEFINITION TO ${NR_CLI_DB_USERNAME}
+          GRANT CONNECT SQL, VIEW SERVER STATE, VIEW ANY DEFINITION TO ${NEW_RELIC_MSSQL_DB_USERNAME}
           DECLARE db_create_cursor CURSOR
           READ_ONLY FORWARD_ONLY
           FOR SELECT NAME FROM master.sys.databases WHERE NAME NOT IN (`"master`",`"msdb`",`"tempdb`",`"model`",`"rdsadmin`",`"distribution`") and state !=6
@@ -246,7 +246,7 @@ install:
           FETCH NEXT FROM db_create_cursor INTO @name WHILE @@FETCH_STATUS = 0
           BEGIN
             BEGIN TRY
-              EXECUTE(`"USE [`" + @name + `"]; IF NOT EXISTS(SELECT name from sys.database_principals where name = `"`"${NR_CLI_DB_USERNAME}`"`") BEGIN CREATE USER ${NR_CLI_DB_USERNAME} FOR LOGIN ${NR_CLI_DB_USERNAME}; END`" )
+              EXECUTE(`"USE [`" + @name + `"]; IF NOT EXISTS(SELECT name from sys.database_principals where name = `"`"${NEW_RELIC_MSSQL_DB_USERNAME}`"`") BEGIN CREATE USER ${NEW_RELIC_MSSQL_DB_USERNAME} FOR LOGIN ${NEW_RELIC_MSSQL_DB_USERNAME}; END`" )
             END TRY
             BEGIN CATCH
             END CATCH
@@ -255,7 +255,7 @@ install:
           CLOSE db_create_cursor
           DEALLOCATE db_create_cursor
 
-          select name from sys.syslogins where name = `"${NR_CLI_DB_USERNAME}`"
+          select name from sys.syslogins where name = `"${NEW_RELIC_MSSQL_DB_USERNAME}`"
           "@
 
             $NriSqlFile = "$env:TEMP\nri-sql.sql"
@@ -283,7 +283,7 @@ install:
 
             If ($SqlOutput.Length -ge 3) {
               $userName = $SqlOutput[2].ToString().Trim();
-              If ($userName -eq ${NR_CLI_DB_USERNAME}) {
+              If ($userName -eq ${NEW_RELIC_MSSQL_DB_USERNAME}) {
                 # User created successfully
                 return $true
               }
@@ -299,7 +299,7 @@ install:
 
           foreach ($instance in $instances) {
 
-            $connection = "${NR_CLI_DB_HOSTNAME}\${instance},${NR_CLI_DB_PORT}"
+            $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance},${NEW_RELIC_MSSQL_DB_PORT}"
             $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
             If ($name.Length -ge 3) {
               $actualName = $name[2].ToString().Trim();
@@ -307,9 +307,9 @@ install:
                 # Was able to connect with port
                 $canLogin=($loginModes | Where-Object -Property PSPath -like -Value "*${actualName}*")
                 if (-Not ($canLogin -eq $null)) {
-                  $isCreated = (Create-SqlUser -InstanceName $instance -Port $NR_CLI_DB_PORT)
+                  $isCreated = (Create-SqlUser -InstanceName $instance -Port $NEW_RELIC_MSSQL_DB_PORT)
                   if ($isCreated) {
-                    Write-OhiConfig -InstanceName $instance -Port $NR_CLI_DB_PORT
+                    Write-OhiConfig -InstanceName $instance -Port $NEW_RELIC_MSSQL_DB_PORT
                     $setupCount++
                   }
                 }
@@ -317,7 +317,7 @@ install:
               }
             }
 
-            $connection = "${NR_CLI_DB_HOSTNAME}\${instance}"
+            $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance}"
             $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
             If ($name.Length -ge 3) {
               $actualName = $name[2].ToString().Trim();


### PR DESCRIPTION
The following backwards-compatible aliases are added:

- `NR_CLI_DB_HOSTNAME` -> `NEW_RELIC_MSSQL_DB_HOSTNAME`
- `NR_CLI_DB_PORT` -> `NEW_RELIC_MSSQL_DB_PORT`
- `NR_CLI_DB_USERNAME` -> `NEW_RELIC_MSSQL_DB_USERNAME`
- `NR_CLI_DB_PASSWORD` -> `NEW_RELIC_MSSQL_DB_PASSWORD`
- `NR_CLI_SQL_USERNAME` -> `NEW_RELIC_MSSQL_SQL_USERNAME`
- `NR_CLI_SQL_PASSWORD` -> `NEW_RELIC_MSSQL_SQL_PASSWORD`
- `NR_CLI_ENABLE_BUFFER_METRICS` -> `NEW_RELIC_MSSQL_ENABLE_BUFFER_METRICS`
- `NR_CLI_ENABLE_RESERVE_METRICS` -> `NEW_RELIC_MSSQL_ENABLE_RESERVE_METRICS`