### PR TITLE
SUSE 15-SPx logs support

### DIFF
--- a/recipes/newrelic/infrastructure/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/linux-logs.yml
@@ -46,8 +46,8 @@ installTargets:
     platformVersion: "((7|8|9)\\.?.*)"
   - type: host
     os: linux
-    platform: "suse"
-    platformVersion: "15\\.[1-4]"
+    platformFamily: suse
+    platformVersion: "(15\\.[1-4]|15-SP[1-4])"
     kernelArch: x86_64
   # ARM supported
   - type: host

--- a/test/definitions/infra-agent/suse154-infra.json
+++ b/test/definitions/infra-agent/suse154-infra.json
@@ -1,0 +1,34 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+    "resources": [
+        {
+            "id": "host1",
+            "provider": "aws",
+            "type": "ec2",
+            "size": "t3.nano",
+            "ami_name": "suse-sles-15-sp4-v????????-hvm-*"
+        }
+    ],
+    "instrumentations": {
+        "resources": [
+            {
+                "id": "nr_infra_suse154",
+                "resource_ids": [
+                    "host1"
+                ],
+                "provider": "newrelic",
+                "source_repository": "https://github.com/newrelic/open-install-library",
+                "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
+                "params": {
+                    "validate_output": "Infrastructure Agent\\s+\\(installed\\)",
+                    "local_recipes": true
+                }
+            }
+        ]
+    }
+}

--- a/test/definitions/logging/suse154-logs.json
+++ b/test/definitions/logging/suse154-logs.json
@@ -1,0 +1,34 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+    "resources": [
+        {
+            "id": "suse154-logs",
+            "provider": "aws",
+            "type": "ec2",
+            "size": "t3.nano",
+            "ami_name": "suse-sles-15-sp4-v????????-hvm-*"
+        }
+    ],
+    "instrumentations": {
+        "resources": [
+            {
+                "id": "nr_infra_suse154",
+                "resource_ids": [
+                    "suse154-logs"
+                ],
+                "provider": "newrelic",
+                "source_repository": "https://github.com/newrelic/open-install-library",
+                "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
+                "params": {
+                    "validate_output": "Logs Integration\\s+\\(installed\\)",
+                    "local_recipes": true
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Adds logs support for SUSE platform versions 15-SP[1-4]
- Checks `platformFamily` field for `suse` as it's consistently populated for SUSE unlike `platform`
- Adds nonregression tests for 15-SP4 infra/logs