### PR TITLE
chore(ohi): Update pinned Ubuntu versions

### DIFF
--- a/recipes/newrelic/infrastructure/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/linux-logs.yml
@@ -33,7 +33,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "((16|18|20|22)\\.04)" # Xenial, Bionic, Focal
+    platformVersion: "(((16|18|20|21|22)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
   - type: host
     os: linux
     platform: "redhat"
@@ -63,7 +63,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "((16|18|20|22)\\.04)" # Xenial, Bionic, Focal
+    platformVersion: "(((16|18|20|21|22)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
     kernelArch: aarch64
   - type: host
     os: linux

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -17,7 +17,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "((16|18|20)\\.04)" # Xenial, Bionic, Focal
+    platformVersion: "(((16|18|20|21|22)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
 
 # keyword convention for dealing with search terms that could land someone on this instrumentation project
 keywords:

--- a/recipes/newrelic/infrastructure/ohi/redis/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/redis/debian.yml
@@ -17,7 +17,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "((16|18|20)\\.04)" # Xenial, Bionic, Focal
+    platformVersion: "(((16|18|20|21|22)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
 
 # keyword convention for dealing with search terms that could land someone on this instrumentation project
 keywords:

--- a/test/definitions/ohi/linux/mysql-ubuntu22.json
+++ b/test/definitions/ohi/linux/mysql-ubuntu22.json
@@ -1,0 +1,49 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+    "resources": [
+        {
+            "id": "host1",
+            "provider": "aws",
+            "type": "ec2",
+            "size": "t3.micro",
+            "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-202?????",
+            "user_name": "ubuntu"
+        }
+    ],
+    "services": [
+        {
+            "id": "mysql1",
+            "destinations": [
+                "host1"
+            ],
+            "source_repository": "https://github.com/newrelic/open-install-library.git",
+            "deploy_script_path": "test/deploy/linux/mysql/install/debian/roles",
+            "port": 9999,
+            "params": {
+                "create_env_var": true
+            }
+        }
+    ],
+    "instrumentations": {
+        "resources": [
+            {
+                "id": "nr_infra_mysql",
+                "resource_ids": [
+                    "host1"
+                ],
+                "provider": "newrelic",
+                "source_repository": "https://github.com/newrelic/open-install-library.git",
+                "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+                "params": {
+                    "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mysql/debian.yml",
+                    "validate_output": "(MySQL Integration)\\s+\\(installed\\)"
+                }
+            }
+        ]
+    }
+}

--- a/test/definitions/ohi/linux/redis-ubuntu22.json
+++ b/test/definitions/ohi/linux/redis-ubuntu22.json
@@ -1,0 +1,49 @@
+{
+    "global_tags": {
+        "owning_team": "virtuoso",
+        "Environment": "development",
+        "Department": "product",
+        "Product": "virtuoso"
+    },
+    "resources": [
+        {
+            "id": "host1",
+            "provider": "aws",
+            "type": "ec2",
+            "size": "t3.small",
+            "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-202?????",
+            "user_name": "ubuntu"
+        }
+    ],
+    "services": [
+        {
+            "id": "redis1",
+            "destinations": [
+                "host1"
+            ],
+            "source_repository": "https://github.com/newrelic/open-install-library.git",
+            "deploy_script_path": "test/deploy/linux/redis/install/debian/roles",
+            "port": 6379,
+            "params": {
+                "create_env_var": true
+            }
+        }
+    ],
+    "instrumentations": {
+        "resources": [
+            {
+                "id": "nr_infra_redis",
+                "resource_ids": [
+                    "host1"
+                ],
+                "provider": "newrelic",
+                "source_repository": "https://github.com/newrelic/open-install-library.git",
+                "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+                "params": {
+                    "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/redis/debian.yml",
+                    "validate_output": "(Redis Integration)\\s+\\(installed\\)"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adding support for recipes with pinned Ubuntu versions (mysql & redis) to match the infra agent [docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/#operating-systems)