### PR TITLE
Re-instate max-parallel for EU tests

### DIFF
--- a/.github/workflows/nonregression-eu.yml
+++ b/.github/workflows/nonregression-eu.yml
@@ -83,6 +83,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix) }}
       fail-fast: false
+      max-parallel: 20
     env:
       MATRIX: ${{ toJSON(matrix) }}
     steps:


### PR DESCRIPTION
Re-instate `max-parallel` for GHA's Non-regression EU tests.