### PR TITLE
chore: add Debian 12 infrastructure keyword

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -19,6 +19,7 @@ keywords:
   - Jessie
   - Stretch
   - Buster
+  - Bookworm
 
 processMatch: []
 


### PR DESCRIPTION
- Packages for Debian 12 added in infrastructure agent 1.47.0: https://github.com/newrelic/infrastructure-agent/releases/tag/1.47.0