### PR TITLE
feat: Update minimum k8s version

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -146,7 +146,7 @@ install:
           fi
 
           # Check the Kubernetes version
-          KUBECTL_VERSION=$($SUDO $KUBECTL version --short 2>&1)
+          KUBECTL_VERSION=$($SUDO $KUBECTL version 2>&1)
           CLIENT_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
           CLIENT_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
           SERVER_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
@@ -314,7 +314,7 @@ install:
               fi
             fi
 
-            K8S_VERSION=$($SUDO $KUBECTL version --short | grep "Server Version")
+            K8S_VERSION=$($SUDO $KUBECTL version | grep "Server Version")
             if echo ${K8S_VERSION} | grep "\-gke\." >/dev/null; then
               PIXIE_SUPPORTED=true
             fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -146,7 +146,15 @@ install:
           fi
 
           # Check the Kubernetes version
-          KUBECTL_VERSION=$($SUDO $KUBECTL version 2>&1)
+          KUBECTL_VERSION=$($SUDO $KUBECTL version --short 2>&1)
+
+          # Check if $KUBECTL_VERSION contains an error with unknown flag --short
+          # run again without --short flag since it was deprecated in kubectl version 1.28
+          if echo "$KUBECTL_VERSION" | grep -q "unknown flag: --short"
+          then
+            KUBECTL_VERSION=$($SUDO $KUBECTL version 2>&1)
+          fi
+
           CLIENT_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')
           CLIENT_MINOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Client Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $2; }')
           SERVER_MAJOR_VERSION=$(echo "${KUBECTL_VERSION}" | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1; }')

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -322,7 +322,14 @@ install:
               fi
             fi
 
-            K8S_VERSION=$($SUDO $KUBECTL version | grep "Server Version")
+            K8S_VERSION=$($SUDO $KUBECTL version --short | grep "Server Version")
+            # Check if $K8S_VERSION contains an error with unknown flag --short
+            # run again without --short flag since it was deprecated in kubectl version 1.28
+            if echo ${K8S_VERSION} | grep -q "unknown flag: --short"
+            then
+              K8S_VERSION=$($SUDO $KUBECTL version | grep "Server Version")
+            fi
+
             if echo ${K8S_VERSION} | grep "\-gke\." >/dev/null; then
               PIXIE_SUPPORTED=true
             fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -170,8 +170,8 @@ install:
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 16 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 27 ]]; then
-            echo "Installation failed. Kubernetes v1.16 to v1.27 is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 23 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 27 ]]; then
+            echo "Installation failed. Kubernetes v1.23 to v1.27 is required, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 131
           fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -147,11 +147,13 @@ install:
 
           # Check the Kubernetes version
           KUBECTL_VERSION=$($SUDO $KUBECTL version --short 2>&1)
+          SHORT_FLAG_ERROR=false
 
           # Check if $KUBECTL_VERSION contains an error with unknown flag --short
           # run again without --short flag since it was deprecated in kubectl version 1.28
           if echo "$KUBECTL_VERSION" | grep -q "unknown flag: --short"
           then
+            SHORT_FLAG_ERROR=true
             KUBECTL_VERSION=$($SUDO $KUBECTL version 2>&1)
           fi
 
@@ -322,12 +324,12 @@ install:
               fi
             fi
 
-            K8S_VERSION=$($SUDO $KUBECTL version --short | grep "Server Version")
-            # Check if $K8S_VERSION contains an error with unknown flag --short
-            # run again without --short flag since it was deprecated in kubectl version 1.28
-            if echo ${K8S_VERSION} | grep -q "unknown flag: --short"
-            then
+            # SHORT_FLAG_ERROR will be true if it returned an --short flag error earlier in the script
+            # if SHORT_FLAG_ERROR is true, run KUBECTL version without --short flag since it was deprecated in kubectl version 1.28
+            if $SHORT_FLAG_ERROR == true; then
               K8S_VERSION=$($SUDO $KUBECTL version | grep "Server Version")
+            else
+              K8S_VERSION=$($SUDO $KUBECTL version --short | grep "Server Version")
             fi
 
             if echo ${K8S_VERSION} | grep "\-gke\." >/dev/null; then


### PR DESCRIPTION
Update k8s minimum version to 1.23.

Added a check for `KUBECTL_VERSION=$($SUDO $KUBECTL version --short 2>&1)` command to see if it return's an error containing `unknown flag: --short` which means the user has kubectl v1.28 and rerun the command without using `--short` flag.

I tested this recipe locally on kubectl version 1.23 and 1.28 and the installation worked without errors. 