### PR TITLE
Enable Fleet connection (opamp) by default (NR-165936)

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -79,6 +79,7 @@ install:
         - task: update_otel_mem_limit
         - task: update_otel_end_point
         - task: config_supervisors
+        - task: config_opamp
         - task: config_host_monitoring
         - task: restart_super_agent
         - task: assert_super_agent_started
@@ -335,10 +336,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false"] ; then
-            sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml           
+          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false" ] ; then
+            sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sudo sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" ] ; then
@@ -355,6 +356,33 @@ install:
           else
             sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+
+    config_opamp:
+      cmds:
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" == "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -98,6 +98,7 @@ install:
         - task: update_otel_mem_limit
         - task: update_otel_end_point
         - task: config_supervisors
+        - task: config_opamp
         - task: config_host_monitoring
         - task: restart_super_agent
         - task: assert_super_agent_started
@@ -271,10 +272,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false"] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false" ] ; then
             sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml           
           else
-            sudo sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" ] ; then
@@ -291,6 +292,33 @@ install:
           else
             sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+
+    config_opamp:
+      cmds:
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" == "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -69,6 +69,7 @@ install:
         - task: update_otel_mem_limit
         - task: update_otel_end_point
         - task: config_supervisors
+        - task: config_opamp
         - task: config_host_monitoring
         - task: restart_super_agent
         - task: assert_super_agent_started
@@ -225,10 +226,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false"] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" && "{{.NR_CLI_NRDOT}}" == "false" ] ; then
             sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml           
           else
-            sudo sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" == "false" ] ; then
@@ -245,6 +246,33 @@ install:
           else
             sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+
+    config_opamp:
+      cmds:
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" == "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:


### PR DESCRIPTION
Follow-up task for the super agent recipe now that the fleet management endpoint is ready.

scope:

the default install should define the required configs so that the agents are registered in Fleet.
at the moment, this needs:
define the opamp url depending on the NEW_RELIC_REGION parameter (US, EU, STAGING):

[opamp.staging-service.newrelic.com/v1/opamp](http://opamp.staging-service.newrelic.com/v1/opamp)
[opamp.service.newrelic.com/v1/opamp](http://opamp.service.newrelic.com/v1/opamp)
[opamp.service.eu.newrelic.com/v1/opamp](http://opamp.service.eu.newrelic.com/v1/opamp)
define the api-key using the ingest_key (same used for the infra-agent and otel collector)

add a new param to enable customers to optionally disable the opamp connection, proposal:
NR_CLI_FLEET_ENABLED=false (default value is true)