### PR TITLE
chore: Fix cassandra deploy scripts

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -121,7 +121,7 @@ install:
                 HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
                 CONFIG_PATH: /etc/cassandra/cassandra.yaml
                 REMOTE_MONITORING: true
-              inventory_source: config/redis
+              inventory_source: config/cassandra
               interval: 60
           EOT
 

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -107,7 +107,7 @@ install:
           sudo cp /etc/newrelic-infra/integrations.d/cassandra-config.yml.sample /etc/newrelic-infra/integrations.d/cassandra-config.yml;
 
         - |
-          sudo tee -a /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
+          sudo tee /etc/newrelic-infra/integrations.d/cassandra-config.yml > /dev/null <<"EOT"
           integrations:
             - name: nri-cassandra
               env:
@@ -122,9 +122,9 @@ install:
               env:
                 INVENTORY: true
                 HOSTNAME: {{.NR_CLI_DB_HOSTNAME}}
-                CONFIG_PATH: /etc/cassandra/cassandra.yaml
+                CONFIG_PATH: /etc/cassandra/conf/cassandra.yaml
                 REMOTE_MONITORING: true
-              inventory_source: config/redis
+              inventory_source: config/cassandra
               interval: 60
           EOT
 

--- a/test/deploy/linux/cassandra/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/configure/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: Install Cassandra
+    msg: Configure
 
 - name: Set default create_newrelic_user (default not create)
   set_fact:
@@ -12,69 +12,42 @@
     create_env_var: "false"
   when: create_env_var is undefined
 
-- name: Get latest packages info
-  shell: "apt-get update -y"
+# By default JMX security is disabled.
+- name: Require authentication
   become: true
+  ansible.builtin.lineinfile:
+    path: /etc/cassandra/cassandra-env.sh
+    regexp: "jmxremote.authenticate=false"
+    line: '  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"'
 
-- name: Install dependiences
-  shell: sudo apt install apt-transport-https ca-certificates wget dirmngr gnupg software-properties-common -y
+- name: Configure access file
   become: true
+  ansible.builtin.lineinfile:
+    path: /etc/cassandra/cassandra-env.sh
+    regexp: "jmxremote.access.file"
+    line: JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.access.file=/etc/cassandra/jmxremote.access"
 
-- name: Get java keys
-  shell: wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+- name: Add passwords file
   become: true
+  ansible.builtin.copy:
+    dest: /etc/cassandra/jmxremote.password
+    content: |
+      cassandra cassandra
+      newrelic Virtuoso4all
 
-- name: Get java repo
-  shell: sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-  become: yes
+- name: Add access file
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/cassandra/jmxremote.access
+    content: |
+      cassandra readwrite
+      newrelic readonly
 
-- name: update packages
-  shell: apt-get update -y
-  become: yes
-
-- name: install java
-  shell: sudo apt install adoptopenjdk-8-hotspot -y
-  become: yes
-
-- name: add cassandra keys
-  shell: wget -q -O - https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
-  become: yes
-
-- name: add cassandra repo
-  shell: sudo sh -c 'echo "deb https://www.apache.org/dist/cassandra/debian 311x main" > /etc/apt/sources.list.d/cassandra.list'
-  become: yes
-
-- name: update packages
-  shell: apt-get update -y
-  become: yes
-
-- name: install cassandra
-  shell: apt install cassandra -y
-  become: yes
-
-- name: Allow to create user
-  shell: "sudo sed -i 's/authenticator: AllowAllAuthenticator/authenticator: PasswordAuthenticator/g' /etc/cassandra/cassandra.yaml"
-  become: yes
-
-- name: restart cassandra
-  shell: systemctl restart cassandra
-  become: yes
-
-- name: Ensure Cassandra is ready to accept query
-  shell: cqlsh localhost 9042 -ucassandra -pcassandra -e "SELECT dateof(now()) FROM system.local ;"
-  register: output
-  retries: 20
-  delay: 15
-  until: output is not failed
-
-- fail:
-    msg: "Cassandra is not available, details: {{output}}"
-  when: output is failed
-
-- name: Create newrelic login
-  shell: cqlsh localhost 9042 -ucassandra -pcassandra -e "CREATE USER newrelic WITH PASSWORD 'Virtuoso4all!';"
-  become: yes
-  when: create_newrelic_user|bool
+- name: Restart Cassandra
+  become: true
+  ansible.builtin.systemd:
+    name: cassandra
+    state: restarted
 
 - block:
   - name: Export USERNAME

--- a/test/deploy/linux/cassandra/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/configure/tasks/main.yml
@@ -33,7 +33,7 @@
     dest: /etc/cassandra/jmxremote.password
     content: |
       cassandra cassandra
-      newrelic Virtuoso4all
+      newrelic Virtuoso4all!
 
 - name: Add access file
   become: true

--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
@@ -1,0 +1,17 @@
+---
+- debug:
+    msg: Install Cassandra
+
+- name: Add cassandra repo
+  shell: echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+  become: true
+
+- name: add cassandra keys
+  shell: wget -q -O - https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+  become: true
+
+- name: Install cassandra
+  ansible.builtin.apt:
+    name: cassandra
+    update_cache: yes
+  become: true

--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installDependencies.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installDependencies.yml
@@ -1,0 +1,16 @@
+---
+- debug:
+    msg: Install dependencies
+
+- name: Update repository cache and install packages
+  ansible.builtin.apt:
+    pkg:
+      - apt-transport-https
+      - ca-certificates
+      - wget
+      - dirmngr
+      - gnupg
+      - software-properties-common
+      - wget
+    update_cache: true
+  become: true

--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: installDependencies.yml
+- include_tasks: installCassandra.yml

--- a/test/deploy/linux/cassandra/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/configure/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- debug:
+    msg: Configure
+
+- name: Set default create_newrelic_user (default not create)
+  set_fact:
+    create_newrelic_user: "false"
+  when: create_newrelic_user is undefined
+
+- name: Set default create_env_var (default not create)
+  set_fact:
+    create_env_var: "false"
+  when: create_env_var is undefined
+
+# By default JMX security is disabled.
+- name: Require authentication
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/cassandra/conf/cassandra-env.sh
+    regexp: "jmxremote.authenticate=false"
+    line: '  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"'
+
+- name: Configure access file
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/cassandra/conf/cassandra-env.sh
+    regexp: "jmxremote.access.file"
+    line: JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.access.file=/etc/cassandra/jmxremote.access"
+
+- name: Add passwords file
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/cassandra/jmxremote.password
+    content: |
+      cassandra cassandra
+      newrelic Virtuoso4all
+
+- name: Add access file
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/cassandra/jmxremote.access
+    content: |
+      cassandra readwrite
+      newrelic readonly
+
+- name: Restart Cassandra
+  become: true
+  ansible.builtin.systemd:
+    name: cassandra
+    state: restarted

--- a/test/deploy/linux/cassandra/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/configure/tasks/main.yml
@@ -33,7 +33,7 @@
     dest: /etc/cassandra/jmxremote.password
     content: |
       cassandra cassandra
-      newrelic Virtuoso4all
+      newrelic Virtuoso4all!
 
 - name: Add access file
   become: true

--- a/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installCassandra.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installCassandra.yml
@@ -1,0 +1,30 @@
+---
+- debug:
+    msg: Install Cassandra
+
+- name: Add Cassandra repo
+  become: true
+  ansible.builtin.blockinfile:
+    create: true
+    path: /etc/yum.repos.d/cassandra.repo
+    block: |
+      [cassandra]
+      name=Apache Cassandra
+      baseurl=https://redhat.cassandra.apache.org/41x/noboolean
+      gpgcheck=1
+      repo_gpgcheck=1
+      gpgkey=https://downloads.apache.org/cassandra/KEYS
+
+- name: Install Cassandra
+  become: true
+  ansible.builtin.yum:
+    name: cassandra
+    update_cache: true
+    state: present
+
+- name: Start Cassandra
+  become: true
+  ansible.builtin.systemd:
+    name: cassandra
+    enabled: true
+    state: started

--- a/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installDependencies.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installDependencies.yml
@@ -1,0 +1,11 @@
+---
+- debug:
+    msg: Install dependencies
+
+- name: Update repository cache and install packages
+  ansible.builtin.yum:
+    name:
+      - curl
+      - wget
+    update_cache: true
+  become: true

--- a/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installJava.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/installJava.yml
@@ -1,0 +1,28 @@
+---
+- debug:
+    msg: Install Java
+
+- name: Install Java
+  become: true
+  ansible.builtin.yum:
+    name: java-1.8.0-openjdk-devel
+    update_cache: true
+    state: present
+
+- name: Add JAVA_HOME env root
+  shell: "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk' >> ~/.bashrc"
+  become: true
+- name: Add JAVA_HOME env user
+  shell: "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk' >> ~/.bashrc"
+
+- name: Add JRE_HOME env root
+  shell: "echo 'export JRE_HOME=/usr/lib/jvm/java-1.8.0-openjdk/jre' >> ~/.bashrc"
+  become: true
+- name: Add JRE_HOME env user
+  shell: "echo 'export JRE_HOME=/usr/lib/jvm/java-1.8.0-openjdk/jre' >> ~/.bashrc"
+
+- name: Add JAVA_HOME to path root
+  shell: "echo 'export PATH=$PATH:$JAVA_HOME/bin:$JRE_HOME/bin' >> ~/.bashrc"
+  become: true
+- name: Add JAVA_HOME to path user
+  shell: "echo 'export PATH=$PATH:$JAVA_HOME/bin:$JRE_HOME/bin' >> ~/.bashrc"

--- a/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/cassandra/install/rhel/roles/prepare/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include_tasks: installDependencies.yml
+- include_tasks: installJava.yml
+- include_tasks: installCassandra.yml

--- a/test/manual/definitions/ohi/linux/apache-cassandra-debian10.json
+++ b/test/manual/definitions/ohi/linux/apache-cassandra-debian10.json
@@ -7,30 +7,27 @@
   },
   "resources": [
     {
-      "id": "apachecasslinux2",
+      "id": "apachecassdebian10",
       "provider": "aws",
       "type": "ec2",
       "size": "t3.small",
-      "ami_name": "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2"
+      "ami_name": "debian-10-amd64-202?????-*",
+      "user_name": "admin"
     }
   ],
   "services": [
     {
       "id": "apache1",
-      "destinations": [
-        "apachecasslinux2"
-      ],
+      "destinations": ["apachecassdebian10"],
       "source_repository": "https://github.com/newrelic/open-install-library.git",
-      "deploy_script_path": "test/deploy/linux/apache/install/rhel/roles",
+      "deploy_script_path": "test/deploy/linux/apache/install/debian/roles",
       "port": 80
     },
     {
       "id": "cassandra1",
-      "destinations": [
-        "apachecasslinux2"
-      ],
+      "destinations": ["apachecassdebian10"],
       "source_repository": "https://github.com/newrelic/open-install-library.git",
-      "deploy_script_path": "test/deploy/linux/cassandra/install/linux2/roles",
+      "deploy_script_path": "/test/deploy/linux/cassandra/install/debian/roles",
       "port": 9042
     }
   ]

--- a/test/manual/definitions/ohi/linux/apache-cassandra-linux2.json
+++ b/test/manual/definitions/ohi/linux/apache-cassandra-linux2.json
@@ -1,0 +1,34 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "apachecasslinux2",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "apache1",
+      "destinations": ["apachecasslinux2"],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/apache/install/rhel/roles",
+      "port": 80
+    },
+    {
+      "id": "cassandra1",
+      "destinations": ["apachecasslinux2"],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "/test/deploy/linux/cassandra/install/rhel/roles",
+      "port": 9042
+    }
+  ]
+}


### PR DESCRIPTION
**Deployer scripts**
* Enable JMX authentication and add user with credentials. **NOTE**: Try as I might, I could not figure out how to escape the `!` that is usually included in our standard test credentials.
   ```
   user: newrelic
   pw: Virtuoso4all
   ```
* AL2 quirks
   * When installing cassandra with `yum`, configuration files are located at `/etc/cassandra/conf/`, instead of the default `/etc/cassandra`

**Testing**

**NOTES**: 
* The current `rhel` recipe is broken. You will need to reference the fixed recipe in this branch when testing.
* To fully validate that the CLI install was successful, ensure that you see a new cassandra entity show up in the entity explorer.

1. If you run demo-deployer in a docker container with open-install-library as a mounted volume, you can reference local deploy scripts in the deployer config (e.g. apache-cassandra-debian10.json) by replacing "source_repository" with "local_source_path". For example:
   ```
   {
     ...
     "local_source_path": "/mnt/deployer/open-install-library",
     "deploy_script_path": "/test/deploy/linux/cassandra/install/debian/roles",
     ...
   }
   ```
2. Cassandra install via CLI using the creds above should succeed
3. Cassandra install via CLI should fail when using incorrect creds