### PR TITLE
Super-agent install recipe, do not send any logs if NRI_HOST_MONITORING is 'newrelic'(NR-179505)

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -399,6 +399,7 @@ install:
           else
             if [ -f /etc/nr-otel-collector/config.yaml ]; then
               sed -i 's/\<otlp, hostmetrics\>/otlp/g' /etc/nr-otel-collector/config.yaml
+              sed -i 's/\<otlp, filelog\>/otlp/g' /etc/nr-otel-collector/config.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/super-agent/logs/linux-logs.yml
@@ -132,10 +132,7 @@ install:
           if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" != "otel" ]; then
             mkdir -p "/etc/newrelic-infra/logging.d"
             touch /etc/newrelic-infra/logging.d/logging.yml;
-            touch /etc/newrelic-infra/logging.d/discovered.yml;    
-            if [ -f /etc/nr-otel-collector/config.yaml ]; then
-              sed -i 's/\<otlp, filelog\>/otlp/g' /etc/nr-otel-collector/config.yaml
-            fi
+            touch /etc/newrelic-infra/logging.d/discovered.yml;
           fi
 
     setup:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -336,6 +336,7 @@ install:
           else
             if [ -f /etc/nr-otel-collector/config.yaml ]; then
               sed -i 's/\<otlp, hostmetrics\>/otlp/g' /etc/nr-otel-collector/config.yaml
+              sed -i 's/\<otlp, filelog\>/otlp/g' /etc/nr-otel-collector/config.yaml            
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -291,6 +291,7 @@ install:
           else
             if [ -f /etc/nr-otel-collector/config.yaml ]; then
               sed -i 's/\<otlp, hostmetrics\>/otlp/g' /etc/nr-otel-collector/config.yaml
+              sed -i 's/\<otlp, filelog\>/otlp/g' /etc/nr-otel-collector/config.yaml
             fi
           fi
 


### PR DESCRIPTION
Move filelog removal to the main super-agent recipe to not send any logs if NRI_HOST_MONITORING is 'newrelic'.