### PR TITLE
feat(ohi): add super-agent as infra-agent substitute dependency for OHIs

### DIFF
--- a/docs/recipe-spec/recipe-spec.md
+++ b/docs/recipe-spec/recipe-spec.md
@@ -40,6 +40,12 @@ repository: string, required
 # ex:
 # dependencies:
 #   - infrastructure-agent-installer
+#
+# A special 'OR' variant for recipe dependencies involves the infrastructure and super agents. It allows the super-agent
+# to be used as an alternative recipe dependency instead of the infrastructure-agent-installer when the super-agent is a targeted install:
+# ex:
+# dependencies:
+#   - infrastructure-agent-installer || super-agent
 dependencies: list, optional
 
 # Still TBD

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -8,6 +8,7 @@ repository: https://github.com/newrelic/nri-mysql
 
 dependencies:
   - infrastructure-agent-installer
+  - super-agent
 
 installTargets:
   - type: host
@@ -24,6 +25,7 @@ keywords:
   - Infrastructure
   - Integration
   - mysql
+  - ohi
 
 # Examine Infrastructure events for correlated data
 processMatch:
@@ -77,14 +79,14 @@ install:
         - task: input_assert
           vars:
             MAX_RETRIES: 3
-        - task: restart
 
     assert_infra:
       cmds:
         - |
           IS_INFRA_INSTALLED=$(sudo ps aux | grep newrelic-infra-service | grep -v grep | wc -l)
-          if [ $IS_INFRA_INSTALLED -eq 0 ] ; then
-            echo "The infrastructure agent is required to install this integration, we recommend going through our guided install path for this pre-requisite which can be found here:  https://docs.newrelic.com/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview" >&2
+          IS_SUPER_AGENT_INSTALLED=$(sudo ps aux | grep newrelic-super-agent | grep -v grep | wc -l)
+          if [ $IS_INFRA_INSTALLED -eq 0 ] && [ $IS_SUPER_AGENT_INSTALLED -eq 0 ] ; then
+            echo "The infrastructure agent or the super agent is required to install this integration. We recommend going through our guided install path for this pre-requisite which can be found at: https://docs.newrelic.com/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview" >&2
             exit 1
           fi
 
@@ -264,24 +266,6 @@ install:
               inventory_source: config/mysql
               interval: 30
           EOT
-
-    restart:
-      cmds:
-        - |
-          if [ {{.IS_SYSTEMCTL}} -gt 0 ]; then
-            sudo systemctl restart newrelic-infra
-          else
-            if [ {{.IS_INITCTL}} -gt 0 ]; then
-              sudo initctl restart newrelic-infra
-            else
-              sudo /etc/init.d/newrelic-infra restart
-            fi
-          fi
-      vars:
-        IS_SYSTEMCTL:
-          sh: command -v systemctl | wc -l
-        IS_INITCTL:
-          sh: command -v initctl | wc -l
 
     collect_meta:
       cmds:

--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -7,8 +7,7 @@ description: New Relic install recipe for default MySQL Open Source on-host inte
 repository: https://github.com/newrelic/nri-mysql
 
 dependencies:
-  - infrastructure-agent-installer
-  - super-agent
+  - infrastructure-agent-installer || super-agent
 
 installTargets:
   - type: host
@@ -25,7 +24,6 @@ keywords:
   - Infrastructure
   - Integration
   - mysql
-  - ohi
 
 # Examine Infrastructure events for correlated data
 processMatch:


### PR DESCRIPTION
Allows `super-agent` as an`infrastructure-agent` alternative/substitute dependency for OHIs. Related to: https://github.com/newrelic/newrelic-cli/pull/1534 in the CLI side.

Ref: [NR-173011](https://new-relic.atlassian.net/browse/NR-173011)