### PR TITLE
Initial migration of OIL tests to use deployer-platform

### DIFF
--- a/.github/workflows/nonregression-dp.yml
+++ b/.github/workflows/nonregression-dp.yml
@@ -1,7 +1,11 @@
-name: Smoke Tests (dp)(EU)
+name: Non Regression Testing (dp)
 
 on:
   workflow_dispatch:
+#  schedule:
+#    - cron: "0 9 * * 1-5"
+#  push:
+#    branches: [ main ]
 
 jobs:
   log-context:
@@ -49,7 +53,9 @@ jobs:
           script: |
             const fs = require('fs');
             const fsp = fs.promises;
-            const path = require('path');
+            const path = require("path");
+
+            const { isOHIValidationTimeout } = require("${{ github.workspace }}/.github/workflows/scripts/ohiValidationTimeout");
 
             // readdir recursive directory search
             const { readdir } = fsp;
@@ -61,12 +67,17 @@ jobs:
                 }));
                 return Array.prototype.concat(...files);
             }
-            const definitionsDir = 'test/definitions-eu/smoke'
+            const definitionsDir = 'test/definitions'
             const testDefinitions = await getFiles(definitionsDir);
 
-            const outputTestFilesMap = testDefinitions.map(testDefinitionFile => {
-                return { testDefinitionFile, 'testDisplayName': testDefinitionFile.replace(`${definitionsDir}/`, '') }
-            })
+            const outputTestFilesMap = testDefinitions
+              .filter((testDefinitionFile) => !isOHIValidationTimeout(testDefinitionFile))
+              .map((testDefinitionFile) => {
+                return {
+                  testDefinitionFile,
+                  testDisplayName: testDefinitionFile.replace(`${definitionsDir}/`, ""),
+                };
+              });
             const output = {
                 "include": outputTestFilesMap
             }
@@ -75,7 +86,7 @@ jobs:
 
   test-deploy-recipe:
     name: ${{ matrix.testDisplayName }}
-    needs: [ get-test-definition-files ]
+    needs: [get-test-definition-files]
     if: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix).include[0] }} # Avoids empty matrix validation error
     runs-on: ubuntu-latest
     strategy:
@@ -84,11 +95,6 @@ jobs:
     env:
       MATRIX: ${{ toJSON(matrix) }}
     steps:
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '20.x'
-
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
@@ -137,7 +143,7 @@ jobs:
             const outputPath = `${process.env.GITHUB_WORKSPACE}/${testDefinitionFile}`;
             fs.writeFileSync(outputPath, jsonContent);
 
-            return testDefinitionFile;      
+            return testDefinitionFile;
 
       - name: Install Test Dependencies
         working-directory: .github/workflows/scripts/dp
@@ -161,7 +167,7 @@ jobs:
 
   slack-notify:
     runs-on: ubuntu-latest
-    needs: [ test-deploy-recipe ]
+    needs: [test-deploy-recipe]
     if: always()
     steps:
       - name: Build Result Slack Notification
@@ -225,7 +231,7 @@ jobs:
                       type: "mrkdwn",
                       text: [
                         "*Result:*",
-                        `• ${ ${{ needs.test-deploy-recipe.result == 'success' }} === true ? '✅' : '❌' } Non-regression testing of smoke tests (EU): ${{ needs.test-deploy-recipe.result }}`
+                        `• ${ ${{ needs.test-deploy-recipe.result == 'success' }} === true ? '✅' : '❌' } Non-regression testing of all recipes: ${{ needs.test-deploy-recipe.result }}`
                       ].join('\n')
                     }
                   },

--- a/.github/workflows/scripts/dp/main.js
+++ b/.github/workflows/scripts/dp/main.js
@@ -1,0 +1,118 @@
+const https = require('https')
+const {SQSClient, SendMessageCommand} = require('@aws-sdk/client-sqs')
+const {DynamoDBClient, QueryCommand} = require('@aws-sdk/client-dynamodb')
+const {unmarshall} = require('@aws-sdk/util-dynamodb')
+
+const AWS_REGION = process.env.AWS_REGION
+const SQS_URL = process.env.SQS_URL
+const DYNAMO_TABLE = process.env.DYNAMO_TABLE
+const AWS_CREDS = {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+};
+
+const sqs = new SQSClient({region: AWS_REGION, credentials: AWS_CREDS})
+const dynamodb = new DynamoDBClient({region: AWS_REGION, credentials: AWS_CREDS})
+
+
+function queryForDeploymentStatus(messageId) {
+    const query_params = {
+        TableName: DYNAMO_TABLE,
+        KeyConditionExpression: 'id = :id',
+        FilterExpression: 'completed = :completed',
+        ExpressionAttributeNames: {
+            '#id': 'id',
+            '#completed': 'completed',
+            '#status': 'status',
+            '#message': 'message',
+        },
+        ExpressionAttributeValues: {
+            ':id': {
+                S: messageId,
+            },
+            ':completed': {
+                BOOL: true,
+            },
+        },
+        ProjectionExpression: '#id, #completed, #status, #message',
+        ScanIndexForward: false,  //returns items by descending timestamp
+    }
+    return new QueryCommand(query_params)
+}
+
+async function isDeploymentSuccessful(deploymentId, retries, waitSeconds) {
+    for (let i = 0; i < retries; i++) {
+        console.log(`Deployment pending, sleeping ${waitSeconds} seconds...`)
+        await sleep(waitSeconds * 1000)
+
+        try {
+            const response = await dynamodb.send(queryForDeploymentStatus(deploymentId))
+            console.log(`Query succeeded. Items found: ${response.Items.length}`)
+
+            for (let i = 0; i < response.Items.length; i++) {
+                const item = unmarshall(response.Items[i])
+                if (item.completed) {
+                    console.log(`Completed: ${item.id} - ${item.message} - ${item.completed} - ${item.status}`)
+                    if (item.status === 'FAILED') {
+                        console.error(`::error:: Deployment failed: ${item.message}`)
+                        return false
+                    }
+
+                    return true
+                }
+            }
+        } catch (err) {
+            console.log(`Error querying table: ${err}`)
+        }
+    }
+    return false
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function main() {
+    const url = process.env.TEST_DEFINITION_URL
+
+    https.get(url, (res) => {
+        let body = ''
+
+        res.on('data', (chunk) => {
+            body += chunk
+        })
+
+        res.on('end', async () => {
+            let messageId
+            try {
+                const command = new SendMessageCommand({
+                    QueueUrl: SQS_URL,
+                    MessageBody: body,
+                })
+                data = await sqs.send(command)
+                messageId = data.MessageId
+                console.log(`Message sent: ${messageId}`)
+            } catch (err) {
+                console.error(`Error sending message: ${err}`)
+            }
+
+            // Execute the query with retries/sleeps
+            let RETRIES = 100, WAIT_SECONDS = 30
+            const success = await isDeploymentSuccessful(messageId, RETRIES, WAIT_SECONDS)
+            if (!success) {
+                console.log('::set-output name=exit_status::1')
+            }
+        })
+
+        res.on('error', (err) => {
+            console.error(`Error calling URL: ${err}`)
+            console.log('::set-output name=exit_status::1')
+        })
+
+        console.log('::set-output name=exit_status::0')
+    })
+}
+
+if (require.main === module) {
+    main()
+}

--- a/.github/workflows/scripts/dp/package-lock.json
+++ b/.github/workflows/scripts/dp/package-lock.json
@@ -1,0 +1,5129 @@
+{
+  "name": "dp",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dp",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "1.2.6",
+        "@aws-sdk/client-dynamodb": "3.27.0",
+        "@aws-sdk/client-sqs": "3.27.0",
+        "@aws-sdk/credential-providers": "3.451.0",
+        "@aws-sdk/util-dynamodb": "3.27.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.468.0.tgz",
+      "integrity": "sha512-rx/9uHI4inRbp2tw3Y4Ih4PNZkVj32h7WneSg3MVgVjAoVD5Zti9KhS5hkvsBxfgmQmg0AQbE+b1sy5WGAgntA==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+      "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.2.2",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.25.0.tgz",
+      "integrity": "sha512-uEVKqKkPVz6atbCxCNJY5O7V+ieSK8crUswXo8/WePyEbGEgxJ4t9x/WG4lV8kBjelmvQHDR4GqfJmb5Sh9xSg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.451.0.tgz",
+      "integrity": "sha512-xoImUiGoaXJZpOCgbWcdrU4vHJ8HG5KluaCkc32kuFobM277sjQimaUIHOGHL24M5vyo4QxcJD9CT/IhX63Vlg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.451.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+      "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.451.0.tgz",
+      "integrity": "sha512-48NcIRxWBdP1fom6RSjwn2R2u7SE7eeV3p+c4s7ukEOfrHhBxJfn3EpqBVQMGzdiU55qFImy+Fe81iA2lXq3Jw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-sdk-sts": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+      "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+      "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+      "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+      "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+      "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.451.0",
+        "@aws-sdk/token-providers": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+      "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+      "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+      "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+      "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+      "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+      "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+      "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+      "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.27.0.tgz",
+      "integrity": "sha512-jlG7Rqj45axVu6Km036EpO5IejYmb6iiK+2ZZqFek/y3JYNPCS6Cl29GUCgEgTlmuJ6YkRG7TdV+1hrQVndulw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.27.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.27.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/util-waiter": "3.25.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.27.0.tgz",
+      "integrity": "sha512-qxkjkcPI2JOS4CQGKQw2H6WnlzV0aXX4QSTKdF9iiJR6555Bo9Da+NGjfq3WvANYFRDe/cj+8IOaNutPI+TXBg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.27.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/md5-js": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.25.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.27.0.tgz",
+      "integrity": "sha512-/Op+OaQgcAG/FyyqJc2NVfIJWEd1cTWIl8gBWSTUugrhhd5rMnAtg3u5ds/tYUimVQJv03z4bDjbI0Rnv/t6XQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.27.0.tgz",
+      "integrity": "sha512-QagsjULn6eacR/IL9d/nky17jUcqnbeShrHGrAyOhAXtehG3g2kkFcGbFy30iNw8gl1LteZL9dslpPFdWIEI1A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-sdk-sts": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.27.0.tgz",
+      "integrity": "sha512-gc7dfBzdmUHJamMjOc0bzAkIm3VUIK9kbLQSy0+nfjT641+AYvXO3qpjR6ywvutsbKhBg5kyGn/4QhyRxg61OQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
+      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+      "dependencies": {
+        "@smithy/smithy-client": "^2.1.15",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.451.0.tgz",
+      "integrity": "sha512-g1ZT46NuYfou00d94rJZ59N4TLI1T+v46lbHTtF9jwohiUsi7/vHkPIOdrgtrThGzGUVl01w62N0a2mpMydaBA==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.27.0.tgz",
+      "integrity": "sha512-IbPdlYl0A5GcpuT394cJceexxo0tzUzC7jIUxqL8gNbB/MIXC5ZlkeX9Z7bYloNb8SXk7GumXyQTsK1CchUvQA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.451.0.tgz",
+      "integrity": "sha512-q82kEzymqimkJ2dHmuN2RGpi9HTFSxwwoXALnzPRaRcvR/v+YY8FMgSTfwXzPkHUDf/q8J+aDz6lPcYlnsP3sQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-stream": "^2.0.20",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.27.0.tgz",
+      "integrity": "sha512-rhzlEvxiB7ecpVDl3NkjP1vPmqs+HHmqNXrK4efOYshwIbu+/h3xPePQMBOQ0AGezYn3k/iumoXXysVhVqtwUA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.27.0.tgz",
+      "integrity": "sha512-jvWUDz6nFqUvjmPRebwf1mWsOZ+inmZNQxz20DC/ROCRfGF1y8Yqf7KgCJy8MQOlDdTA4lPS+w6OJ0J/OOGbPg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.27.0",
+        "@aws-sdk/credential-provider-imds": "3.27.0",
+        "@aws-sdk/credential-provider-sso": "3.27.0",
+        "@aws-sdk/credential-provider-web-identity": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.27.0.tgz",
+      "integrity": "sha512-GfCDX/AA7EJKyVGmNnh3wngWfEWFkuNJyend6FLN+81s3kUpXTkILuZCwQrD9AyjBYR2ksv0t929nW2fBUGT9Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.27.0",
+        "@aws-sdk/credential-provider-imds": "3.27.0",
+        "@aws-sdk/credential-provider-ini": "3.27.0",
+        "@aws-sdk/credential-provider-process": "3.27.0",
+        "@aws-sdk/credential-provider-sso": "3.27.0",
+        "@aws-sdk/credential-provider-web-identity": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.27.0.tgz",
+      "integrity": "sha512-F9pqKKnd5+fwoldVQJX9uLbDyPyIDnCpZGbiTw6BZANZM1qhjoEn7rNE5g2h0tkeq4dWMA9bANKMR4j3YhTpXw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.27.0.tgz",
+      "integrity": "sha512-yXyy+/FYFtpnRmPBiw5rxwSQBj1pcI0R+z77EA8a8+tozZPjsIri+xBsU62DtIlv/2yVb/goPgw+w2vg0L4NFw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.27.0.tgz",
+      "integrity": "sha512-FYvDzB4UqmJjY+ZZoIAPM1EFK9/RdNn1VT5xvDcebQe7xKOVUG1tZbOA4rVZ3MUcxfyRqp7Ou/AhIWu/9RSt2Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.451.0.tgz",
+      "integrity": "sha512-ihbYZrI/tSVsZFDGLfJoCx3sg1s9EQqWA+xbLoquK+RjMqTnaeshYntFJmQA5yqCIbcAkyw63OwOIBRrVb7tMA==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.451.0",
+        "@aws-sdk/client-sso": "3.451.0",
+        "@aws-sdk/client-sts": "3.451.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.451.0",
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-http": "3.451.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+      "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.451.0.tgz",
+      "integrity": "sha512-48NcIRxWBdP1fom6RSjwn2R2u7SE7eeV3p+c4s7ukEOfrHhBxJfn3EpqBVQMGzdiU55qFImy+Fe81iA2lXq3Jw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-sdk-sts": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+      "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+      "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+      "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+      "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+      "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.451.0",
+        "@aws-sdk/token-providers": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+      "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+      "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+      "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+      "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+      "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+      "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+      "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+      "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.23.0.tgz",
+      "integrity": "sha512-Yhe1JvrTEA+BQuT/wfwvYDMqozB4GKXVRA4ZzU5VhkvMwbWd7/xGzDLQ0JG7jtYX3TwRYsBLI1XdQ1oYG3bmrQ==",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.25.0.tgz",
+      "integrity": "sha512-792kkbfSRBdiFb7Q2cDJts9MKxzAwuQSwUIwRKAOMazU8HkKbKnXXAFSsK3T7VasOFOh7O7YEGN0q9UgEw1q+g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.25.0.tgz",
+      "integrity": "sha512-qRn6iqG9VLt8D29SBABcbauDLn92ssMjtpyVApiOhDYyFm2VA2avomOHD6y2PRBMwM5FMQAygZbpA2HIN2F96w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.25.0.tgz",
+      "integrity": "sha512-ZBXjBAF2JSiO/wGBa1oaXsd1q5YG3diS8TfIUMXeQoe9O66R5LGoGOQeAbB/JjlwFot6DZfAcfocvl6CtWwqkw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
+      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.25.0.tgz",
+      "integrity": "sha512-97MtL1VF3JCkyJJnwi8LcXpqItnH1VtgoqtVqmaASYp5GXnlsnA1WDnB0754ufPHlssS1aBj/gkLzMZ0Htw/Rg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.25.0.tgz",
+      "integrity": "sha512-uOXus0MmZi/mucRIr5yfwM1vDhYG66CujNfnhyEaq5f4kcDA1Q5qPWSn9dkQPV9JWTZK3WTuYiOPSgtmlAYTAg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.27.0.tgz",
+      "integrity": "sha512-RmUAePYGmDepRJM/J9Xbm6aKfvislGpTURoCNPBTSEYtSRNBWMJAp3dC/AS9kctwSjcWFral8UdLLCh92EFVZw==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/endpoint-cache": "3.23.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.25.0.tgz",
+      "integrity": "sha512-xKD/CfsUS3ul2VaQ3IgIUXgA7jU2/Guo/DUhYKrLZTOxm0nuvsIFw0RqSCtRBCLptE5Qi+unkc1LcFDbfqrRbg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.25.0.tgz",
+      "integrity": "sha512-M1F7BlAsDKoEM8hBaU2pHlLSM40rzzgtZ6jFNhfmTwGcjxe1N7JXCH5QPa7aI8wnJq2RoIRHVfVsUH4GwvOZnA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
+      "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.27.0.tgz",
+      "integrity": "sha512-H57NP27qOxgbPRwCFkBYtAJylhAOWKSv3/TsCpDNnrb3Z0pqKUQH9mLC8hRGTRplkA7SDGfiuf9bsoNhZ3HFwQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/service-error-classification": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.25.0.tgz",
+      "integrity": "sha512-ac4tN49+Ehxz7wx/upGHeGvYreMFxg0aVC1t+8DMXPOAXzga0VhkW0qAng7Xh0W2+IcaqpDtx+rQ+C244g5XHw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.27.0.tgz",
+      "integrity": "sha512-4geCMczCujTz4GWSrwKhxEW9rYikp5NrLcIpHI0NjthQQfa8T4/D1WSsSnW3JNmQcMgQXeC9h8jTn0dOE4EhUw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.25.0.tgz",
+      "integrity": "sha512-065Kugo8yXzBkcVAxctxFCHKlHcINnaQRsJ8ifvgc+UOEgvTG9+LfGWDwfdgarW9CkF7RkCoZOyaqFsO+HJWsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.27.0.tgz",
+      "integrity": "sha512-eOXwKOFuCIGAW3wZO9Cyh+z7swZYTq8BiBDjwWu6u0UBb5B/zMiq1z1LDa88iZY200O3Zip8+6RZV7LLd3XH+Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.25.0.tgz",
+      "integrity": "sha512-s2VgdsasOVKHY3/SIGsw9AeZMMsdcIbBGWim9n5IO3j8C8y54EdRLVCEja8ePvMDZKIzuummwatYPHaUrnqPtQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.25.0.tgz",
+      "integrity": "sha512-HXd/Qknq8Cp7fzJYU7jDDpN7ReJ3arUrnt+dAPNaDDrhmrBbCZp+24UXN6X6DAj0JICRoRuF/l7KxjwdF5FShw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.27.0.tgz",
+      "integrity": "sha512-5jeCLV7NI/ouQCMGDnGbxpCBhGirksXY55uvAaeysMxzjJLmPDwOZUD1gMhfYe8lxvktwhAndOdPQofWwTFUoQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.25.0.tgz",
+      "integrity": "sha512-zVeAM/bXewZiuMtcUZI/xGDID6knkzOv73ueVkzUbP0Ki8bfao7diR3hMbIt5Fy/r8cAVjJce9v6zFqo4sr1WA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.27.0.tgz",
+      "integrity": "sha512-8vovVNldgJwCpUfehdwUPwvzfUPB7TEW/tcTgrkLQW/cpEULbRrymtiZrzSkBLspNw2iU5d3FpQxE61s1ou0UA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.25.0.tgz",
+      "integrity": "sha512-4Jebt5G8uIFa+HZO7KOgOtA66E/CXysQekiV5dfAsU8ca+rX5PB6qhpWZ2unX/l6He+oDQ0zMoW70JkNiP4/4w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.25.0.tgz",
+      "integrity": "sha512-o/R3/viOxjWckI+kepkxJSL7fIdg1hHYOW/rOpo9HbXS0CJrHVnB8vlBb+Xwl1IFyY2gg+5YZTjiufcgpgRBkw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.25.0.tgz",
+      "integrity": "sha512-FCNyaOLFLVS5j43MhVA7/VJUDX0t/9RyNTNulHgzFjj6ffsgqcY0uwUq1RO3QCL4asl56zOrLVJgK+Z7wMbvFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
+      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.25.0.tgz",
+      "integrity": "sha512-66FfIab87LnnHtOLrGrVOht9Pw6lE8appyOpBdtoeoU5DP7ARSWuDdsYmKdGdRCWvn/RaVFbSYua9k0M1WsGqg==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
+      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.25.0.tgz",
+      "integrity": "sha512-6KDRRz9XVrj9RxrBLC6dzfnb2TDl3CjIzcNpLdRuKFgzEEdwV+5D+EZuAQU3MuHG5pWTIwG72k/dmCbJ2MDPUQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.27.0.tgz",
+      "integrity": "sha512-PpsSDUsRqw8HGuXv+AR2UzhVUJz4APM7K6Br8TTDPKvDwQtXkT5GROXRyAwU+htPcOHq006lS5EiF343y0HRvg==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
+      "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+      "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+      "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+      "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+      "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+      "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.25.0.tgz",
+      "integrity": "sha512-vS0+cTKwj6CujlR07HmeEBxzWPWSrdmZMYnxn/QC9KW9dFu0lsyCGSCqWsFluI6GI0flsnYYWNkP5y4bfD9tqg==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.25.0.tgz",
+      "integrity": "sha512-qZ3Vq0NjHsE7Qq6R5NVRswIAsiyYjCDnAV+/Vt4jU/K0V3mGumiasiJyRyblW4Da8R6kfcJk0mHSMFRJfoHh8Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
+      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
+      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
+      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
+      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
+      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
+      "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.27.0.tgz",
+      "integrity": "sha512-ZrgkiaLYtEq3p2R3RwaiomzkK/uJhqKnDBv/Cm9rhcWOoAbn/rzrS57vTxN46cXJ1jGDvQOhwF2JREMCzYB08Q==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
+      "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/util-endpoints": "^1.0.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
+      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
+      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.25.0.tgz",
+      "integrity": "sha512-qGqiWfs49NRmQVXPsBXgMRVkjDZocicU0V2wak98e0t7TOI+KmP8hnwsTkE6c4KwhsFOOUhAzjn5zk3kOwi6tQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.25.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.27.0.tgz",
+      "integrity": "sha512-jigZzAuhEnaLFeYEDGKQq8tas8OsT6qI7WAm/UnCXqtLhdnIu7u1yPhXk+TjI7SSn4Z6zP6Oh1qtFxzhpPmdoQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
+      "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
+      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.25.0.tgz",
+      "integrity": "sha512-rhJ7Q2fcPD8y4H0qNEpaspkSUya0OaNcVrca9wCZKs7jWnropPzrQ+e2MH7fWJ/8jgcBV890+Txr4fWkD4J01g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
+      "integrity": "sha512-JkS36PIS3/UCbq/MaozzV7jECeL+BTt4R75bwY8i+4RASys4xOyUS1HsRyUNSqUXFP4QyCz5aNnh3ltuaxv+pw==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.21.tgz",
+      "integrity": "sha512-rlLIGT+BeqjnA6C2FWumPRJS1UW07iU5ZxDHtFuyam4W65gIaOFMjkB90ofKCIh+0mLVQrQFrl/VLtQT/6FWTA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz",
+      "integrity": "sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
+      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.1.tgz",
+      "integrity": "sha512-6MNk16fqb8EwcYY8O8WxB3ArFkLZ2XppsSNo1h7SQcFdDDwIumiJeO6wRzm7iB68xvsOQzsdQKbdtTieS3hfSQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.17.tgz",
+      "integrity": "sha512-Il6WuBcI1nD+e2DM7tTADMf01wEPGK8PAhz4D+YmDUVaoBqlA+CaH2uDJhiySifmuKBZj748IfygXty81znKhw==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.15.tgz",
+      "integrity": "sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.17.tgz",
+      "integrity": "sha512-OyadvMcKC7lFXTNBa8/foEv7jOaqshQZkjWS9coEXPRZnNnihU/Ls+8ZuJwGNCOrN2WxXZFmDWhegbnM4vak8w==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.3.tgz",
+      "integrity": "sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-middleware": "^2.0.8",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.24.tgz",
+      "integrity": "sha512-q2SvHTYu96N7lYrn3VSuX3vRpxXHR/Cig6MJpGWxd0BWodUQUWlKvXpWQZA+lTaFJU7tUvpKhRd4p4MU3PbeJg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-retry": "^2.0.8",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.15.tgz",
+      "integrity": "sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.9.tgz",
+      "integrity": "sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.8.tgz",
+      "integrity": "sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.1.tgz",
+      "integrity": "sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.15",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz",
+      "integrity": "sha512-28Ky0LlOqtEjwg5CdHmwwaDRHcTWfPRzkT6HrhwOSRS2RryAvuDfJrZpM+BMcrdeCyEg1mbcgIMoqTla+rdL8Q==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.11.tgz",
+      "integrity": "sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.15.tgz",
+      "integrity": "sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.15.tgz",
+      "integrity": "sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.8.tgz",
+      "integrity": "sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.7.tgz",
+      "integrity": "sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.17.tgz",
+      "integrity": "sha512-ru5IUbHUAYgJ5ZqZaBi6PEsMjFT/do0Eu21Qt7b07NuRuPlwAMhlqNRDy/KE9QAF20ygehb+xe9ebmyZ26/BSA==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.15",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.18.tgz",
+      "integrity": "sha512-7FqdbaJiVaHJDD9IfDhmzhSDbpjyx+ZsfdYuOpDJF09rl8qlIAIlZNoSaflKrQ3cEXZN2YxGPaNWGhbYimyIRQ==",
+      "dependencies": {
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-stream": "^2.0.23",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.7.0.tgz",
+      "integrity": "sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.15.tgz",
+      "integrity": "sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
+      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.22.tgz",
+      "integrity": "sha512-qcF20IHHH96FlktvBRICDXDhLPtpVmtksHmqNGtotb9B0DYWXsC6jWXrkhrrwF7tH26nj+npVTqh9isiFV1gdA==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.29.tgz",
+      "integrity": "sha512-+uG/15VoUh6JV2fdY9CM++vnSuMQ1VKZ6BdnkUM7R++C/vLjnlg+ToiSR1FqKZbMmKBXmsr8c/TsDWMAYvxbxQ==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/credential-provider-imds": "^2.1.4",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.7.tgz",
+      "integrity": "sha512-Q2gEind3jxoLk6hdKWyESMU7LnXz8aamVwM+VeVjOYzYT1PalGlY/ETa48hv2YpV4+YV604y93YngyzzzQ4IIA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.8.tgz",
+      "integrity": "sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.8.tgz",
+      "integrity": "sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.23.tgz",
+      "integrity": "sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.468.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.468.0.tgz",
+          "integrity": "sha512-rx/9uHI4inRbp2tw3Y4Ih4PNZkVj32h7WneSg3MVgVjAoVD5Zti9KhS5hkvsBxfgmQmg0AQbE+b1sy5WGAgntA==",
+          "requires": {
+            "@smithy/types": "^2.7.0",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+              "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+      "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.2.2",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "requires": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.25.0.tgz",
+      "integrity": "sha512-uEVKqKkPVz6atbCxCNJY5O7V+ieSK8crUswXo8/WePyEbGEgxJ4t9x/WG4lV8kBjelmvQHDR4GqfJmb5Sh9xSg==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.451.0.tgz",
+      "integrity": "sha512-xoImUiGoaXJZpOCgbWcdrU4vHJ8HG5KluaCkc32kuFobM277sjQimaUIHOGHL24M5vyo4QxcJD9CT/IhX63Vlg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.451.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+          "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.451.0",
+            "@aws-sdk/middleware-host-header": "3.451.0",
+            "@aws-sdk/middleware-logger": "3.451.0",
+            "@aws-sdk/middleware-recursion-detection": "3.451.0",
+            "@aws-sdk/middleware-user-agent": "3.451.0",
+            "@aws-sdk/region-config-resolver": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@aws-sdk/util-user-agent-browser": "3.451.0",
+            "@aws-sdk/util-user-agent-node": "3.451.0",
+            "@smithy/config-resolver": "^2.0.18",
+            "@smithy/fetch-http-handler": "^2.2.6",
+            "@smithy/hash-node": "^2.0.15",
+            "@smithy/invalid-dependency": "^2.0.13",
+            "@smithy/middleware-content-length": "^2.0.15",
+            "@smithy/middleware-endpoint": "^2.2.0",
+            "@smithy/middleware-retry": "^2.0.20",
+            "@smithy/middleware-serde": "^2.0.13",
+            "@smithy/middleware-stack": "^2.0.7",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/node-http-handler": "^2.1.9",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/smithy-client": "^2.1.15",
+            "@smithy/types": "^2.5.0",
+            "@smithy/url-parser": "^2.0.13",
+            "@smithy/util-base64": "^2.0.1",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.19",
+            "@smithy/util-defaults-mode-node": "^2.0.25",
+            "@smithy/util-endpoints": "^1.0.4",
+            "@smithy/util-retry": "^2.0.6",
+            "@smithy/util-utf8": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.451.0.tgz",
+          "integrity": "sha512-48NcIRxWBdP1fom6RSjwn2R2u7SE7eeV3p+c4s7ukEOfrHhBxJfn3EpqBVQMGzdiU55qFImy+Fe81iA2lXq3Jw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.451.0",
+            "@aws-sdk/credential-provider-node": "3.451.0",
+            "@aws-sdk/middleware-host-header": "3.451.0",
+            "@aws-sdk/middleware-logger": "3.451.0",
+            "@aws-sdk/middleware-recursion-detection": "3.451.0",
+            "@aws-sdk/middleware-sdk-sts": "3.451.0",
+            "@aws-sdk/middleware-signing": "3.451.0",
+            "@aws-sdk/middleware-user-agent": "3.451.0",
+            "@aws-sdk/region-config-resolver": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@aws-sdk/util-user-agent-browser": "3.451.0",
+            "@aws-sdk/util-user-agent-node": "3.451.0",
+            "@smithy/config-resolver": "^2.0.18",
+            "@smithy/fetch-http-handler": "^2.2.6",
+            "@smithy/hash-node": "^2.0.15",
+            "@smithy/invalid-dependency": "^2.0.13",
+            "@smithy/middleware-content-length": "^2.0.15",
+            "@smithy/middleware-endpoint": "^2.2.0",
+            "@smithy/middleware-retry": "^2.0.20",
+            "@smithy/middleware-serde": "^2.0.13",
+            "@smithy/middleware-stack": "^2.0.7",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/node-http-handler": "^2.1.9",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/smithy-client": "^2.1.15",
+            "@smithy/types": "^2.5.0",
+            "@smithy/url-parser": "^2.0.13",
+            "@smithy/util-base64": "^2.0.1",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.19",
+            "@smithy/util-defaults-mode-node": "^2.0.25",
+            "@smithy/util-endpoints": "^1.0.4",
+            "@smithy/util-retry": "^2.0.6",
+            "@smithy/util-utf8": "^2.0.2",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+          "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+          "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.451.0",
+            "@aws-sdk/credential-provider-process": "3.451.0",
+            "@aws-sdk/credential-provider-sso": "3.451.0",
+            "@aws-sdk/credential-provider-web-identity": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+          "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.451.0",
+            "@aws-sdk/credential-provider-ini": "3.451.0",
+            "@aws-sdk/credential-provider-process": "3.451.0",
+            "@aws-sdk/credential-provider-sso": "3.451.0",
+            "@aws-sdk/credential-provider-web-identity": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+          "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+          "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.451.0",
+            "@aws-sdk/token-providers": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+          "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+          "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+          "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+          "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+          "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/signature-v4": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "@smithy/util-middleware": "^2.0.6",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+          "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+          "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+          "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-dynamodb": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.27.0.tgz",
+      "integrity": "sha512-jlG7Rqj45axVu6Km036EpO5IejYmb6iiK+2ZZqFek/y3JYNPCS6Cl29GUCgEgTlmuJ6YkRG7TdV+1hrQVndulw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.27.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.27.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/util-waiter": "3.25.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-sqs": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.27.0.tgz",
+      "integrity": "sha512-qxkjkcPI2JOS4CQGKQw2H6WnlzV0aXX4QSTKdF9iiJR6555Bo9Da+NGjfq3WvANYFRDe/cj+8IOaNutPI+TXBg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.27.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/md5-js": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.25.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.27.0.tgz",
+      "integrity": "sha512-/Op+OaQgcAG/FyyqJc2NVfIJWEd1cTWIl8gBWSTUugrhhd5rMnAtg3u5ds/tYUimVQJv03z4bDjbI0Rnv/t6XQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.27.0.tgz",
+      "integrity": "sha512-QagsjULn6eacR/IL9d/nky17jUcqnbeShrHGrAyOhAXtehG3g2kkFcGbFy30iNw8gl1LteZL9dslpPFdWIEI1A==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/credential-provider-node": "3.27.0",
+        "@aws-sdk/fetch-http-handler": "3.25.0",
+        "@aws-sdk/hash-node": "3.25.0",
+        "@aws-sdk/invalid-dependency": "3.25.0",
+        "@aws-sdk/middleware-content-length": "3.25.0",
+        "@aws-sdk/middleware-host-header": "3.25.0",
+        "@aws-sdk/middleware-logger": "3.25.0",
+        "@aws-sdk/middleware-retry": "3.27.0",
+        "@aws-sdk/middleware-sdk-sts": "3.27.0",
+        "@aws-sdk/middleware-serde": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/middleware-user-agent": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/node-http-handler": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/smithy-client": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.25.0",
+        "@aws-sdk/util-user-agent-node": "3.27.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.27.0.tgz",
+      "integrity": "sha512-gc7dfBzdmUHJamMjOc0bzAkIm3VUIK9kbLQSy0+nfjT641+AYvXO3qpjR6ywvutsbKhBg5kyGn/4QhyRxg61OQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
+      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+      "requires": {
+        "@smithy/smithy-client": "^2.1.15",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.451.0.tgz",
+      "integrity": "sha512-g1ZT46NuYfou00d94rJZ59N4TLI1T+v46lbHTtF9jwohiUsi7/vHkPIOdrgtrThGzGUVl01w62N0a2mpMydaBA==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.27.0.tgz",
+      "integrity": "sha512-IbPdlYl0A5GcpuT394cJceexxo0tzUzC7jIUxqL8gNbB/MIXC5ZlkeX9Z7bYloNb8SXk7GumXyQTsK1CchUvQA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.451.0.tgz",
+      "integrity": "sha512-q82kEzymqimkJ2dHmuN2RGpi9HTFSxwwoXALnzPRaRcvR/v+YY8FMgSTfwXzPkHUDf/q8J+aDz6lPcYlnsP3sQ==",
+      "requires": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-stream": "^2.0.20",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.27.0.tgz",
+      "integrity": "sha512-rhzlEvxiB7ecpVDl3NkjP1vPmqs+HHmqNXrK4efOYshwIbu+/h3xPePQMBOQ0AGezYn3k/iumoXXysVhVqtwUA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/url-parser": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.27.0.tgz",
+      "integrity": "sha512-jvWUDz6nFqUvjmPRebwf1mWsOZ+inmZNQxz20DC/ROCRfGF1y8Yqf7KgCJy8MQOlDdTA4lPS+w6OJ0J/OOGbPg==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.27.0",
+        "@aws-sdk/credential-provider-imds": "3.27.0",
+        "@aws-sdk/credential-provider-sso": "3.27.0",
+        "@aws-sdk/credential-provider-web-identity": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.27.0.tgz",
+      "integrity": "sha512-GfCDX/AA7EJKyVGmNnh3wngWfEWFkuNJyend6FLN+81s3kUpXTkILuZCwQrD9AyjBYR2ksv0t929nW2fBUGT9Q==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.27.0",
+        "@aws-sdk/credential-provider-imds": "3.27.0",
+        "@aws-sdk/credential-provider-ini": "3.27.0",
+        "@aws-sdk/credential-provider-process": "3.27.0",
+        "@aws-sdk/credential-provider-sso": "3.27.0",
+        "@aws-sdk/credential-provider-web-identity": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.27.0.tgz",
+      "integrity": "sha512-F9pqKKnd5+fwoldVQJX9uLbDyPyIDnCpZGbiTw6BZANZM1qhjoEn7rNE5g2h0tkeq4dWMA9bANKMR4j3YhTpXw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.27.0.tgz",
+      "integrity": "sha512-yXyy+/FYFtpnRmPBiw5rxwSQBj1pcI0R+z77EA8a8+tozZPjsIri+xBsU62DtIlv/2yVb/goPgw+w2vg0L4NFw==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.27.0.tgz",
+      "integrity": "sha512-FYvDzB4UqmJjY+ZZoIAPM1EFK9/RdNn1VT5xvDcebQe7xKOVUG1tZbOA4rVZ3MUcxfyRqp7Ou/AhIWu/9RSt2Q==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.451.0.tgz",
+      "integrity": "sha512-ihbYZrI/tSVsZFDGLfJoCx3sg1s9EQqWA+xbLoquK+RjMqTnaeshYntFJmQA5yqCIbcAkyw63OwOIBRrVb7tMA==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.451.0",
+        "@aws-sdk/client-sso": "3.451.0",
+        "@aws-sdk/client-sts": "3.451.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.451.0",
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-http": "3.451.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+          "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.451.0",
+            "@aws-sdk/middleware-host-header": "3.451.0",
+            "@aws-sdk/middleware-logger": "3.451.0",
+            "@aws-sdk/middleware-recursion-detection": "3.451.0",
+            "@aws-sdk/middleware-user-agent": "3.451.0",
+            "@aws-sdk/region-config-resolver": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@aws-sdk/util-user-agent-browser": "3.451.0",
+            "@aws-sdk/util-user-agent-node": "3.451.0",
+            "@smithy/config-resolver": "^2.0.18",
+            "@smithy/fetch-http-handler": "^2.2.6",
+            "@smithy/hash-node": "^2.0.15",
+            "@smithy/invalid-dependency": "^2.0.13",
+            "@smithy/middleware-content-length": "^2.0.15",
+            "@smithy/middleware-endpoint": "^2.2.0",
+            "@smithy/middleware-retry": "^2.0.20",
+            "@smithy/middleware-serde": "^2.0.13",
+            "@smithy/middleware-stack": "^2.0.7",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/node-http-handler": "^2.1.9",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/smithy-client": "^2.1.15",
+            "@smithy/types": "^2.5.0",
+            "@smithy/url-parser": "^2.0.13",
+            "@smithy/util-base64": "^2.0.1",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.19",
+            "@smithy/util-defaults-mode-node": "^2.0.25",
+            "@smithy/util-endpoints": "^1.0.4",
+            "@smithy/util-retry": "^2.0.6",
+            "@smithy/util-utf8": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.451.0.tgz",
+          "integrity": "sha512-48NcIRxWBdP1fom6RSjwn2R2u7SE7eeV3p+c4s7ukEOfrHhBxJfn3EpqBVQMGzdiU55qFImy+Fe81iA2lXq3Jw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.451.0",
+            "@aws-sdk/credential-provider-node": "3.451.0",
+            "@aws-sdk/middleware-host-header": "3.451.0",
+            "@aws-sdk/middleware-logger": "3.451.0",
+            "@aws-sdk/middleware-recursion-detection": "3.451.0",
+            "@aws-sdk/middleware-sdk-sts": "3.451.0",
+            "@aws-sdk/middleware-signing": "3.451.0",
+            "@aws-sdk/middleware-user-agent": "3.451.0",
+            "@aws-sdk/region-config-resolver": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@aws-sdk/util-user-agent-browser": "3.451.0",
+            "@aws-sdk/util-user-agent-node": "3.451.0",
+            "@smithy/config-resolver": "^2.0.18",
+            "@smithy/fetch-http-handler": "^2.2.6",
+            "@smithy/hash-node": "^2.0.15",
+            "@smithy/invalid-dependency": "^2.0.13",
+            "@smithy/middleware-content-length": "^2.0.15",
+            "@smithy/middleware-endpoint": "^2.2.0",
+            "@smithy/middleware-retry": "^2.0.20",
+            "@smithy/middleware-serde": "^2.0.13",
+            "@smithy/middleware-stack": "^2.0.7",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/node-http-handler": "^2.1.9",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/smithy-client": "^2.1.15",
+            "@smithy/types": "^2.5.0",
+            "@smithy/url-parser": "^2.0.13",
+            "@smithy/util-base64": "^2.0.1",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.19",
+            "@smithy/util-defaults-mode-node": "^2.0.25",
+            "@smithy/util-endpoints": "^1.0.4",
+            "@smithy/util-retry": "^2.0.6",
+            "@smithy/util-utf8": "^2.0.2",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+          "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+          "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.451.0",
+            "@aws-sdk/credential-provider-process": "3.451.0",
+            "@aws-sdk/credential-provider-sso": "3.451.0",
+            "@aws-sdk/credential-provider-web-identity": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+          "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.451.0",
+            "@aws-sdk/credential-provider-ini": "3.451.0",
+            "@aws-sdk/credential-provider-process": "3.451.0",
+            "@aws-sdk/credential-provider-sso": "3.451.0",
+            "@aws-sdk/credential-provider-web-identity": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+          "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+          "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.451.0",
+            "@aws-sdk/token-providers": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+          "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+          "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+          "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+          "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.451.0",
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+          "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/signature-v4": "^2.0.0",
+            "@smithy/types": "^2.5.0",
+            "@smithy/util-middleware": "^2.0.6",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+          "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+          "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+          "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/endpoint-cache": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.23.0.tgz",
+      "integrity": "sha512-Yhe1JvrTEA+BQuT/wfwvYDMqozB4GKXVRA4ZzU5VhkvMwbWd7/xGzDLQ0JG7jtYX3TwRYsBLI1XdQ1oYG3bmrQ==",
+      "requires": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.25.0.tgz",
+      "integrity": "sha512-792kkbfSRBdiFb7Q2cDJts9MKxzAwuQSwUIwRKAOMazU8HkKbKnXXAFSsK3T7VasOFOh7O7YEGN0q9UgEw1q+g==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.25.0.tgz",
+      "integrity": "sha512-qRn6iqG9VLt8D29SBABcbauDLn92ssMjtpyVApiOhDYyFm2VA2avomOHD6y2PRBMwM5FMQAygZbpA2HIN2F96w==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.25.0.tgz",
+      "integrity": "sha512-ZBXjBAF2JSiO/wGBa1oaXsd1q5YG3diS8TfIUMXeQoe9O66R5LGoGOQeAbB/JjlwFot6DZfAcfocvl6CtWwqkw==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
+      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.25.0.tgz",
+      "integrity": "sha512-97MtL1VF3JCkyJJnwi8LcXpqItnH1VtgoqtVqmaASYp5GXnlsnA1WDnB0754ufPHlssS1aBj/gkLzMZ0Htw/Rg==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.25.0.tgz",
+      "integrity": "sha512-uOXus0MmZi/mucRIr5yfwM1vDhYG66CujNfnhyEaq5f4kcDA1Q5qPWSn9dkQPV9JWTZK3WTuYiOPSgtmlAYTAg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.27.0.tgz",
+      "integrity": "sha512-RmUAePYGmDepRJM/J9Xbm6aKfvislGpTURoCNPBTSEYtSRNBWMJAp3dC/AS9kctwSjcWFral8UdLLCh92EFVZw==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.27.0",
+        "@aws-sdk/endpoint-cache": "3.23.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.25.0.tgz",
+      "integrity": "sha512-xKD/CfsUS3ul2VaQ3IgIUXgA7jU2/Guo/DUhYKrLZTOxm0nuvsIFw0RqSCtRBCLptE5Qi+unkc1LcFDbfqrRbg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.25.0.tgz",
+      "integrity": "sha512-M1F7BlAsDKoEM8hBaU2pHlLSM40rzzgtZ6jFNhfmTwGcjxe1N7JXCH5QPa7aI8wnJq2RoIRHVfVsUH4GwvOZnA==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
+      "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
+      "requires": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.27.0.tgz",
+      "integrity": "sha512-H57NP27qOxgbPRwCFkBYtAJylhAOWKSv3/TsCpDNnrb3Z0pqKUQH9mLC8hRGTRplkA7SDGfiuf9bsoNhZ3HFwQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/service-error-classification": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.25.0.tgz",
+      "integrity": "sha512-ac4tN49+Ehxz7wx/upGHeGvYreMFxg0aVC1t+8DMXPOAXzga0VhkW0qAng7Xh0W2+IcaqpDtx+rQ+C244g5XHw==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.27.0.tgz",
+      "integrity": "sha512-4geCMczCujTz4GWSrwKhxEW9rYikp5NrLcIpHI0NjthQQfa8T4/D1WSsSnW3JNmQcMgQXeC9h8jTn0dOE4EhUw==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.27.0",
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.25.0.tgz",
+      "integrity": "sha512-065Kugo8yXzBkcVAxctxFCHKlHcINnaQRsJ8ifvgc+UOEgvTG9+LfGWDwfdgarW9CkF7RkCoZOyaqFsO+HJWsg==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.27.0.tgz",
+      "integrity": "sha512-eOXwKOFuCIGAW3wZO9Cyh+z7swZYTq8BiBDjwWu6u0UBb5B/zMiq1z1LDa88iZY200O3Zip8+6RZV7LLd3XH+Q==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/signature-v4": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.25.0.tgz",
+      "integrity": "sha512-s2VgdsasOVKHY3/SIGsw9AeZMMsdcIbBGWim9n5IO3j8C8y54EdRLVCEja8ePvMDZKIzuummwatYPHaUrnqPtQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.25.0.tgz",
+      "integrity": "sha512-HXd/Qknq8Cp7fzJYU7jDDpN7ReJ3arUrnt+dAPNaDDrhmrBbCZp+24UXN6X6DAj0JICRoRuF/l7KxjwdF5FShw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.27.0.tgz",
+      "integrity": "sha512-5jeCLV7NI/ouQCMGDnGbxpCBhGirksXY55uvAaeysMxzjJLmPDwOZUD1gMhfYe8lxvktwhAndOdPQofWwTFUoQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.27.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.25.0.tgz",
+      "integrity": "sha512-zVeAM/bXewZiuMtcUZI/xGDID6knkzOv73ueVkzUbP0Ki8bfao7diR3hMbIt5Fy/r8cAVjJce9v6zFqo4sr1WA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/protocol-http": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.27.0.tgz",
+      "integrity": "sha512-8vovVNldgJwCpUfehdwUPwvzfUPB7TEW/tcTgrkLQW/cpEULbRrymtiZrzSkBLspNw2iU5d3FpQxE61s1ou0UA==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.25.0.tgz",
+      "integrity": "sha512-4Jebt5G8uIFa+HZO7KOgOtA66E/CXysQekiV5dfAsU8ca+rX5PB6qhpWZ2unX/l6He+oDQ0zMoW70JkNiP4/4w==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.25.0.tgz",
+      "integrity": "sha512-o/R3/viOxjWckI+kepkxJSL7fIdg1hHYOW/rOpo9HbXS0CJrHVnB8vlBb+Xwl1IFyY2gg+5YZTjiufcgpgRBkw==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.25.0.tgz",
+      "integrity": "sha512-FCNyaOLFLVS5j43MhVA7/VJUDX0t/9RyNTNulHgzFjj6ffsgqcY0uwUq1RO3QCL4asl56zOrLVJgK+Z7wMbvFg==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
+      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.25.0.tgz",
+      "integrity": "sha512-66FfIab87LnnHtOLrGrVOht9Pw6lE8appyOpBdtoeoU5DP7ARSWuDdsYmKdGdRCWvn/RaVFbSYua9k0M1WsGqg=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
+      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.25.0.tgz",
+      "integrity": "sha512-6KDRRz9XVrj9RxrBLC6dzfnb2TDl3CjIzcNpLdRuKFgzEEdwV+5D+EZuAQU3MuHG5pWTIwG72k/dmCbJ2MDPUQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.27.0.tgz",
+      "integrity": "sha512-PpsSDUsRqw8HGuXv+AR2UzhVUJz4APM7K6Br8TTDPKvDwQtXkT5GROXRyAwU+htPcOHq006lS5EiF343y0HRvg==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
+      "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+          "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+          "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+          "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@aws-sdk/util-endpoints": "3.451.0",
+            "@smithy/protocol-http": "^3.0.9",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+          "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/types": "^2.5.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+          "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+          "requires": {
+            "@aws-sdk/types": "3.451.0",
+            "@smithy/node-config-provider": "^2.1.5",
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.25.0.tgz",
+      "integrity": "sha512-vS0+cTKwj6CujlR07HmeEBxzWPWSrdmZMYnxn/QC9KW9dFu0lsyCGSCqWsFluI6GI0flsnYYWNkP5y4bfD9tqg=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.25.0.tgz",
+      "integrity": "sha512-qZ3Vq0NjHsE7Qq6R5NVRswIAsiyYjCDnAV+/Vt4jU/K0V3mGumiasiJyRyblW4Da8R6kfcJk0mHSMFRJfoHh8Q==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
+      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
+      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
+      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
+      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
+      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
+      "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-dynamodb": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.27.0.tgz",
+      "integrity": "sha512-ZrgkiaLYtEq3p2R3RwaiomzkK/uJhqKnDBv/Cm9rhcWOoAbn/rzrS57vTxN46cXJ1jGDvQOhwF2JREMCzYB08Q==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
+      "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
+      "requires": {
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/util-endpoints": "^1.0.4",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.451.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+          "requires": {
+            "@smithy/types": "^2.5.0",
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
+      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
+      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.25.0.tgz",
+      "integrity": "sha512-qGqiWfs49NRmQVXPsBXgMRVkjDZocicU0V2wak98e0t7TOI+KmP8hnwsTkE6c4KwhsFOOUhAzjn5zk3kOwi6tQ==",
+      "requires": {
+        "@aws-sdk/types": "3.25.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.27.0.tgz",
+      "integrity": "sha512-jigZzAuhEnaLFeYEDGKQq8tas8OsT6qI7WAm/UnCXqtLhdnIu7u1yPhXk+TjI7SSn4Z6zP6Oh1qtFxzhpPmdoQ==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.27.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
+      "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
+      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.25.0.tgz",
+      "integrity": "sha512-rhJ7Q2fcPD8y4H0qNEpaspkSUya0OaNcVrca9wCZKs7jWnropPzrQ+e2MH7fWJ/8jgcBV890+Txr4fWkD4J01g==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.25.0",
+        "@aws-sdk/types": "3.25.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@smithy/abort-controller": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
+      "integrity": "sha512-JkS36PIS3/UCbq/MaozzV7jECeL+BTt4R75bwY8i+4RASys4xOyUS1HsRyUNSqUXFP4QyCz5aNnh3ltuaxv+pw==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.21.tgz",
+      "integrity": "sha512-rlLIGT+BeqjnA6C2FWumPRJS1UW07iU5ZxDHtFuyam4W65gIaOFMjkB90ofKCIh+0mLVQrQFrl/VLtQT/6FWTA==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz",
+      "integrity": "sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
+      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.1.tgz",
+      "integrity": "sha512-6MNk16fqb8EwcYY8O8WxB3ArFkLZ2XppsSNo1h7SQcFdDDwIumiJeO6wRzm7iB68xvsOQzsdQKbdtTieS3hfSQ==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.17.tgz",
+      "integrity": "sha512-Il6WuBcI1nD+e2DM7tTADMf01wEPGK8PAhz4D+YmDUVaoBqlA+CaH2uDJhiySifmuKBZj748IfygXty81znKhw==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.15.tgz",
+      "integrity": "sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.17.tgz",
+      "integrity": "sha512-OyadvMcKC7lFXTNBa8/foEv7jOaqshQZkjWS9coEXPRZnNnihU/Ls+8ZuJwGNCOrN2WxXZFmDWhegbnM4vak8w==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.3.tgz",
+      "integrity": "sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==",
+      "requires": {
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-middleware": "^2.0.8",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.24.tgz",
+      "integrity": "sha512-q2SvHTYu96N7lYrn3VSuX3vRpxXHR/Cig6MJpGWxd0BWodUQUWlKvXpWQZA+lTaFJU7tUvpKhRd4p4MU3PbeJg==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-retry": "^2.0.8",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.15.tgz",
+      "integrity": "sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.9.tgz",
+      "integrity": "sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.8.tgz",
+      "integrity": "sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.1.tgz",
+      "integrity": "sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.15",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz",
+      "integrity": "sha512-28Ky0LlOqtEjwg5CdHmwwaDRHcTWfPRzkT6HrhwOSRS2RryAvuDfJrZpM+BMcrdeCyEg1mbcgIMoqTla+rdL8Q==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.11.tgz",
+      "integrity": "sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.15.tgz",
+      "integrity": "sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.15.tgz",
+      "integrity": "sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.8.tgz",
+      "integrity": "sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==",
+      "requires": {
+        "@smithy/types": "^2.7.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.7.tgz",
+      "integrity": "sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.17.tgz",
+      "integrity": "sha512-ru5IUbHUAYgJ5ZqZaBi6PEsMjFT/do0Eu21Qt7b07NuRuPlwAMhlqNRDy/KE9QAF20ygehb+xe9ebmyZ26/BSA==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.0.15",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.18.tgz",
+      "integrity": "sha512-7FqdbaJiVaHJDD9IfDhmzhSDbpjyx+ZsfdYuOpDJF09rl8qlIAIlZNoSaflKrQ3cEXZN2YxGPaNWGhbYimyIRQ==",
+      "requires": {
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-stream": "^2.0.23",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.7.0.tgz",
+      "integrity": "sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.15.tgz",
+      "integrity": "sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==",
+      "requires": {
+        "@smithy/querystring-parser": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
+      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "requires": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.22.tgz",
+      "integrity": "sha512-qcF20IHHH96FlktvBRICDXDhLPtpVmtksHmqNGtotb9B0DYWXsC6jWXrkhrrwF7tH26nj+npVTqh9isiFV1gdA==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.29.tgz",
+      "integrity": "sha512-+uG/15VoUh6JV2fdY9CM++vnSuMQ1VKZ6BdnkUM7R++C/vLjnlg+ToiSR1FqKZbMmKBXmsr8c/TsDWMAYvxbxQ==",
+      "requires": {
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/credential-provider-imds": "^2.1.4",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.7.tgz",
+      "integrity": "sha512-Q2gEind3jxoLk6hdKWyESMU7LnXz8aamVwM+VeVjOYzYT1PalGlY/ETa48hv2YpV4+YV604y93YngyzzzQ4IIA==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.8.tgz",
+      "integrity": "sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==",
+      "requires": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.8.tgz",
+      "integrity": "sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==",
+      "requires": {
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.23.tgz",
+      "integrity": "sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
+    "mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "requires": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/.github/workflows/scripts/dp/package.json
+++ b/.github/workflows/scripts/dp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dp",
+  "version": "1.0.0",
+  "description": "Runs OIL tests using deployer-platform to provision target hosts",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@actions/core": "1.2.6",
+    "@aws-sdk/client-sqs": "3.27.0",
+    "@aws-sdk/client-dynamodb": "3.27.0",
+    "@aws-sdk/util-dynamodb": "3.27.0",
+    "@aws-sdk/credential-providers": "3.451.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/.github/workflows/smoke-eu-dp.yml
+++ b/.github/workflows/smoke-eu-dp.yml
@@ -1,0 +1,258 @@
+name: Smoke Tests (dp)(EU)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  log-context:
+    runs-on: ubuntu-latest
+    steps:
+      # Dump all contexts
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+  get-test-definition-files:
+    name: Get Test Definition Files
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-test-definition-files.outputs.result }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get Test Definition Files
+        id: get-test-definition-files
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const fs = require('fs');
+            const fsp = fs.promises;
+            const path = require('path');
+
+            // readdir recursive directory search
+            const { readdir } = fsp;
+            async function getFiles(dir) {
+                const dirents = await readdir(dir, { withFileTypes: true });
+                const files = await Promise.all(dirents.map((dirent) => {
+                    const res = path.join(dir, dirent.name);
+                    return dirent.isDirectory() ? getFiles(res) : res;
+                }));
+                return Array.prototype.concat(...files);
+            }
+            const definitionsDir = 'test/definitions-eu/smoke'
+            const testDefinitions = await getFiles(definitionsDir);
+
+            const outputTestFilesMap = testDefinitions.map(testDefinitionFile => {
+                return { testDefinitionFile, 'testDisplayName': testDefinitionFile.replace(`${definitionsDir}/`, '') }
+            })
+            const output = {
+                "include": outputTestFilesMap
+            }
+            console.log(output);
+            return output;
+
+  test-deploy-recipe:
+    name: ${{ matrix.testDisplayName }}
+    needs: [get-test-definition-files]
+    if: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix).include[0] }} # Avoids empty matrix validation error
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.get-test-definition-files.outputs.matrix) }}
+      fail-fast: false
+    env:
+      MATRIX: ${{ toJSON(matrix) }}
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '20.x'
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Update Test Definition Files URLs
+        id: get-test-definition-files
+        env:
+          TEST_DEFINITION_FILE: ${{ matrix.testDefinitionFile }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const fs = require('fs');
+            const fsp = fs.promises;
+            const path = require('path');
+
+            // before returning, we need to edit the deploy config files in-place so they 
+            // use the right URLs from the branch
+            async function getDeployConfigFile(file, outputDir) {
+              const data = await fsp.readFile(path.join(outputDir, file));
+              return JSON.parse(data);
+            }
+
+            // Get testDefinitonFile from MATRIX env var
+            const testDefinitionFile = process.env.TEST_DEFINITION_FILE;
+            console.log(`Detected Deploy Config: ${JSON.stringify(testDefinitionFile, null, 2)}`)
+
+            // Update URLs to use branch this PR is opened with
+            const data = await getDeployConfigFile(testDefinitionFile, process.env.GITHUB_WORKSPACE);
+
+            // Update github source URLs with branch name
+            let jsonContent = JSON.stringify(data, null, 2);
+            const branchName = process.env.GITHUB_HEAD_REF ? process.env.GITHUB_HEAD_REF : process.env.GITHUB_REF_NAME;
+            const replacementString = `$1$2-b ${branchName} $3$4`;
+            const sourceRepositoryRegex = /(.*)(\")(https:\/\/github.com\/newrelic\/open-install-library)(.*)/gi;
+            jsonContent = jsonContent.replace(sourceRepositoryRegex, replacementString);
+            console.log(`Detected Deploy Config: ${JSON.stringify(jsonContent, null, 2)}`)
+
+            // Update raw URLs with branch name
+            const replacementString2 = `$1${branchName}$3`;
+            const sourceRepositoryRegex2 = /(raw.githubusercontent.com\/newrelic\/open-install-library\/)(main)(\/newrelic\/recipes\/)*/gi;
+            jsonContent = jsonContent.replace(sourceRepositoryRegex2, replacementString2);
+            console.log(`Detected Deploy Config: ${JSON.stringify(jsonContent, null, 2)}`)
+
+            // Write file back to workspace
+            const outputPath = `${process.env.GITHUB_WORKSPACE}/${testDefinitionFile}`;
+            fs.writeFileSync(outputPath, jsonContent);
+
+            return testDefinitionFile;      
+
+      - name: Write Test Definition File JSON to file
+        env:
+          USER_JSON: ${{ secrets.GIT_DEPLOYER_DOCKER_USER_CONFIG_EU }}
+        run: |
+          echo "$USER_JSON" > configs/gitusdkreu${{ github.run_id }}.json
+
+      - name: Install Test Dependencies
+        working-directory: ${{ github.workspace }}/.github/scripts/dp
+        run: npm install
+
+      - name: Run Test
+        id: runDeployerPlatformTest
+        working-directory: ${{ github.workspace }}/.github/scripts/dp
+        run: |
+          echo "TEST_DEFINITION=$(echo $MATRIX | jq -c -r '.testDefinitionFile')" >> $GITHUB_ENV      
+          node main.js
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SQS_URL: ${{ secrets.SQS_URL }}
+          DYNAMO_TABLE: ${{ secrets.DYNAMO_TABLE }}
+
+      - name: Report any error
+        if: steps.runDeployerPlatformTest.outputs.exit_status != 0
+        run: exit 1
+
+  slack-notify:
+    runs-on: ubuntu-latest
+    needs: [test-deploy-recipe]
+    if: always()
+    steps:
+      - name: Build Result Slack Notification
+        uses: 8398a7/action-slack@v3
+        with:
+          author_name: GitHub Actions
+          status: custom
+          fields: commit,repo,ref,author,eventName,message,workflow
+          custom_payload: |
+            {
+              username: "GitHub Actions",
+              icon_emoji: ":octocat:",
+              attachments: [{
+                color: ${{
+                  needs.test-deploy-recipe.result == 'success'
+                }} === true ? '#43cc11' : '#e05d44',
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `Build for ${process.env.AS_REPO}`
+                    }
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {
+                        type: "mrkdwn",
+                        text: `*Commit:*\n${process.env.AS_COMMIT}`
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: `*Author:*\n${process.env.AS_AUTHOR}`
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: `*Branch:*\n${process.env.AS_REF}`
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: `*Message:*\n${process.env.AS_MESSAGE}`
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: `*Type:*\n${process.env.AS_EVENT_NAME}`
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: "*PR:*\n${{ github.event.pull_request.html_url }}"
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: `*Workflow:*\n${ process.env.AS_WORKFLOW }`
+                      }
+                    ]
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: [
+                        "*Result:*",
+                        `• ${ ${{ needs.test-deploy-recipe.result == 'success' }} === true ? '✅' : '❌' } Non-regression testing of smoke tests (EU): ${{ needs.test-deploy-recipe.result }}`
+                      ].join('\n')
+                    }
+                  },
+                  {
+                    type: "context",
+                    elements: [
+                      {
+                        type: "image",
+                        image_url: "https://avatars2.githubusercontent.com/in/15368",
+                        alt_text: "Github Actions"
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: "This message was created automatically by GitHub Actions."
+                      }
+                    ]
+                  }
+                ]
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
The following changes to start the test migration to deployer-platform:
- added NodeJS script that reads the test definition file json and sends to SQS.  This json contains the newrelic install command, so the deployment will end up in either `PROVISIONED` or `FAILED` state when these run (this is what we query from Dynamo to determine pass/fail

- EU region-specific workflow (manually triggered for the time being) to permit configuring GHA secrets for an EU NR user (smoke-eu-dp.yml)

- US region-specific workflow (manually triggered for the time being) to permit configuring GHA secrets for a US NR user (nonregression-dp.yml)