### PR TITLE
feat(kubernetes): Add gke autopilot check to script

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -632,6 +632,14 @@ install:
               fi
             fi
           else
+            # We currently dont' support installing in GKE Autopilot using kubectl
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+             echo ""
+             echo -e "\033[0;31mUsing kubectl to install the Kubernetes integration is currently not supported.\033[0m" >&2
+             echo -e "\033[0;31mPlease install helm and try again.\033[0m" >&2
+             exit 131
+            fi
+
             echo ""
             echo "Using kubectl to install the Kubernetes integration"
             echo ""
@@ -658,9 +666,11 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
-            # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
-            # BODY="${BODY},\""newrelic-infrastructure.kubelet.config.port\":\"10255\""
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+              # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
+              # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
+              # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""
+            fi
 
             # leaving this commented out for the future
             # if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -552,7 +552,7 @@ install:
             fi
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
-            # if installing in GKE Autopilot, we need to turn off controlPlane and set kubelet scheme and port
+            # if installing in GKE Autopilot, we need to turn off controlPlane and pixie and set kubelet scheme and port
             if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
               ARGS="${ARGS} --set newrelic-infrastructure.controlPlane.enabled=false"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.scheme=http"
@@ -620,10 +620,16 @@ install:
             echo "{\"Metadata\":{\"helmVersion\":\"$($SUDO helm version -c --short)\", \"helmCommandBeforeExecution\":\"$SUDO helm upgrade $CLEANED_ARGS\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\",\"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
 
             # With 2>&1 >/dev/null, ERROR only keeps the error message if $? is non-zero and is empty if $? is zero
+            echo "Installing newrelic-bundle......."
             ERROR=$($SUDO helm upgrade $ARGS 2>&1 >/dev/null)
             if [[ "${ERROR}" != "" ]]; then
-              echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
-              exit 131
+              if [[ "${GKE_AUTOPILOT_ANSWER}" == "Y" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
+                echo "Warnings from GKE Autopilot: $ERROR"
+                break
+              else
+                echo "helm (version $HELM_VERSION) repo upgrade installation failed due to: $ERROR"
+                exit 131
+              fi
             fi
           else
             echo ""
@@ -651,7 +657,7 @@ install:
             BODY="${BODY},\"global.lowDataMode\":\"${NR_CLI_LOW_DATA_MODE}\""
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
-            # # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
+            # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
             # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
             # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
             # BODY="${BODY},\""newrelic-infrastructure.kubelet.config.port\":\"10255\""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -220,8 +220,8 @@ install:
                 NR_CLI_LOGGING=false
                 break
               fi
-              echo -e "Please type Y or N only."
             fi
+              echo -e "Please type Y or N only."
           done
 
           # Determine the cluster name if not provided

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -191,27 +191,37 @@ install:
           DEBUG_MESSAGE=""
 
           # Determine if user is installing in gke autopilot
+
+          GKE_AUTOPILOT_ANSWER="N"
           while :; do
             echo -e -n "${GREEN}Are you installing in a GKE Autopilot cluster? Y/N? ${NC} "
-            read ans
-            echo ""
-            GKE_AUTOPILOT_ANSWER=$(echo "${ans^^}" | cut -c1-1)
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "N" ]]; then
+
+            if [[ "{{.NEW_RELIC_ASSUME_YES}}" == "true" ]]; then
+              echo "Assume yes flag was provided - answering N for installing in GKE Autopilot."
               echo "Continuing with installing the integration."
-              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              GKE_AUTOPILOT_ANSWER="N"
               break
+            else
+              read ans
+              echo ""
+              GKE_AUTOPILOT_ANSWER=$(echo "${ans^^}" | cut -c1-1)
+              if [[ "$GKE_AUTOPILOT_ANSWER" == "N" ]]; then
+                echo "Continuing with installing the integration."
+                echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                break
+              fi
+              if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+                echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+                echo "GKE Autopilot does not allowed privileged access. Turning off privileged mode." >&2
+                echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
+                echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
+                NR_CLI_PRIVILEGED=false
+                PIXIE_SUPPORTED=false
+                NR_CLI_LOGGING=false
+                break
+              fi
+              echo -e "Please type Y or N only."
             fi
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
-              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
-              echo "GKE Autopilot does not allowed privileged access. Turning off privileged mode." >&2
-              echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
-              echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
-              NR_CLI_PRIVILEGED=false
-              PIXIE_SUPPORTED=false
-              NR_CLI_LOGGING=false
-              break
-            fi
-            echo -e "Please type Y or N only."
           done
 
           # Determine the cluster name if not provided

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -190,6 +190,29 @@ install:
           # DEBUG_MESSAGE is used to collect all necessary debug info we need.
           DEBUG_MESSAGE=""
 
+          # Determine if user is installing in gke autopilot
+          while :; do
+            echo -e -n "${GREEN}Are you installing in a GKE Autopilot cluster? Y/N? ${NC} "
+            read ans
+            echo ""
+            GKE_AUTOPILOT_ANSWER=$(echo "${ans^^}" | cut -c1-1)
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "N" ]]; then
+              echo "Continuing with installing the integration."
+              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              break
+            fi
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo "GKE Autopilot does not allowed privileged access. Turning off privileged mode." >&2
+              echo -e "\033[0;31mTurning off Pixie and Logging for this installation which requires privileged access.\033[0m" >&2
+              NR_CLI_PRIVILEGED=false
+              PIXIE_SUPPORTED=false
+              NR_CLI_LOGGING=false
+              break
+            fi
+            echo -e "Please type Y or N only."
+          done
+
           # Determine the cluster name if not provided
           CLUSTER=$($SUDO $KUBECTL config current-context 2>/dev/null || echo "unknown")
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -552,6 +552,14 @@ install:
             fi
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
+            # if installing in GKE Autopilot, we need to turn off controlPlane and set kubelet scheme and port
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+              ARGS="${ARGS} --set newrelic-infrastructure.controlPlane.enabled=false"
+              ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.scheme=http"
+              ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.port=10255"
+              ARGS="${ARGS} --set newrelic-pixie.enabled=false"
+            fi
+
             # leaving this commented out for the future
             # if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then
             #   ARGS="${ARGS} --set kube-state-metrics.image.tag=v2.6.0"
@@ -642,6 +650,11 @@ install:
             BODY="${BODY},\"newrelic-infrastructure.privileged\":\"${NR_CLI_PRIVILEGED}\""
             BODY="${BODY},\"global.lowDataMode\":\"${NR_CLI_LOW_DATA_MODE}\""
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
+
+            # # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
+            # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
+            # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
+            # BODY="${BODY},\""newrelic-infrastructure.kubelet.config.port\":\"10255\""
 
             # leaving this commented out for the future
             # if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -204,7 +204,8 @@ install:
             if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               echo "GKE Autopilot does not allowed privileged access. Turning off privileged mode." >&2
-              echo -e "\033[0;31mTurning off Pixie and Logging for this installation which requires privileged access.\033[0m" >&2
+              echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
+              echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
               NR_CLI_PRIVILEGED=false
               PIXIE_SUPPORTED=false
               NR_CLI_LOGGING=false

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -632,14 +632,6 @@ install:
               fi
             fi
           else
-            # We currently dont' support installing in GKE Autopilot using kubectl
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
-             echo ""
-             echo -e "\033[0;31mUsing kubectl to install the Kubernetes integration is currently not supported.\033[0m" >&2
-             echo -e "\033[0;31mPlease install helm and try again.\033[0m" >&2
-             exit 131
-            fi
-
             echo ""
             echo "Using kubectl to install the Kubernetes integration"
             echo ""
@@ -666,11 +658,11 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            # if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
-              # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
-              # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
-              # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""
-            # fi
+            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+              BODY="${BODY},\"newrelic-infrastructure.controlPlane.enabled\":\"false\""
+              BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
+              BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""
+            fi
 
             # leaving this commented out for the future
             # if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -212,7 +212,7 @@ install:
               fi
               if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
                 echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
-                echo "GKE Autopilot does not allowed privileged access. Turning off privileged mode." >&2
+                echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
                 echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
                 echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
                 NR_CLI_PRIVILEGED=false

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -666,11 +666,11 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+            # if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
               # BODY="${BODY},\"newrelic-infrastructure.controlPlane\":\"false\""
               # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
               # BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""
-            fi
+            # fi
 
             # leaving this commented out for the future
             # if [[ $SERVER_MAJOR_VERSION -eq 1 && $SERVER_MINOR_VERSION -lt 25 ]]; then


### PR DESCRIPTION
Updating the script to check if user is installing in a GKE Autopilot. If they are, it will turn off privileged mode, control plane and then turn off pixie since it requires privileged access. It also turns off logging which is not currently supported in GKE autopilot. 