### PR TITLE
feat: update super-agent recipes to match new agent-id conventions

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -331,14 +331,14 @@ install:
           # Remove old config location (to deprecate)
           rm -f /etc/newrelic-super-agent/nrdot-values.yaml
           sed -i "/^OTEL_EXPORTER_OTLP_ENDPOINT/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-          # Create nr_otel_collector sub-agent dir
-          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector
+          # Create nr-otel-collector sub-agent dir
+          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            echo 'otel_exporter_otlp_endpoint: "staging-otlp.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'otel_exporter_otlp_endpoint: "staging-otlp.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            echo 'otel_exporter_otlp_endpoint: "otlp.eu01.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'otel_exporter_otlp_endpoint: "otlp.eu01.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           else
-            echo 'otel_exporter_otlp_endpoint: "otlp.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'otel_exporter_otlp_endpoint: "otlp.nr-data.net:4317"' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           fi
 
     config_supervisors:
@@ -355,18 +355,18 @@ install:
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-            sed -i '/^\s*nr_infra_agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*nr_infra_agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            sed -i '/^\s*nr_otel_collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml 
           else
-            sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -267,14 +267,14 @@ install:
         - |
           # Remove old config location (to deprecate)
           rm -f /etc/newrelic-super-agent/nrdot-values.yaml
-          # Create nr_otel_collector sub-agent dir
-          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector
+          # Create nr-otel-collector sub-agent dir
+          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.eu01.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.eu01.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           else
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.nr-data.net:4317' >> //etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.nr-data.net:4317' >> //etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           fi
 
     config_supervisors:
@@ -291,18 +291,18 @@ install:
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then
-            sed -i '/^\s*nr_infra_agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nri-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*nr_infra_agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nri-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
-            sed -i '/^\s*nr_otel_collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml 
           else
-            sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml            
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -222,14 +222,14 @@ install:
         - |
           # Remove old config location (to deprecate)
           rm -f /etc/newrelic-super-agent/nrdot-values.yaml
-          # Create nr_otel_collector sub-agent dir
-          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector
+          # Create nr-otel-collector sub-agent dir
+          mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=staging-otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.eu01.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.eu01.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           else
-            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr_otel_collector/values.yml
+            echo 'OTEL_EXPORTER_OTLP_ENDPOINT=otlp.nr-data.net:4317' >> /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values.yml
           fi
 
     config_supervisors:
@@ -246,18 +246,18 @@ install:
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then
-            sed -i '/^\s*nr_infra_agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nri-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*nr_infra_agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nri-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
-            sed -i '/^\s*nr_otel_collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml 
           else
-            sed -i '/^\s*#\s*nr_otel_collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 


### PR DESCRIPTION
This PR updates the sub-agent ids in the super-agent recipe to match the new ids conventions defined in [newrelic-super-agent#374](https://github.com/newrelic/newrelic-super-agent/pull/374) (private repository).