### PR TITLE
fix(ohi): Ingest current nginx log only

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/linux.yml
@@ -37,11 +37,11 @@ processMatch:
 
 logMatch:
   - name: nginx
-    file: /var/log/nginx/access.log* # assumes log rotation like access.log.0, access.log.1, etc.
+    file: /var/log/nginx/access.log
     attributes:
       logtype: nginx
   - name: nginx
-    file: /var/log/nginx/error.log* # assumes log rotation like error.log.0, error.log.1, etc.
+    file: /var/log/nginx/error.log
     attributes:
       logtype: nginx-error
 

--- a/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
+++ b/recipes/newrelic/infrastructure/ohi/nginx/suse.yml
@@ -24,11 +24,11 @@ processMatch:
 
 logMatch:
   - name: nginx
-    file: /var/log/nginx/access.log* # assumes log rotation like access.log.0, access.log.1, etc.
+    file: /var/log/nginx/access.log
     attributes:
       logtype: nginx
   - name: nginx
-    file: /var/log/nginx/error.log* # assumes log rotation like error.log.0, error.log.1, etc.
+    file: /var/log/nginx/error.log
     attributes:
       logtype: nginx-error
 


### PR DESCRIPTION
Enables log ingestion of `Nginx`'s currently active `access/error` logs only, excluding any rotated ones (access.log.1, etc). Ref: [NR-216304](https://new-relic.atlassian.net/browse/NR-216304).