### PR TITLE
fix(ohi): Ingest current cassandra logs only

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/debian.yml
@@ -32,9 +32,9 @@ processMatch:
 # Matches partial list of the Log forwarding parameters
 logMatch:
   - name: cassandra-system
-    file: /var/log/cassandra/system.log*
+    file: /var/log/cassandra/system.log
   - name: cassandra-debug
-    file: /var/log/cassandra/debug.log*
+    file: /var/log/cassandra/debug.log
 
 # The newrelic-cli will use this integration name to check the config file(s)
 # that were setup during the installation to ensure the integration

--- a/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/cassandra/rhel.yml
@@ -36,9 +36,9 @@ processMatch:
 # Matches partial list of the Log forwarding parameters
 logMatch:
   - name: cassandra-system
-    file: /var/log/cassandra/system.log*
+    file: /var/log/cassandra/system.log
   - name: cassandra-debug
-    file: /var/log/cassandra/debug.log*
+    file: /var/log/cassandra/debug.log
 
 # The newrelic-cli will use this integration name to check the config file(s)
 # that were setup during the installation to ensure the integration

--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
@@ -7,7 +7,7 @@
   become: true
 
 - name: add cassandra keys
-  shell: wget -q -O - https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+  shell: wget -q -O - https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
   become: true
 
 - name: Install cassandra


### PR DESCRIPTION
Enables log ingestion of `Cassandra`'s currently active `system/debug` logs only, excluding any rotated ones (system.log.1, etc). Ref: [NR-216306](https://new-relic.atlassian.net/browse/NR-216306).