### PR TITLE
fix(ohi): Update gpg key url

### DIFF
--- a/test/deploy/linux/mysql/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/mysql/install/rhel/roles/configure/tasks/main.yml
@@ -38,7 +38,7 @@
   become: true
 
 - name: Import most recent repo key
-  shell: "rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022"
+  shell: "rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023"
   become: true
 
 - name: Install MySQL


### PR DESCRIPTION
Fixes `Header V4 RSA/SHA256 Signature, key ID a8d3785c: NOKEY` error that is causing the `mysql-rhel.json` test to fail. Ref: [NR-218868](https://new-relic.atlassian.net/browse/NR-218868).