### PR TITLE
Add logging support for GKE autopilot

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -220,9 +220,10 @@ install:
                 PIXIE_SUPPORTED=false
 
                 while :; do
-                  echo -e "\033[0;31mUsing FileStore will give better reliability but will imply storage cost on Google Cloud FileStore.\033[0m" >&2
-                  echo -e "\033[0;31mNot using FileStore will imply some logs being lost or duplicated during Fluent-Bit redeploys or restarts.\033[0m" >&2
-                  echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
+                  echo -e "The newrelic-logging Helm chart can optionally use FileStore to keep track of read logs across Fluent Bit restarts." >&2
+                  echo -e "\033[0;31mUsing FileStore will provide better reliability but will have associated storage costs on Google Cloud FileStore (recommended).\033[0m" >&2
+                  echo -e "\033[0;31mNot using FileStore will keep track of log offsets in memory but can potentially cause some logs being lost or duplicated during Fluent Bit redeploys or restarts.\033[0m" >&2
+                  echo -e -n "${GREEN}Do you want to enable FileStore to keep track of read logs across restarts? Y/N? ${NC} "
                   read filestoreans
                   echo ""
                   LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)


### PR DESCRIPTION
This change depends on https://github.com/newrelic/helm-charts/pull/1259

It adds support for enable logs integration in GKE autopilot by using no database or FileStore to persist fluent-bit database files

As FileStore will have an extra cost we want to enable users to select if they want to use that, or go without database (that will imply some logs being lost on fluent bit restarts)

