### PR TITLE
Add logging support for GKE autopilot

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -664,8 +664,6 @@ install:
               fi
             fi
 
-            echo $ARGS
-
             # Adding a quick test to ensure we don't expose any keys in case non-compatible versions of sed are used
             SEDTEST=$(echo 0 | sed -E 's/[a-zA-Z0-9\-]/1/')
 

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -80,7 +80,6 @@ install:
           NR_CLI_LOGGING="{{.NR_CLI_LOGGING}}"
           NR_CLI_LOGGING_LOW_DATA_MODE="{{.NR_CLI_LOGGING_LOW_DATA_MODE}}"
 
-
           # Prometheus integrations
 
           # Legacy Prometheus integration
@@ -215,13 +214,13 @@ install:
                 echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
                 echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
                 echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
-                echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
                 NR_CLI_PRIVILEGED=false
                 PIXIE_SUPPORTED=false
 
                 while :; do
-                  echo -e "\033[0;31mUsing FileStore will give better reliability but will imply storage cost on Google Cloud FileStore.\033[0m" >&2
-                  echo -e "\033[0;31mNot using FileStore will imply some logs being lost or duplicated during Fluent-Bit redeploys or restarts.\033[0m" >&2
+                  echo -e "\033[0;31mFluent-Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys.\033[0m" >&2
+                  echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                  echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent-Bit gets restarted.\033[0m" >&2
                   echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
                   read filestoreans
                   echo ""
@@ -231,9 +230,10 @@ install:
                     NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
                     NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
                     break
-                  fi 
+                  fi
                   if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
                     NR_CLI_LOGGING_PERSISTENCE=none
+                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
                     break
                   fi
                   echo -e "Please type Y or N only."
@@ -731,6 +731,15 @@ install:
             BODY="${BODY},\"kubeEvents.enabled\":\"${NR_CLI_KUBE_EVENTS}\""
             BODY="${BODY},\"logging.enabled\":\"${NR_CLI_LOGGING}\""
             BODY="${BODY},\"newrelic-logging.lowDataMode\":\"${NR_CLI_LOGGING_LOW_DATA_MODE}\""
+            if [[ -n "${NR_CLI_LOGGING_PERSISTENCE}" ]]; then
+              BODY="${BODY},\"newrelic-logging.fluentBit.persistence.mode\":\"${NR_CLI_LOGGING_PERSISTENCE}\""
+            fi
+            if [[ -n "${NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS}" ]]; then
+              BODY="${BODY},\"newrelic-logging.fluentBit.persistence.persistentVolume.storageClass\":\"${NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS}\""
+            fi
+            if [[ -n "${NR_CLI_LOGGING_LINUX_MOUNT_PATH}" ]]; then
+              BODY="${BODY},\"newrelic-logging.fluentBit.linuxMountPath\":\"${NR_CLI_LOGGING_LINUX_MOUNT_PATH}\""
+            fi
             BODY="${BODY},\"global.licenseKey\":\"${NEW_RELIC_LICENSE_KEY}\""
             if [[ "${NEW_RELIC_REGION}" == "STAGING" ]]; then
               BODY="${BODY},\"global.nrStaging\":true"

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -217,27 +217,39 @@ install:
                 NR_CLI_PRIVILEGED=false
                 PIXIE_SUPPORTED=false
 
-                while :; do
-                  echo -e "\033[0;31mFluent-Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys.\033[0m" >&2
-                  echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
-                  echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent-Bit gets restarted.\033[0m" >&2
-                  echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
-                  read filestoreans
-                  echo ""
-                  LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
-                  if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
-                    NR_CLI_LOGGING_PERSISTENCE=persistentVolume
-                    NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
-                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                    break
+                if [[ "$NR_CLI_LOGGING" == "true" ]]; then
+                  # We assume that if those both envs are set, the FileStore decision has been made on the Guided install.
+                  if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
+                    while :; do
+                      echo ""
+                      echo -e "\033[0;31mFluent-Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys.\033[0m" >&2
+                      echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                      echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent-Bit gets restarted.\033[0m" >&2
+                      echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
+                      read filestoreans
+                      echo ""
+                      LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
+                      if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
+                        NR_CLI_LOGGING_PERSISTENCE=persistentVolume
+                        NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
+                        NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                        break
+                      fi
+                      if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
+                        NR_CLI_LOGGING_PERSISTENCE=none
+                        NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                        break
+                      fi
+                      echo -e "Please type Y or N only."
+                    done
+                  else
+                    if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
+                      echo -e "\033[0;31mFluent-Bit is not using a database and data loss or data duplication can happen when Fluent-Bit gets restarted.\033[0m" >&2
+                    elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
+                      echo -e "\033[0;31mFluent-Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                    fi
                   fi
-                  if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
-                    NR_CLI_LOGGING_PERSISTENCE=none
-                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                    break
-                  fi
-                  echo -e "Please type Y or N only."
-                done
+                fi
                 break
               fi
             fi
@@ -651,6 +663,8 @@ install:
                 fi
               fi
             fi
+
+            echo $ARGS
 
             # Adding a quick test to ensure we don't expose any keys in case non-compatible versions of sed are used
             SEDTEST=$(echo 0 | sed -E 's/[a-zA-Z0-9\-]/1/')

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -80,6 +80,7 @@ install:
           NR_CLI_LOGGING="{{.NR_CLI_LOGGING}}"
           NR_CLI_LOGGING_LOW_DATA_MODE="{{.NR_CLI_LOGGING_LOW_DATA_MODE}}"
 
+
           # Prometheus integrations
 
           # Legacy Prometheus integration
@@ -217,7 +218,26 @@ install:
                 echo -e "\033[0;31mTurning off Logging for this installation which currently is not supported in GKE Autopilot.\033[0m" >&2
                 NR_CLI_PRIVILEGED=false
                 PIXIE_SUPPORTED=false
-                NR_CLI_LOGGING=false
+
+                while :; do
+                  echo -e "\033[0;31mUsing FileStore will give better reliability but will imply storage cost on Google Cloud FileStore.\033[0m" >&2
+                  echo -e "\033[0;31mNot using FileStore will imply some logs being lost or duplicated during Fluent-Bit redeploys or restarts.\033[0m" >&2
+                  echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
+                  read filestoreans
+                  echo ""
+                  LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
+                  if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
+                    NR_CLI_LOGGING_PERSISTENCE=persistentVolume
+                    NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
+                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                    break
+                  fi 
+                  if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
+                    NR_CLI_LOGGING_PERSISTENCE=none
+                    break
+                  fi
+                  echo -e "Please type Y or N only."
+                done
                 break
               fi
             fi
@@ -258,6 +278,9 @@ install:
           NR_CLI_KUBE_EVENTS=${NR_CLI_KUBE_EVENTS:-true}
           NR_CLI_LOGGING=${NR_CLI_LOGGING:-false}
           NR_CLI_LOGGING_LOW_DATA_MODE=${NR_CLI_LOGGING_LOW_DATA_MODE:-true}
+          NR_CLI_LOGGING_PERSISTENCE=${NR_CLI_LOGGING_PERSISTENCE:-""}
+          NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=${NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS:-""}
+          NR_CLI_LOGGING_LINUX_MOUNT_PATH=${NR_CLI_LOGGING_LINUX_MOUNT_PATH:-""}
 
           # Prometheus integrations
 
@@ -595,6 +618,16 @@ install:
             ARGS="${ARGS} --set kubeEvents.enabled=${NR_CLI_KUBE_EVENTS}"
             ARGS="${ARGS} --set logging.enabled=${NR_CLI_LOGGING}"
             ARGS="${ARGS} --set newrelic-logging.lowDataMode=${NR_CLI_LOGGING_LOW_DATA_MODE}"
+            if [[ -n "${NR_CLI_LOGGING_PERSISTENCE}" ]]; then
+              ARGS="${ARGS} --set newrelic-logging.fluentBit.persistence.mode=${NR_CLI_LOGGING_PERSISTENCE}"
+            fi
+            if [[ -n "${NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS}" ]]; then
+              ARGS="${ARGS} --set newrelic-logging.fluentBit.persistence.persistentVolume.storageClass=${NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS}"
+            fi
+            if [[ -n "${NR_CLI_LOGGING_LINUX_MOUNT_PATH}" ]]; then
+              ARGS="${ARGS} --set newrelic-logging.fluentBit.linuxMountPath=${NR_CLI_LOGGING_LINUX_MOUNT_PATH}"
+            fi
+            
             if [[ "${NEW_RELIC_REGION}" == "STAGING" ]]; then
               ARGS="${ARGS} --set global.nrStaging=true"
             fi

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -222,10 +222,10 @@ install:
                   if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
                     while :; do
                       echo ""
-                      echo -e "\033[0;31mFluent-Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys.\033[0m" >&2
+                      echo -e "\033[0;31mFluent Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys.\033[0m" >&2
                       echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
-                      echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent-Bit gets restarted.\033[0m" >&2
-                      echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent-Bit? Y/N? ${NC} "
+                      echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent Bit gets restarted.\033[0m" >&2
+                      echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent Bit? Y/N? ${NC} "
                       read filestoreans
                       echo ""
                       LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
@@ -244,9 +244,9 @@ install:
                     done
                   else
                     if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
-                      echo -e "\033[0;31mFluent-Bit is not using a database and data loss or data duplication can happen when Fluent-Bit gets restarted.\033[0m" >&2
+                      echo -e "\033[0;31mFluent Bit is not using a database and data loss or data duplication can happen when Fluent Bit gets restarted.\033[0m" >&2
                     elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
-                      echo -e "\033[0;31mFluent-Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent-Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                      echo -e "\033[0;31mFluent Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
                     fi
                   fi
                 fi


### PR DESCRIPTION
This change depends on https://github.com/newrelic/helm-charts/pull/1259

It adds support for enable logs integration in GKE autopilot by using no database or FileStore to persist fluent-bit database files

As FileStore will have an extra cost we want to enable users to select if they want to use that, or go without database (that will imply some logs being lost on fluent bit restarts)