### PR TITLE
chore(dotnet): Modifying ports to avoid port address issue

### DIFF
--- a/test/deploy/linux/apache/deploy-application/dotNet/debian/roles/onbeforestart/tasks/main.yml
+++ b/test/deploy/linux/apache/deploy-application/dotNet/debian/roles/onbeforestart/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Set default proxy_port (default to 5000)
   set_fact:
-    proxy_port: "5000"
+    proxy_port: "5005"
   when: proxy_port is undefined
 
 - name: Set default is_selfcontained (default to false)
@@ -40,7 +40,7 @@
 - name: Init template variable for self contained application
   set_fact:
     apache_service_description: Self Contained .NET 5 APP.NET Core 5 Web app
-    apache_proxy_port: 5000
+    apache_proxy_port: 5006
   when: is_selfcontained|bool
 
 - name: Init template variable for framework dependent application


### PR DESCRIPTION
JIRA: https://new-relic.atlassian.net/browse/NR-218247

As part of this ticket I'm modifying the existing dotnet sample application installation ports to avoid the port address already in use issue during instrumentation 