### PR TITLE
update GKE autopilot question 

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -193,7 +193,7 @@ install:
           # Determine if user is installing in gke autopilot
 
           while :; do
-            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
               echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
@@ -579,7 +579,7 @@ install:
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
             # if installing in GKE Autopilot, we need to turn off controlPlane and pixie and set kubelet scheme and port
-            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               ARGS="${ARGS} --set newrelic-infrastructure.controlPlane.enabled=false"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.scheme=http"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.port=10255"
@@ -659,7 +659,7 @@ install:
             echo "Installing newrelic-bundle......."
             ERROR=$($SUDO helm upgrade $ARGS 2>&1 >/dev/null)
             if [[ "${ERROR}" != "" ]]; then
-              if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
+              if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
                 echo "Warnings from GKE Autopilot: $ERROR"
                 break
               else
@@ -694,7 +694,7 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               BODY="${BODY},\"newrelic-infrastructure.controlPlane.enabled\":\"false\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -194,7 +194,7 @@ install:
 
           GKE_AUTOPILOT_ANSWER="N"
           while :; do
-            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
               echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
@@ -235,7 +235,7 @@ install:
                   fi
                 fi
               fi
-            fi 
+            fi
           done
 
           # Determine the cluster name if not provided

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -194,66 +194,47 @@ install:
 
           GKE_AUTOPILOT_ANSWER="N"
           while :; do
-            echo -e -n "${GREEN}Are you installing in a GKE Autopilot cluster? Y/N? ${NC} "
+            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
+              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
+              echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
+              NR_CLI_PRIVILEGED=false
+              PIXIE_SUPPORTED=false
 
-            if [[ "{{.NEW_RELIC_ASSUME_YES}}" == "true" ]]; then
-              echo "Assume yes flag was provided - answering N for installing in GKE Autopilot."
-              echo "Continuing with installing the integration."
-              GKE_AUTOPILOT_ANSWER="N"
-              break
-            else
-              read ans
-              echo ""
-              GKE_AUTOPILOT_ANSWER=$(echo "${ans^^}" | cut -c1-1)
-              if [[ "$GKE_AUTOPILOT_ANSWER" == "N" ]]; then
-                echo "Continuing with installing the integration."
-                echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"No\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
-                break
-              fi
-              if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
-                echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
-                echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
-                echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
-                NR_CLI_PRIVILEGED=false
-                PIXIE_SUPPORTED=false
-
-                if [[ "$NR_CLI_LOGGING" == "true" ]]; then
-                  # We assume that if those both envs are set, the FileStore decision has been made on the Guided install.
-                  if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
-                    while :; do
-                      echo ""
-                      echo -e "\033[0;31mFluent Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys.\033[0m" >&2
-                      echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
-                      echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent Bit gets restarted.\033[0m" >&2
-                      echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent Bit? Y/N? ${NC} "
-                      read filestoreans
-                      echo ""
-                      LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
-                      if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
-                        NR_CLI_LOGGING_PERSISTENCE=persistentVolume
-                        NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
-                        NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                        break
-                      fi
-                      if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
-                        NR_CLI_LOGGING_PERSISTENCE=none
-                        NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                        break
-                      fi
-                      echo -e "Please type Y or N only."
-                    done
-                  else
-                    if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
-                      echo -e "\033[0;31mFluent Bit is not using a database and data loss or data duplication can happen when Fluent Bit gets restarted.\033[0m" >&2
-                    elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
-                      echo -e "\033[0;31mFluent Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+              if [[ "$NR_CLI_LOGGING" == "true" ]]; then
+                # We assume that if those both envs are set, the FileStore decision has been made on the Guided install.
+                if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
+                  while :; do
+                    echo ""
+                    echo -e "\033[0;31mFluent Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys.\033[0m" >&2
+                    echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                    echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent Bit gets restarted.\033[0m" >&2
+                    echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent Bit? Y/N? ${NC} "
+                    read filestoreans
+                    echo ""
+                    LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
+                    if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
+                      NR_CLI_LOGGING_PERSISTENCE=persistentVolume
+                      NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
+                      NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                      break
                     fi
+                    if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
+                      NR_CLI_LOGGING_PERSISTENCE=none
+                      NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                      break
+                    fi
+                    echo -e "Please type Y or N only."
+                  done
+                else
+                  if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
+                    echo -e "\033[0;31mFluent Bit is not using a database and data loss or data duplication can happen when Fluent Bit gets restarted.\033[0m" >&2
+                  elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
+                    echo -e "\033[0;31mFluent Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
                   fi
                 fi
-                break
               fi
-            fi
-              echo -e "Please type Y or N only."
+            fi 
           done
 
           # Determine the cluster name if not provided

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -192,9 +192,8 @@ install:
 
           # Determine if user is installing in gke autopilot
 
-          GKE_AUTOPILOT_ANSWER="N"
           while :; do
-            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
               echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
@@ -235,7 +234,7 @@ install:
                   fi
                 fi
               fi
-            fi
+            fi 
           done
 
           # Determine the cluster name if not provided
@@ -580,7 +579,7 @@ install:
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
             # if installing in GKE Autopilot, we need to turn off controlPlane and pixie and set kubelet scheme and port
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
               ARGS="${ARGS} --set newrelic-infrastructure.controlPlane.enabled=false"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.scheme=http"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.port=10255"
@@ -660,7 +659,7 @@ install:
             echo "Installing newrelic-bundle......."
             ERROR=$($SUDO helm upgrade $ARGS 2>&1 >/dev/null)
             if [[ "${ERROR}" != "" ]]; then
-              if [[ "${GKE_AUTOPILOT_ANSWER}" == "Y" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
+              if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
                 echo "Warnings from GKE Autopilot: $ERROR"
                 break
               else
@@ -695,7 +694,7 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            if [[ "$GKE_AUTOPILOT_ANSWER" == "Y" ]]; then
+            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
               BODY="${BODY},\"newrelic-infrastructure.controlPlane.enabled\":\"false\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -193,7 +193,7 @@ install:
           # Determine if user is installing in gke autopilot
 
           while :; do
-            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
               echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
               echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
@@ -579,7 +579,7 @@ install:
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
 
             # if installing in GKE Autopilot, we need to turn off controlPlane and pixie and set kubelet scheme and port
-            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               ARGS="${ARGS} --set newrelic-infrastructure.controlPlane.enabled=false"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.scheme=http"
               ARGS="${ARGS} --set newrelic-infrastructure.kubelet.config.port=10255"
@@ -659,7 +659,7 @@ install:
             echo "Installing newrelic-bundle......."
             ERROR=$($SUDO helm upgrade $ARGS 2>&1 >/dev/null)
             if [[ "${ERROR}" != "" ]]; then
-              if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
+              if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]] && ! (echo "${ERROR}" | grep -q "Error"); then
                 echo "Warnings from GKE Autopilot: $ERROR"
                 break
               else
@@ -694,7 +694,7 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
 
             # if installing in GKE Autopilot, turn off controlPlane and set kubelet scheme and port
-            if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
+            if [[ "{{.NRI_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
               BODY="${BODY},\"newrelic-infrastructure.controlPlane.enabled\":\"false\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.scheme\":\"http\""
               BODY="${BODY},\"newrelic-infrastructure.kubelet.config.port\":\"10255\""

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -196,6 +196,7 @@ install:
           while :; do
             if [[ "{{.NRI-CLI-GKE-AUTOPILOT}}" == "true" ]]; then
               echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+              echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
               echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
               echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
               NR_CLI_PRIVILEGED=false

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -190,52 +190,48 @@ install:
           # DEBUG_MESSAGE is used to collect all necessary debug info we need.
           DEBUG_MESSAGE=""
 
-          # Determine if user is installing in gke autopilot
+          if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
+            echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
+            echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
+            echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
+            echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
+            NR_CLI_PRIVILEGED=false
+            PIXIE_SUPPORTED=false
 
-          while :; do
-            if [[ "{{.NR_CLI_GKE_AUTOPILOT}}" == "true" ]]; then
-              echo "{\"Metadata\":{\"gkeAutopilotAnswer\":\"Yes\",\"DebugMessage\":\"$DEBUG_MESSAGE\"}}" | tee -a {{.NR_CLI_OUTPUT}} > /dev/null
-              echo -e "\033[0;31mGKE Autopilot usage confirmed.\033[0m" >&2
-              echo -e "\033[0;31mGKE Autopilot does not allow privileged access. Turning off privileged mode.\033[0m" >&2
-              echo -e "\033[0;31mTurning off Pixie for this installation which requires privileged access.\033[0m" >&2
-              NR_CLI_PRIVILEGED=false
-              PIXIE_SUPPORTED=false
-
-              if [[ "$NR_CLI_LOGGING" == "true" ]]; then
-                # We assume that if those both envs are set, the FileStore decision has been made on the Guided install.
-                if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
-                  while :; do
-                    echo ""
-                    echo -e "\033[0;31mFluent Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys.\033[0m" >&2
-                    echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
-                    echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent Bit gets restarted.\033[0m" >&2
-                    echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent Bit? Y/N? ${NC} "
-                    read filestoreans
-                    echo ""
-                    LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
-                    if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
-                      NR_CLI_LOGGING_PERSISTENCE=persistentVolume
-                      NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
-                      NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                      break
-                    fi
-                    if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
-                      NR_CLI_LOGGING_PERSISTENCE=none
-                      NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
-                      break
-                    fi
-                    echo -e "Please type Y or N only."
-                  done
-                else
-                  if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
-                    echo -e "\033[0;31mFluent Bit is not using a database and data loss or data duplication can happen when Fluent Bit gets restarted.\033[0m" >&2
-                  elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
-                    echo -e "\033[0;31mFluent Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+            if [[ "$NR_CLI_LOGGING" == "true" ]]; then
+              # We assume that if those both envs are set, the FileStore decision has been made on the Guided install.
+              if [[ -z "$NR_CLI_LOGGING_PERSISTENCE" || -z "$NR_CLI_LOGGING_LINUX_MOUNT_PATH" ]]; then
+                while :; do
+                  echo ""
+                  echo -e "\033[0;31mFluent Bit can use a FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys.\033[0m" >&2
+                  echo -e "\033[0;31mUsing FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
+                  echo -e "\033[0;31mNot using FileStore will produce data loss or data duplication when Fluent Bit gets restarted.\033[0m" >&2
+                  echo -e -n "${GREEN}Do you want to use FileStore to keep track of read and sent logs by Fluent Bit? Y/N? ${NC} "
+                  read filestoreans
+                  echo ""
+                  LOGGING_USE_FILESTORE=$(echo "${filestoreans^^}" | cut -c1-1)
+                  if [[ "$LOGGING_USE_FILESTORE" == "Y" ]]; then
+                    NR_CLI_LOGGING_PERSISTENCE=persistentVolume
+                    NR_CLI_LOGGING_PERSISTENCE_STORAGE_CLASS=standard-rwx
+                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                    break
                   fi
+                  if [[ "$LOGGING_USE_FILESTORE" == "N" ]]; then
+                    NR_CLI_LOGGING_PERSISTENCE=none
+                    NR_CLI_LOGGING_LINUX_MOUNT_PATH=/var/log
+                    break
+                  fi
+                  echo -e "Please type Y or N only."
+                done
+              else
+                if [[ "$NR_CLI_LOGGING_PERSISTENCE" == "none" ]]; then
+                  echo -e "\033[0;31mFluent Bit is not using a database and data loss or data duplication can happen when Fluent Bit gets restarted.\033[0m" >&2
+                elif [[ "$NR_CLI_LOGGING_PERSISTENCE" == "persistentVolume" ]]; then
+                  echo -e "\033[0;31mFluent Bit is using FileStore volume to prevent data loss or duplicated logs during Fluent Bit pod restarts or redeploys. Using FileStore will incur additional costs as charged by Google. Consult your Google Cloud Admin or visit the FileStore docs.\033[0m" >&2
                 fi
               fi
-            fi 
-          done
+            fi
+          fi 
 
           # Determine the cluster name if not provided
           CLUSTER=$($SUDO $KUBECTL config current-context 2>/dev/null || echo "unknown")


### PR DESCRIPTION
depends on: https://source.datanerd.us/nr1-dev-experience/marketplace/pull/1257 

removes the question asking if cluster is GKE Autopilot and instead reads the answer from the CLI variable `NR_CLI_GKE_AUTOPILOT` as created in the referenced PR: https://source.datanerd.us/nr1-dev-experience/marketplace/pull/1257  


<img width="1023" alt="Screenshot 2024-02-14 at 12 48 21" src="https://github.com/newrelic/open-install-library/assets/115833851/db505f08-9129-4e98-933b-166924e20dc4">

