### PR TITLE
fix: MacOS restart agent hanging

### DIFF
--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -164,7 +164,7 @@ install:
     restart:
       cmds:
         - |
-          sudo -i -u $SUDO_USER brew services restart newrelic-infra-agent
+          brew services restart newrelic-infra-agent &>/dev/null
 
     assert_agent_status_ok:
       cmds:


### PR DESCRIPTION
Fixes an issue on macOS (darwin) which caused the Infrastructure Agent restart step to hang indefinitely.