### PR TITLE
feat: Add deploy config for Java docker flow

### DIFF
--- a/test/deploy/linux/java/docker-flow/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/java/docker-flow/roles/configure/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+- debug:
+    msg: Install Java, Create Dockerfile, and setup Java application
+
+# create a directory to host java application and newrelic
+- name: Create myJavaApp directory
+  file:
+    path: "/home/{{ ansible_user }}/myJavaApp"
+    state: directory
+
+# create a sample Dockerfile
+- name: Create a sample Dockerfile
+  copy:
+    content: |
+      FROM openjdk:8
+      WORKDIR /app
+      COPY . /app
+      EXPOSE 80
+      CMD ["java", "Main"]
+    dest: "/home/{{ ansible_user }}/myJavaApp/Dockerfile"
+    mode: "0644"
+  when: ansible_os_family == 'RedHat'
+
+- name: Install Java
+  yum:
+    name: java-1.8.0-openjdk-devel
+    state: present
+  become: yes
+  when: ansible_os_family == 'RedHat'
+
+# create a java app
+- name: Create sample Java application
+  copy:
+    content: |
+      public class Main {
+        public static void main(String[] args) {
+          // define the number of iterations for the loop
+          int iterations = 500;
+          
+          // loop to print "Hello, Java!" multiple times with a delay
+          for (int i = 0; i < iterations; i++) {
+            System.out.println("Hello, Java!");
+
+            // Delay for 5 secsonds (5000 ms)
+            try { 
+              Thread.sleep(5000);
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+          }
+        }
+      }
+    dest: "/home/{{ ansible_user }}/myJavaApp/Main.java"
+    mode: 0644
+
+# compile java file
+- name: compile java code
+  shell: javac Main.java
+  args:
+    chdir: "/home/{{ ansible_user }}/myJavaApp"
+
+# create Manifest
+- name: Create Manifest.txt file
+  copy:
+    content: |
+      Main-Class: Main
+    dest: "/home/{{ ansible_user }}/myJavaApp/Manifest.txt"
+
+# create jar file for the Java app
+- name: Create JAR file
+  command: jar cfm Main.jar Manifest.txt Main.class
+  args:
+    chdir: "/home/{{ ansible_user }}/myJavaApp"
+
+# Give all permissions to the jar file
+- name: Change permissions for the JAR file
+  file:
+    path: "/home/{{ ansible_user }}/myJavaApp/Main.jar"
+    mode: "0777"  # Adjust the permissions as needed

--- a/test/manual/definitions/apm/java/linux/docker-flows/java-docker-flows.json
+++ b/test/manual/definitions/apm/java/linux/docker-flows/java-docker-flows.json
@@ -1,0 +1,34 @@
+{
+    "global_tags": {
+      "owning_team": "virtuoso",
+      "Environment": "development",
+      "Department": "product",
+      "Product": "virtuoso"
+    },
+    "resources": [
+      {
+        "id": "linux2",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "ami_name": "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2",
+        "user_name": "ec2-user"
+      }
+    ],
+    "services": [
+      {
+        "id": "docker",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/docker/install/roles",
+        "port": 9999,
+        "destinations": ["linux2"]
+      },
+      {
+        "id": "java",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/java/docker-flow/roles",
+        "port": 80,
+        "destinations": ["linux2"]
+      }
+    ]
+  }


### PR DESCRIPTION
This PR will create a deploy config to instrument Java (Docker flow). This config consists of prerequisites to instrument Java such as install docker, install jdk, create a sample java application.

Ticket: [https://new-relic.atlassian.net/browse/NR-191190](https://new-relic.atlassian.net/browse/NR-191190)