### PR TITLE
Use config examples to set up the super-agent, allowing to have empty agents.

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -344,14 +344,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          # Remove values_file keys from config.yaml
-          sed -i '/^\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-          sed -i '/^\s*#\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-        - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
           else
-            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -280,14 +280,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          # Remove values_file keys from config.yaml
-          sed -i '/^\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-          sed -i '/^\s*#\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-        - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
-            sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml           
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
           else
-            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -235,14 +235,10 @@ install:
     config_supervisors:
       cmds:
         - |
-          # Remove values_file keys from config.yaml
-          sed -i '/^\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-          sed -i '/^\s*#\s*values_file:/d' /etc/newrelic-super-agent/config.yaml
-        - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
-            sed -i '/^\s*agents:/s/^/#/' /etc/newrelic-super-agent/config.yaml           
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
           else
-            sed -i 's/s*#\s*agents:/agents:/g' /etc/newrelic-super-agent/config.yaml
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then


### PR DESCRIPTION
Use config examples to set up the super-agent, allowing to have empty agents.
Related to this modification in the super-agent [#484](https://github.com/newrelic/newrelic-super-agent/pull/484)