### PR TITLE
fix(superagent): fix repo installation in Amazon Linux

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -227,15 +227,16 @@ install:
         - |
           if [ "{{.AMAZON_LINUX_VERSION}}" != "2" ] && [ "{{.AMAZON_LINUX_VERSION}}" != "2023" ] ; then
             SUPER_AGENT_REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/yum/{{.REPO_DIR}}/{{.DISTRO_VERSION}}/{{.ARCH}}/newrelic-infra.repo")
+            INFRA_REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/{{.DISTRO_VERSION}}/{{.ARCH}}/newrelic-infra.repo")
           else
             SUPER_AGENT_REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/yum/{{.REPO_DIR}}/{{.AMAZON_LINUX_VERSION}}/{{.ARCH}}/newrelic-infra.repo")
+            INFRA_REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/{{.REPO_DIR}}/{{.AMAZON_LINUX_VERSION}}/{{.ARCH}}/newrelic-infra.repo")
           fi
           IS_NEWRELIC_AVAILABLE=$(curl -Ls $SUPER_AGENT_REPO_URL | grep "\[newrelic-infra\]" | wc -l)
           if [ $IS_NEWRELIC_AVAILABLE -eq 0 ] ; then
             echo "newrelic super agent is not available for this architecture {{.ARCH}}. See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi 
-          INFRA_REPO_URL=$(echo -n "{{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/yum/el/{{.DISTRO_VERSION}}/{{.ARCH}}/newrelic-infra.repo")
           
           curl -s $INFRA_REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
           curl -s $SUPER_AGENT_REPO_URL | sed 's/\[newrelic-infra]/\n[newrelic-super-agent]/g' >> /etc/yum.repos.d/newrelic-infra.repo


### PR DESCRIPTION
This PR fixes the installation in Amazon Linux where the URLs for the repo are not built in the same way as in RH.