### PR TITLE
chore: Updated AMI name in ruby deploy config

### DIFF
--- a/test/manual/definitions/apm/ruby/rubyonrails.json
+++ b/test/manual/definitions/apm/ruby/rubyonrails.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t2.medium",
-        "ami_name": "al2023-ami-2023.3.20240122.0-kernel-6.1-x86_64",
+        "ami_name": "al2023-ami-2023.4.20240416.0-kernel-6.1-x86_64",
         "user_name": "ec2-user"
       }
     ],


### PR DESCRIPTION
Updated AMI name in ruby deploy config, as the old AMI is no longer available in Mumbai region