### PR TITLE
Add fleet id to super-agent recipe

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -78,6 +78,7 @@ install:
         - task: migrate_newrelic_infra_config
         - task: update_otel_license_key
         - task: config_supervisors
+        - task: config_fleet_id
         - task: config_opamp
         - task: config_host_monitoring
         - task: update_otel_mem_limit
@@ -387,6 +388,14 @@ install:
           else
             sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+
+    config_fleet_id:
+      cmds:
+        - |
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+            sed -i 's/s*#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_opamp:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -97,6 +97,7 @@ install:
         - task: migrate_newrelic_infra_config
         - task: update_otel_license_key
         - task: config_supervisors
+        - task: config_fleet_id
         - task: config_opamp
         - task: config_host_monitoring
         - task: update_otel_mem_limit
@@ -325,6 +326,14 @@ install:
           else
             sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml            
+          fi
+
+    config_fleet_id:
+      cmds:
+        - |
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+            sed -i 's/s*#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_opamp:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -312,7 +312,7 @@ install:
             cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
             sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
@@ -320,12 +320,12 @@ install:
             sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
+          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
             sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml 
           else
             sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml            
+            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_fleet_id:

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -248,11 +248,11 @@ install:
       cmds:
         - |
           if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
               sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-          else
+            else
               sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
@@ -266,7 +266,7 @@ install:
             cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
             sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
@@ -274,7 +274,7 @@ install:
             sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_NRDOT}}" = "false" ] ; then
+          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
             sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml 
           else
@@ -305,8 +305,6 @@ install:
             sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          # Remove old config location (to deprecate)
-          rm -f /etc/newrelic-super-agent/nrdot-values.yaml
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -68,6 +68,7 @@ install:
         - task: migrate_newrelic_infra_config
         - task: update_otel_license_key
         - task: config_supervisors
+        - task: config_fleet_id
         - task: config_opamp
         - task: config_host_monitoring
         - task: update_otel_mem_limit
@@ -279,6 +280,14 @@ install:
           else
             sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+
+    config_fleet_id:
+      cmds:
+        - |
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+            sed -i 's/s*#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_opamp:


### PR DESCRIPTION
This PR:
- Adds the `fleet_id` configuration to the super-agent recipe
- Align some differences between scripts for different OS. Sadly unifying thes task is not currently supported by newrelic-cli