### PR TITLE
feat(tags): Define custom attributes for macOS

### DIFF
--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -135,6 +135,8 @@ install:
             sed -i.bak "/^status_server_port/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^license_key/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^metrics_process_sample_rate/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
+            sed -i.bak '/^custom_attributes:/,/^\S/{ /^\S/!d }' "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}.bak"
+            sed -i.bak '/^custom_attributes:/d' "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}.bak"
           else
             mkdir -p "{{.V2_CONFIG_FILE_DIR}}"
             touch "{{.V2_CONFIG_FILE}}"
@@ -147,6 +149,7 @@ install:
           echo 'status_server_enabled: true' >> "{{.V2_CONFIG_FILE}}"
           echo 'status_server_port: 18003' >> "{{.V2_CONFIG_FILE}}"
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> "{{.V2_CONFIG_FILE}}"
+          echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> "{{.V2_CONFIG_FILE}}"
 
     setup_proxy:
       cmds:


### PR DESCRIPTION
This PR will define tags (custom attributes) when installing the infra-agent on macOS.
Ticket: [NR-266800](https://new-relic.atlassian.net/browse/NR-266800)