### PR TITLE
chore: revert PR #1074 `feat(tags): Define custom attributes for macOS`

### DIFF
--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -135,8 +135,6 @@ install:
             sed -i.bak "/^status_server_port/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^license_key/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^metrics_process_sample_rate/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
-            sed -i.bak '/^custom_attributes:/,/^\S/{ /^\S/!d }' "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}.bak"
-            sed -i.bak '/^custom_attributes:/d' "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}.bak"
           else
             mkdir -p "{{.V2_CONFIG_FILE_DIR}}"
             touch "{{.V2_CONFIG_FILE}}"
@@ -149,7 +147,6 @@ install:
           echo 'status_server_enabled: true' >> "{{.V2_CONFIG_FILE}}"
           echo 'status_server_port: 18003' >> "{{.V2_CONFIG_FILE}}"
           echo 'license_key: {{.NEW_RELIC_LICENSE_KEY}}' >> "{{.V2_CONFIG_FILE}}"
-          echo '{{.NRIA_CUSTOM_ATTRIBUTES}}' >> "{{.V2_CONFIG_FILE}}"
 
     setup_proxy:
       cmds:


### PR DESCRIPTION
It was recently noticed (via the team's monitoring infrastructure, since the last week) that customers trying to install the infrastructure agent on `darwin` (macOS) platforms seem to be encountering failures looking like the following: `performing GET request to http://localhost:18003/v1/status/entity`. 

Upon further investigation, it was found that most cases of these installation failures did not seem to happen upon the first instance of installation of the infra agent by customers; this error would occur 
- either when the customer would install the infra agent on a subsequent attempt (after a signup, followed by instrumentation of their infrastructure for the first time), 
- or, when they would use older versions of the CLI not pointing to the 0.67.1+ of open-install-library in which any number of installs of the infrastructure agent would be successful via the CLI, however, upgrading to newer versions (which is done by default by install commands displayed in the UI) would then start causing this issue.

It was also found later (upon experimentation with the CLI, using the flag `--localRecipes`) that upon the exclusion of changes in PR #1074 and supplying this using `--localRecipes` to the install command would work fine with a first time install, and all subsequent installs would work fine too. Such installs would not display the following messages in debug logs, as shown with installs done with the changes in #1074:

```bash
DEBUG sed: 1: "/^custom_attributes:/,/ ...": extra characters at the end of d command 
sed: 1: "/^custom_attributes:/,/ ...": extra characters at the end of d command
```

This suspicion was further fortified, on the basis of the observation that upon deletion the file `newrelic-infra.yml` when such installation failures were noticed, and reverting changes in #1074, installs would work perfectly fine. This helped the team narrow down to a key observation that the YAML file seems to be affected with every install following the first install of the infra agent because of these custom attribute errors, which seemingly prevent restarting/installation of the infrastructure agent via brew as defined in the darwin recipe, eventually leading to these failures.

Since #1074 was recently merged and is a bug that requires redressal anyway in fairly foreseeable future, the objective of this PR is to revert changes in #1074, in order to confirm the assertions of the team and allow preventing intermittently failing installs for newly onboarded customers with the aforementioned error.

