### PR TITLE
fix: Update kubernetes v1.26.1

### DIFF
--- a/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
@@ -58,7 +58,7 @@
   when: is_minikube_installed.stdout|int == 0
  
 - name: Start Minikube
-  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.25.3'
+  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.26.1'
 
 - name: Create kubectl wrap command
   template:


### PR DESCRIPTION
Updates the Kubernetes version used by minikube to fix failing tests due to unsupported version.