### PR TITLE
fix: Rename super agent env vars

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -402,7 +402,7 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
@@ -422,14 +422,14 @@ install:
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
             cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml

--- a/recipes/newrelic/infrastructure/super-agent/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/super-agent/logs/linux-logs.yml
@@ -129,7 +129,7 @@ install:
             rm /etc/newrelic-infra/logging.d/discovered.yml;
           fi
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" != "otel" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" != "otel" ]; then
             mkdir -p "/etc/newrelic-infra/logging.d"
             touch /etc/newrelic-infra/logging.d/logging.yml;
             touch /etc/newrelic-infra/logging.d/discovered.yml;
@@ -138,7 +138,7 @@ install:
     setup:
       cmds:
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" != "otel" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" != "otel" ]; then
             NR_CLI_SKIP_LOGS={{.NR_CLI_SKIP_LOGS}}
             target_log_files=()
             target_discovered_log_files=()
@@ -253,7 +253,7 @@ install:
         - |
           sleep 10
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" != "otel" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" != "otel" ]; then
             echo "Log configuration:" | tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
             cat /etc/newrelic-infra/logging.d/logging.yml | tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
             echo "Log installation completed" | tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
@@ -261,7 +261,7 @@ install:
 
 postInstall:
   info: |2
-      ⚙️  If NR_CLI_HOST_MONITORING_SOURCE was set to 'newrelic':
+      ⚙️  If NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE was set to 'newrelic':
       ⚙️  The Logs configuration file (base configuration) can be found in /etc/newrelic-infra/logging.d/logging.yml
       ⚙️  The Logs configuration file for discovered processes can be found in /etc/newrelic-infra/logging.d/discovered.yml
       Edit these files to make changes or configure advanced features for the Logs integration. See the docs for options:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -343,7 +343,7 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
@@ -363,14 +363,14 @@ install:
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
             cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -293,7 +293,7 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
@@ -313,14 +313,14 @@ install:
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NR_CLI_FLEET_ENABLED}}" != "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NR_CLI_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then     
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
             cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml


### PR DESCRIPTION
Rename environment variables pertaining to the Super Agent. Both the recipe(s) and the Super Agent itself will utilize the newly named environment variables.