### PR TITLE
feat(super-agent): support upgrades, do not touch configs

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -225,6 +225,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "skipping setup_infra_license sub-task"
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
@@ -425,6 +426,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "skipping config_supervisors sub-task"
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
@@ -436,6 +438,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "skipping config_supervisors sub-task"
             exit 0
           fi
           if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
@@ -480,6 +483,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "skipping config_opamp sub-task"
             exit 0
           fi
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -491,6 +495,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "skipping config_opamp sub-task"
             exit 0
           fi
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -66,6 +66,7 @@ install:
     default:
       cmds:
         - task: write_recipe_metadata
+        - task: detect_previous_install
         - task: assert_pre_req
         - task: cleanup
         - task: setup_infra_license
@@ -87,12 +88,21 @@ install:
         - task: migrate_newrelic_infra_config
         - task: restart_super_agent
         - task: assert_super_agent_started
+        - task: signal_recipe_applied
         - task: post_install
 
     write_recipe_metadata:
       cmds:
         - |
           echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    detect_previous_install:
+      cmds:
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this installation was detected. Some installation tasks will be skipped."
+            echo "If you would like to run all the tasks, please remove the /etc/newrelic-super-agent/.nr-cli file and re-run the installation."
+          fi
 
     assert_pre_req:
       cmds:
@@ -166,14 +176,22 @@ install:
     cleanup:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             rm -rf /var/db/newrelic-infra/data 2>/dev/null
           fi
 
     setup_infra_license:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -204,7 +222,7 @@ install:
             fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -218,7 +236,11 @@ install:
     setup_infra_proxy:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
           fi
@@ -343,13 +365,23 @@ install:
     update_otel_license_key:
       cmds:
         - |
-          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          fi
 
     update_otel_mem_limit:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -357,45 +389,65 @@ install:
     update_otel_end_point:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              else
+                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              fi
             fi
           fi
 
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-          else
-            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+            else
+              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
 
     config_fleet_id:
       cmds:
         - |
-          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -403,41 +455,60 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
-            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-          else
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              else
+                if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+                  mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+                  cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+                fi
+              fi
             fi
           fi
 
@@ -469,6 +540,11 @@ install:
             echo "The newrelic super agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 31
           fi
+
+    signal_recipe_applied:
+      cmds:
+        - |
+          touch /etc/newrelic-super-agent/.nr-cli
 
     post_install:
       info: |2

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -179,8 +179,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             rm -rf /var/db/newrelic-infra/data 2>/dev/null
           fi
 
@@ -190,8 +191,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -222,7 +224,10 @@ install:
             fi
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -239,8 +244,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
           fi
@@ -368,11 +374,10 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
-          fi
+          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
 
     update_otel_mem_limit:
       cmds:
@@ -380,8 +385,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -392,16 +398,15 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              else
-                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 
@@ -411,33 +416,34 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-            else
-              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+          else
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_fleet_id:
@@ -446,8 +452,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -458,32 +465,35 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
@@ -493,21 +503,20 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          else
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
               cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             else
               if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
                 mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              else
-                if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-                  mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-                  cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-                fi
+                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
               fi
             fi
           fi

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -512,12 +512,7 @@ install:
           else
             if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -420,7 +420,7 @@ install:
             fi
           fi
         - |
-          [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
             if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
               sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
               sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -190,8 +190,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             rm -rf /var/db/newrelic-infra/data 2>/dev/null
           fi
 
@@ -201,8 +202,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -233,7 +235,10 @@ install:
             fi
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -251,8 +256,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
 
@@ -307,11 +313,10 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
-          fi
+          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
 
     update_otel_mem_limit:
       cmds:
@@ -319,8 +324,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -331,16 +337,15 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              else
-                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 
@@ -350,33 +355,34 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-            else
-              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+          else
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_fleet_id:
@@ -385,8 +391,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -397,32 +404,35 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
@@ -432,17 +442,16 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          else
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -236,6 +236,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping setup_infra_license sub-task.
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
@@ -364,6 +365,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_supervisors sub-task."
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
@@ -375,6 +377,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_supervisors sub-task."
             exit 0
           fi
           if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
@@ -419,6 +422,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_opamp sub-task."
             exit 0
           fi
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -430,6 +434,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_opamp sub-task."
             exit 0
           fi
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -52,26 +52,26 @@ processMatch: []
 
 preInstall:
   requireAtDiscovery: |
-      IS_DOCKER_CONTAINER_CGROUP=$(grep 'docker\|lxc' /proc/1/cgroup | wc -l)
-      if [ $IS_DOCKER_CONTAINER_CGROUP -gt 0 ] ; then
-        echo "docker detected with cgroup, unsupported" >&2
-        exit 131
-      fi
-      IS_DOCKER_CONTAINER_ENVIRON=$(grep container=lxc /proc/1/environ | wc -l)
-      if [ $IS_DOCKER_CONTAINER_ENVIRON -gt 0 ] ; then
-        echo "docker detected with environ, unsupported" >&2
-        exit 131
-      fi
-      if [ -f /.dockerenv ] ; then
-        echo "docker detected with .dockerenv, unsupported" >&2
-        exit 131
-      fi
-      IS_WSL_CONTAINER=$(grep -i 'Microsoft' /proc/version | wc -l)
-      if [ $IS_WSL_CONTAINER -gt 0 ] ; then
-        echo "microsoft Windows Subsystem for Linux for infra detected, unsupported" >&2
-        exit 131
-      fi
-      exit 0
+    IS_DOCKER_CONTAINER_CGROUP=$(grep 'docker\|lxc' /proc/1/cgroup | wc -l)
+    if [ $IS_DOCKER_CONTAINER_CGROUP -gt 0 ] ; then
+      echo "docker detected with cgroup, unsupported" >&2
+      exit 131
+    fi
+    IS_DOCKER_CONTAINER_ENVIRON=$(grep container=lxc /proc/1/environ | wc -l)
+    if [ $IS_DOCKER_CONTAINER_ENVIRON -gt 0 ] ; then
+      echo "docker detected with environ, unsupported" >&2
+      exit 131
+    fi
+    if [ -f /.dockerenv ] ; then
+      echo "docker detected with .dockerenv, unsupported" >&2
+      exit 131
+    fi
+    IS_WSL_CONTAINER=$(grep -i 'Microsoft' /proc/version | wc -l)
+    if [ $IS_WSL_CONTAINER -gt 0 ] ; then
+      echo "microsoft Windows Subsystem for Linux for infra detected, unsupported" >&2
+      exit 131
+    fi
+    exit 0
 
   discoveryMode:
     - targeted
@@ -92,6 +92,7 @@ install:
     default:
       cmds:
         - task: write_recipe_metadata
+        - task: detect_previous_install
         - task: assert_pre_req
         - task: cleanup
         - task: setup_infra_license
@@ -107,12 +108,21 @@ install:
         - task: migrate_newrelic_infra_config
         - task: restart_super_agent
         - task: assert_super_agent_started
+        - task: signal_recipe_applied
         - task: post_install
 
     write_recipe_metadata:
       cmds:
         - |
           echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    detect_previous_install:
+      cmds:
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this installation was detected. Some installation tasks will be skipped."
+            echo "If you would like to run all the tasks, please remove the /etc/newrelic-super-agent/.nr-cli file and re-run the installation."
+          fi
 
     assert_pre_req:
       cmds:
@@ -177,14 +187,22 @@ install:
     cleanup:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             rm -rf /var/db/newrelic-infra/data 2>/dev/null
           fi
 
     setup_infra_license:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -215,7 +233,7 @@ install:
             fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -230,7 +248,11 @@ install:
     setup_infra_proxy:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
 
@@ -282,13 +304,23 @@ install:
     update_otel_license_key:
       cmds:
         - |
-          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          fi
 
     update_otel_mem_limit:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -296,45 +328,65 @@ install:
     update_otel_end_point:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              else
+                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              fi
             fi
           fi
 
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-          else
-            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+            else
+              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
 
     config_fleet_id:
       cmds:
         - |
-          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -342,41 +394,55 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
-            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-          else
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              fi
             fi
           fi
 
@@ -408,6 +474,11 @@ install:
             echo "The newrelic super agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 31
           fi
+
+    signal_recipe_applied:
+      cmds:
+        - |
+          touch /etc/newrelic-super-agent/.nr-cli
 
     post_install:
       info: |2

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -194,6 +194,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping setup_infra_license sub-task.
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
@@ -313,6 +314,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_supervisors sub-task."
             exit 0
           fi
           if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
@@ -324,6 +326,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_supervisors sub-task."
             exit 0
           fi
           if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
@@ -368,6 +371,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_opamp sub-task."
             exit 0
           fi
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -379,6 +383,7 @@ install:
           fi
         - |
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "Skipping config_opamp sub-task."
             exit 0
           fi
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -150,10 +150,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            rm -rf /var/db/newrelic-infra/data 2>/dev/null
-          fi
+          rm -rf /var/db/newrelic-infra/data 2>/dev/null
 
     setup_infra_license:
       cmds:
@@ -161,8 +160,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -193,7 +193,10 @@ install:
             fi
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -211,8 +214,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
           fi
@@ -258,11 +262,10 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
-          fi
+          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
 
     update_otel_mem_limit:
       cmds:
@@ -270,8 +273,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -282,16 +286,15 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              else
-                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 
@@ -301,33 +304,34 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-            else
-              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+          else
+            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_fleet_id:
@@ -336,8 +340,9 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -348,32 +353,35 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
-            fi
-          fi
-        - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            else
-              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-            fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            exit 0
+          fi
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
@@ -383,17 +391,16 @@ install:
           # Log if a previous execution of this recipe was detected, indicating we are skipping this task
           if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
             echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+            exit 0
           fi
-          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
-            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
+            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          else
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-              fi
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -58,6 +58,7 @@ install:
     default:
       cmds:
         - task: write_recipe_metadata
+        - task: detect_previous_install
         - task: assert_pre_req
         - task: cleanup
         - task: setup_infra_license
@@ -73,12 +74,21 @@ install:
         - task: migrate_newrelic_infra_config
         - task: restart_super_agent
         - task: assert_super_agent_started
+        - task: signal_recipe_applied
         - task: post_install
 
     write_recipe_metadata:
       cmds:
         - |
           echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    detect_previous_install:
+      cmds:
+        - |
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this installation was detected. Some installation tasks will be skipped."
+            echo "If you would like to run all the tasks, please remove the /etc/newrelic-super-agent/.nr-cli file and re-run the installation."
+          fi
 
     assert_pre_req:
       cmds:
@@ -137,12 +147,22 @@ install:
     cleanup:
       cmds:
         - |
-          rm -rf /var/db/newrelic-infra/data 2>/dev/null
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "cleanup" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            rm -rf /var/db/newrelic-infra/data 2>/dev/null
+          fi
 
     setup_infra_license:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_license" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ -f /etc/newrelic-infra.yml ]; then
               printf "\nAn existing newrelic-infra configuration file was detected. Updating where needed."
 
@@ -173,7 +193,7 @@ install:
             fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] ; then
             if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
               echo 'staging: true' >> /etc/newrelic-infra.yml
             fi
@@ -188,7 +208,11 @@ install:
     setup_infra_proxy:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "setup_infra_proxy" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_INFRA_AGENT}}" != "false" ] && [ ! -z "$HTTPS_PROXY" ]; then
             sed -i "/^proxy/d" /etc/newrelic-infra.yml
             echo 'proxy: {{.HTTPS_PROXY}}' >> /etc/newrelic-infra.yml
           fi
@@ -231,13 +255,23 @@ install:
     update_otel_license_key:
       cmds:
         - |
-          sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
-          echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_license_key" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            sed -i "/^NEW_RELIC_LICENSE_KEY/d" /etc/newrelic-super-agent/newrelic-super-agent.conf
+            echo 'NEW_RELIC_LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"' >> /etc/newrelic-super-agent/newrelic-super-agent.conf
+          fi
 
     update_otel_mem_limit:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_mem_limit" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
             sed -i "s/limit_mib: .*$/limit_mib: 100/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           fi
 
@@ -245,45 +279,65 @@ install:
     update_otel_end_point:
       cmds:
         - |
-          if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
-            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-            else
-              sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "update_otel_end_point" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+              if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+                sed -i "s/endpoint: .*$/endpoint: staging-otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+                sed -i "s/endpoint: .*$/endpoint: otlp.eu01.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              else
+                sed -i "s/endpoint: .*$/endpoint: otlp.nr-data.net:4317/g" /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              fi
             fi
           fi
 
     config_supervisors:
       cmds:
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
-          else
-            cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_supervisors" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ] && [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              cp /etc/newrelic-super-agent/examples/super-agent-config-no-agents.yaml /etc/newrelic-super-agent/config.yaml
+            else
+              cp /etc/newrelic-super-agent/examples/super-agent-config-all-agents.yaml /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
-            sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_INFRA_AGENT}}" = "false" ]; then
+              sed -i '/^\s*nr-infra-agent:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-infra-agent:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/com\.newrelic\.infrastructure_agent/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
-            sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NR_CLI_NRDOT}}" = "false" ]; then
+              sed -i '/^\s*nr-otel-collector:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i '/^\s*#\s*nr-otel-collector:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*agent_type: "newrelic\/io\.opentelemetry\.collector/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
 
     config_fleet_id:
       cmds:
         - |
-          if [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_fleet_id" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ ! -z "{{.NR_CLI_FLEET_ID}}" ] ; then
             sed -i 's/^#\s*fleet_id:/fleet_id:/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/fleet_id: FLEET_ID_HERE/fleet_id: {{.NR_CLI_FLEET_ID}}/g' /etc/newrelic-super-agent/config.yaml
           fi
@@ -291,41 +345,55 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
-            sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_opamp" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+              sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
+              sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            else
+              sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+            fi
           fi
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] && [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
-            echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
-            mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
-          else
-            if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+          # Log if a previous execution of this recipe was detected, indicating we are skipping this task
+          if [ -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            echo "A previous execution of this recipe was detected. Skipping "config_host_monitoring" task."
+          fi
+          if [ ! -f /etc/newrelic-super-agent/.nr-cli ] ; then
+            if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
+              echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            else
+              if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
+                mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
+                cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              fi
             fi
           fi
 
@@ -357,6 +425,11 @@ install:
             echo "The newrelic super agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 31
           fi
+
+    signal_recipe_applied:
+      cmds:
+        - |
+          touch /etc/newrelic-super-agent/.nr-cli
 
     post_install:
       info: |2


### PR DESCRIPTION
This allows to have some degree of idempotence for installs of the super-agent, not touching config files when an installation has run successfully before. It achieves this by placing a sentinel file when an installation runs successfully, and relevant installation tasks first check for the existence of this file to decide if actions are performed or not.