### PR TITLE
Change super agent recipe to support System Identity registration (NR-273901)

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -452,7 +452,7 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -81,6 +81,7 @@ install:
         - task: config_supervisors
         - task: config_fleet_id
         - task: config_opamp
+        - task: config_super_agent_auth
         - task: config_host_monitoring
         - task: update_otel_mem_limit
         - task: update_otel_end_point
@@ -137,6 +138,24 @@ install:
           if [ $IS_TOUCH_INSTALLED -eq 0 ] ; then
             echo "touch is required to run the newrelic install. Please install touch and re-run the installation." >&2
             exit 15
+          fi
+        - |
+          IS_CURL_INSTALLED=$(which curl | wc -l)
+          if [ $IS_CURL_INSTALLED -eq 0 ] ; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          IS_OPENSSL_INSTALLED=$(which openssl | wc -l)
+          if [ $IS_OPENSSL_INSTALLED -eq 0 ] ; then
+            echo "openssl is required to run the newrelic install. Please install openssl and re-run the installation." >&2
+            exit 17
+          fi
+        - |
+          IS_JQ_INSTALLED=$(which jq | wc -l)
+          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
+            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
+            exit 18
           fi
         - |
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
@@ -226,10 +245,9 @@ install:
     log_ssl_ciphers:
       cmds:
         - |
-          IS_OPENSSL_INSTALLED=$(which openssl | wc -l)
           IS_SORT_INSTALLED=$(which sort | wc -l)
           IS_UNIQ_INSTALLED=$(which uniq | wc -l)
-          if [ $IS_OPENSSL_INSTALLED -gt 0 ] && [ $IS_SORT_INSTALLED -gt 0 ] && [ $IS_UNIQ_INSTALLED -gt 0 ]; then
+          if [ $IS_SORT_INSTALLED -gt 0 ] && [ $IS_UNIQ_INSTALLED -gt 0 ]; then
             echo "Detecting available SSL ciphers..."
             openssl ciphers -v | awk '{print " - " $2}' | sort | uniq
           fi
@@ -406,13 +424,19 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*auth_config: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*auth_config: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*token_url: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*client_id: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*provider: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*private_key_path: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -422,9 +446,81 @@ install:
           else
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
+    config_super_agent_auth:
+      cmds:
         - |
+          set -o nounset,pipefail
+
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
-            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
+            mkdir /etc/newrelic-super-agent/keys
+            chown root:root /etc/newrelic-super-agent/keys
+            chmod 700 /etc/newrelic-super-agent/keys
+
+            TEMPORAL_FOLDER=$(mkdir -p "$TMP/super-agent-installation-$RANDOM")
+            openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
+            openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
+
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://staging-system-identity-poc.vip.cf.nr-ops.net/oauth/token
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              echo "TODO: EU region is not supported for this POC"
+            else
+              echo "TODO: US region is not supported for this POC"
+            fi
+
+            NAME="System Identity for $(hostname)"
+
+            for RETRY in 1 2 3; do
+              HTTP_CODE=$(echo '{ "query":
+                  "{
+                    mutation createSystemIdentity {
+                      createSystemIdentity(
+                        name: \"'$NAME'\",
+                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                      ) {
+                        clientId,
+                        id,
+                        name
+                      }
+                    }
+                  }"
+                }' | tr -d $'\n' | curl -X POST \
+                  -s -w "%{http_code}" \
+                  -H "Content-Type: application/json" \
+                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -o "$TEMPORAL_FOLDER/response.json" \
+                  --data @- \
+                  "$REGISTRATION_ENDPOINT"
+                --data '{ "query": "mutation { createSystemIdentity(name: \"'${NAME}'\", organizationId: \"'${ORGANIZATION_ID}'\", publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\") { id name organizationId clientId publicKey } }" }' \
+                ${REGISTRATION_ENDPOINT}
+              )
+
+              if [ $HTTP_CODE -eq 200 ]; then
+                break
+              fi
+
+              echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+              sleep 2
+            done
+
+            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit
+            fi
+
+            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+
+            mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
+            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -452,18 +452,18 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
-            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*auth_config:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
@@ -581,7 +581,6 @@ install:
           sleep 10
           IS_AGENT_INSTALLED=$(sudo ps aux | grep newrelic-super-agent | grep -v grep | wc -l)
           if [ $IS_AGENT_INSTALLED -eq 0 ] ; then
-            journalctl -u newrelic-super-agent --no-pager
             echo "The newrelic super agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 31
           fi

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -443,6 +443,10 @@ install:
             sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{ .NEW_RELIC_LICENSE_KEY }}/g' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -421,22 +421,34 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*auth_config: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*token_url: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*client_id: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*provider: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*private_key_path: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*auth_config: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*token_url: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*client_id: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*provider: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*private_key_path: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" == "" ]; then
+            sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*api-key:/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -449,9 +461,9 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          set -o nounset,pipefail
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            set -o nounset,pipefail
 
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
             mkdir /etc/newrelic-super-agent/keys
             chown root:root /etc/newrelic-super-agent/keys
             chmod 700 /etc/newrelic-super-agent/keys
@@ -462,11 +474,13 @@ install:
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
-              TOKEN_RENEWAL_ENDPOINT=https://staging-system-identity-poc.vip.cf.nr-ops.net/oauth/token
+              # TODO: TOKEN_RENEWAL_ENDPOINT
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              echo "TODO: EU region is not supported for this POC"
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
             else
-              echo "TODO: US region is not supported for this POC"
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
             fi
 
             NAME="System Identity for $(hostname)"
@@ -516,10 +530,11 @@ install:
             NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+
             rm -rf "$TEMPORAL_FOLDER"
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -158,6 +158,12 @@ install:
             exit 18
           fi
         - |
+          IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
+          if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
+            echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
+            exit 19
+          fi
+        - |
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
             IS_AGENT_AVAILABLE=$(curl -Is {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/apt/dists/{{.DEBIAN_CODENAME}}/InRelease | grep " 2[0-9][0-9] " | wc -l)
             if [ $IS_AGENT_AVAILABLE -eq 0 ] ; then
@@ -429,13 +435,23 @@ install:
             sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" == "" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i '/^\s*#\s*api-key:/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
+        - |
+          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
+          fi
+    config_super_agent_auth:
+      cmds:
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
@@ -451,24 +467,14 @@ install:
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
-          if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.eu.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          else
-            sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
-          fi
-    config_super_agent_auth:
-      cmds:
-        - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
-            set -o nounset,pipefail
+            set -uo pipefail
 
             mkdir /etc/newrelic-super-agent/keys
             chown root:root /etc/newrelic-super-agent/keys
             chmod 700 /etc/newrelic-super-agent/keys
 
-            TEMPORAL_FOLDER=$(mkdir -p "$TMP/super-agent-installation-$RANDOM")
+            TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
@@ -507,8 +513,6 @@ install:
                   -o "$TEMPORAL_FOLDER/response.json" \
                   --data @- \
                   "$REGISTRATION_ENDPOINT"
-                --data '{ "query": "mutation { createSystemIdentity(name: \"'${NAME}'\", organizationId: \"'${ORGANIZATION_ID}'\", publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\") { id name organizationId clientId publicKey } }" }' \
-                ${REGISTRATION_ENDPOINT}
               )
 
               if [ $HTTP_CODE -eq 200 ]; then

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -454,13 +454,13 @@ install:
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -480,13 +480,13 @@ install:
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
               REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
             else
               REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             fi
 
             NAME="System Identity for $(hostname)"
@@ -534,7 +534,7 @@ install:
             NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -152,16 +152,10 @@ install:
             exit 17
           fi
         - |
-          IS_JQ_INSTALLED=$(which jq | wc -l)
-          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
-            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
-            exit 18
-          fi
-        - |
           IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
           if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
             echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
-            exit 19
+            exit 18
           fi
         - |
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
@@ -454,6 +448,7 @@ install:
           else
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
+
     config_super_agent_auth:
       cmds:
         - |
@@ -479,17 +474,18 @@ install:
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             fi
 
@@ -497,23 +493,20 @@ install:
 
             for RETRY in 1 2 3; do
               HTTP_CODE=$(echo '{ "query":
-                  "{
-                    mutation createSystemIdentity {
-                      createSystemIdentity(
-                        name: \"'$NAME'\",
-                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
-                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
-                      ) {
-                        clientId,
-                        id,
-                        name
-                      }
+                  "mutation {
+                    create(
+                      name: \"'$NAME'\",
+                      organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                      publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                    ) {
+                      clientId,
+                      name
                     }
                   }"
                 }' | tr -d $'\n' | curl -X POST \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
                   --data @- \
                   "$REGISTRATION_ENDPOINT"
@@ -527,23 +520,24 @@ install:
               sleep 2
             done
 
-            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
-            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-              echo "Error creating an identity: $ERROR_MESSAGE"
-              exit
+            if [ $HTTP_CODE -ne 200 ]; then
+              exit 99
             fi
 
-            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit 100
+            fi
+
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
             # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
-
-            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -581,6 +581,7 @@ install:
           sleep 10
           IS_AGENT_INSTALLED=$(sudo ps aux | grep newrelic-super-agent | grep -v grep | wc -l)
           if [ $IS_AGENT_INSTALLED -eq 0 ] ; then
+            journalctl -u newrelic-super-agent --no-pager
             echo "The newrelic super agent has not started after installing. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 31
           fi

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -318,7 +318,7 @@ install:
             OPTIONS="$OPTIONS -o Acquire::Http::Proxy={{.HTTPS_PROXY}}"
           fi
           apt-get $OPTIONS update -yq
-      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
+      # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail. Just to trigger the pipeline
       ignore_error: true
 
     install_super_agent:

--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -459,7 +459,7 @@ install:
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -469,32 +469,35 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             set -uo pipefail
 
-            mkdir /etc/newrelic-super-agent/keys
+            mkdir -p /etc/newrelic-super-agent/keys
             chown root:root /etc/newrelic-super-agent/keys
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            chown root:root "${TEMPORAL_FOLDER}"
+            chmod 700 "${TEMPORAL_FOLDER}"
             trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://staging-api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.eu.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.newrelic.com/oauth2/token
             fi
 
-            NAME="System Identity for $(hostname)"
+            DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            NAME="System Identity for $(hostname) - $DATE"
 
-            for RETRY in 1 2 3; do
+            for RETRY in 1 2 3; do                                                                                                          
               HTTP_CODE=$(echo '{ "query":
                   "mutation {
-                    create(
+                    systemIdentityCreate(
                       name: \"'$NAME'\",
                       organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
                       publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
@@ -503,12 +506,12 @@ install:
                       name
                     }
                   }"
-                }' | tr -d $'\n' | curl -X POST \
+                }' | tr -d $'\n' | curl \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
+                  -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
-                  --data @- \
+                  --data-binary @- \
                   "$REGISTRATION_ENDPOINT"
               )
 
@@ -524,20 +527,19 @@ install:
               exit 99
             fi
 
-            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
             if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
               echo "Error creating an identity: $ERROR_MESSAGE"
               exit 100
             fi
 
-            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~token_url: PLACEHOLDER~token_url: '"$TOKEN_RENEWAL_ENDPOINT"'~g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
-            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~private_key_path: PLACEHOLDER~private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'~g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -383,6 +383,10 @@ install:
             sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{ .NEW_RELIC_LICENSE_KEY }}/g' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -394,13 +394,13 @@ install:
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -420,13 +420,13 @@ install:
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
               REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
             else
               REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             fi
 
             NAME="System Identity for $(hostname)"
@@ -474,7 +474,7 @@ install:
             NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -392,18 +392,18 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
-            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*auth_config:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -172,16 +172,10 @@ install:
             exit 17
           fi
         - |
-          IS_JQ_INSTALLED=$(which jq | wc -l)
-          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
-            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
-            exit 18
-          fi
-        - |
           IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
           if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
             echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
-            exit 19
+            exit 18
           fi
         - |
           if [ "{{.AMAZON_LINUX_VERSION}}" != "2" ] && [ "{{.AMAZON_LINUX_VERSION}}" != "2023" ] ; then
@@ -420,17 +414,18 @@ install:
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             fi
 
@@ -438,23 +433,20 @@ install:
 
             for RETRY in 1 2 3; do
               HTTP_CODE=$(echo '{ "query":
-                  "{
-                    mutation createSystemIdentity {
-                      createSystemIdentity(
-                        name: \"'$NAME'\",
-                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
-                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
-                      ) {
-                        clientId,
-                        id,
-                        name
-                      }
+                  "mutation {
+                    create(
+                      name: \"'$NAME'\",
+                      organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                      publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                    ) {
+                      clientId,
+                      name
                     }
                   }"
                 }' | tr -d $'\n' | curl -X POST \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
                   --data @- \
                   "$REGISTRATION_ENDPOINT"
@@ -468,23 +460,24 @@ install:
               sleep 2
             done
 
-            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
-            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-              echo "Error creating an identity: $ERROR_MESSAGE"
-              exit
+            if [ $HTTP_CODE -ne 200 ]; then
+              exit 99
             fi
 
-            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit 100
+            fi
+
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
             # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
-
-            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -392,7 +392,7 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -399,7 +399,7 @@ install:
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -409,32 +409,35 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             set -uo pipefail
 
-            mkdir /etc/newrelic-super-agent/keys
+            mkdir -p /etc/newrelic-super-agent/keys
             chown root:root /etc/newrelic-super-agent/keys
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            chown root:root "${TEMPORAL_FOLDER}"
+            chmod 700 "${TEMPORAL_FOLDER}"
             trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://staging-api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.eu.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.newrelic.com/oauth2/token
             fi
 
-            NAME="System Identity for $(hostname)"
+            DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            NAME="System Identity for $(hostname) - $DATE"
 
             for RETRY in 1 2 3; do
               HTTP_CODE=$(echo '{ "query":
                   "mutation {
-                    create(
+                    systemIdentityCreate(
                       name: \"'$NAME'\",
                       organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
                       publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
@@ -443,12 +446,12 @@ install:
                       name
                     }
                   }"
-                }' | tr -d $'\n' | curl -X POST \
+                }' | tr -d $'\n' | curl \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
+                  -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
-                  --data @- \
+                  --data-binary @- \
                   "$REGISTRATION_ENDPOINT"
               )
 
@@ -464,20 +467,19 @@ install:
               exit 99
             fi
 
-            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
             if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
               echo "Error creating an identity: $ERROR_MESSAGE"
               exit 100
             fi
 
-            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~token_url: PLACEHOLDER~token_url: '"$TOKEN_RENEWAL_ENDPOINT"'~g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
-            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~private_key_path: PLACEHOLDER~private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'~g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -101,6 +101,7 @@ install:
         - task: config_supervisors
         - task: config_fleet_id
         - task: config_opamp
+        - task: config_super_agent_auth
         - task: config_host_monitoring
         - task: update_otel_mem_limit
         - task: update_otel_end_point
@@ -157,6 +158,30 @@ install:
           if [ $IS_TOUCH_INSTALLED -eq 0 ] ; then
             echo "touch is required to run the newrelic install. Please install touch and re-run the installation." >&2
             exit 15
+          fi
+        - |
+          IS_CURL_INSTALLED=$(which curl | wc -l)
+          if [ $IS_CURL_INSTALLED -eq 0 ] ; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          IS_OPENSSL_INSTALLED=$(which openssl | wc -l)
+          if [ $IS_OPENSSL_INSTALLED -eq 0 ] ; then
+            echo "openssl is required to run the newrelic install. Please install openssl and re-run the installation." >&2
+            exit 17
+          fi
+        - |
+          IS_JQ_INSTALLED=$(which jq | wc -l)
+          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
+            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
+            exit 18
+          fi
+        - |
+          IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
+          if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
+            echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
+            exit 19
           fi
         - |
           if [ "{{.AMAZON_LINUX_VERSION}}" != "2" ] && [ "{{.AMAZON_LINUX_VERSION}}" != "2023" ] ; then
@@ -342,16 +367,20 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -361,9 +390,97 @@ install:
           else
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
+
+    config_super_agent_auth:
+      cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
-            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            set -uo pipefail
+
+            mkdir /etc/newrelic-super-agent/keys
+            chown root:root /etc/newrelic-super-agent/keys
+            chmod 700 /etc/newrelic-super-agent/keys
+
+            TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
+            openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
+
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            else
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            fi
+
+            NAME="System Identity for $(hostname)"
+
+            for RETRY in 1 2 3; do
+              HTTP_CODE=$(echo '{ "query":
+                  "{
+                    mutation createSystemIdentity {
+                      createSystemIdentity(
+                        name: \"'$NAME'\",
+                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                      ) {
+                        clientId,
+                        id,
+                        name
+                      }
+                    }
+                  }"
+                }' | tr -d $'\n' | curl -X POST \
+                  -s -w "%{http_code}" \
+                  -H "Content-Type: application/json" \
+                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -o "$TEMPORAL_FOLDER/response.json" \
+                  --data @- \
+                  "$REGISTRATION_ENDPOINT"
+              )
+
+              if [ $HTTP_CODE -eq 200 ]; then
+                break
+              fi
+
+              echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+              sleep 2
+            done
+
+            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit
+            fi
+
+            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+
+            mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
+            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+
+            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -138,16 +138,10 @@ install:
             exit 17
           fi
         - |
-          IS_JQ_INSTALLED=$(which jq | wc -l)
-          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
-            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
-            exit 18
-          fi
-        - |
           IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
           if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
             echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
-            exit 19
+            exit 18
           fi
         - |
           IS_INFRA_AVAILABLE=$(curl -Is {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/zypp/sles/{{.SLES_VERSION}}/x86_64/newrelic-infra.repo | grep " 2[0-9][0-9] " | wc -l)
@@ -369,17 +363,18 @@ install:
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
               # TODO: TOKEN_RENEWAL_ENDPOINT
             fi
 
@@ -387,23 +382,20 @@ install:
 
             for RETRY in 1 2 3; do
               HTTP_CODE=$(echo '{ "query":
-                  "{
-                    mutation createSystemIdentity {
-                      createSystemIdentity(
-                        name: \"'$NAME'\",
-                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
-                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
-                      ) {
-                        clientId,
-                        id,
-                        name
-                      }
+                  "mutation {
+                    create(
+                      name: \"'$NAME'\",
+                      organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                      publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                    ) {
+                      clientId,
+                      name
                     }
                   }"
                 }' | tr -d $'\n' | curl -X POST \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
                   --data @- \
                   "$REGISTRATION_ENDPOINT"
@@ -417,23 +409,24 @@ install:
               sleep 2
             done
 
-            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
-            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-              echo "Error creating an identity: $ERROR_MESSAGE"
-              exit
+            if [ $HTTP_CODE -ne 200 ]; then
+              exit 99
             fi
 
-            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit 100
+            fi
+
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
             # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
-
-            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -341,18 +341,18 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
-            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-          else
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*auth_config:/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -332,6 +332,10 @@ install:
             sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
+            sed -i 's/api-key: API_KEY_HERE/api-key: {{ .NEW_RELIC_LICENSE_KEY }}/g' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"staging-service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -343,13 +343,13 @@ install:
         - |
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
             sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
-            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -369,13 +369,13 @@ install:
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
               REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
               REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
             else
               REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              # TODO: TOKEN_RENEWAL_ENDPOINT
+              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
             fi
 
             NAME="System Identity for $(hostname)"
@@ -423,7 +423,7 @@ install:
             NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -348,7 +348,7 @@ install:
             sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*auth_config:\s*$/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
@@ -358,32 +358,35 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
             set -uo pipefail
 
-            mkdir /etc/newrelic-super-agent/keys
+            mkdir -p /etc/newrelic-super-agent/keys
             chown root:root /etc/newrelic-super-agent/keys
             chmod 700 /etc/newrelic-super-agent/keys
 
             TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            chown root:root "${TEMPORAL_FOLDER}"
+            chmod 700 "${TEMPORAL_FOLDER}"
             trap "rm -rf $TEMPORAL_FOLDER" EXIT
             openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
             openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
 
             if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
-              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://staging-system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://staging-api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
             elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
-              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.eu.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.eu.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
             else
-              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/system-identity/graphql
-              TOKEN_RENEWAL_ENDPOINT = https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              REGISTRATION_ENDPOINT=https://api.newrelic.com/graphql
+              TOKEN_RENEWAL_ENDPOINT=https://system-identity-oauth.service.newrelic.com/oauth2/token
             fi
 
-            NAME="System Identity for $(hostname)"
+            DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            NAME="System Identity for $(hostname) - $DATE"
 
             for RETRY in 1 2 3; do
               HTTP_CODE=$(echo '{ "query":
                   "mutation {
-                    create(
+                    systemIdentityCreate(
                       name: \"'$NAME'\",
                       organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
                       publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
@@ -392,12 +395,12 @@ install:
                       name
                     }
                   }"
-                }' | tr -d $'\n' | curl -X POST \
+                }' | tr -d $'\n' | curl \
                   -s -w "%{http_code}" \
                   -H "Content-Type: application/json" \
-                  -H "api-key: {{ .NEW_RELIC_LICENSE_KEY }}" \
+                  -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                   -o "$TEMPORAL_FOLDER/response.json" \
-                  --data @- \
+                  --data-binary @- \
                   "$REGISTRATION_ENDPOINT"
               )
 
@@ -413,20 +416,19 @@ install:
               exit 99
             fi
 
-            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
             if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
               echo "Error creating an identity: $ERROR_MESSAGE"
               exit 100
             fi
 
-            CLIENT_ID=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
-            NAME=$(/usr/local/bin/newrelic utils jq -r '.data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+            CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
 
             mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
-            sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~token_url: PLACEHOLDER~token_url: '"$TOKEN_RENEWAL_ENDPOINT"'~g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
             sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
-            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's~private_key_path: PLACEHOLDER~private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'~g' /etc/newrelic-super-agent/config.yaml
           fi
 
     config_host_monitoring:

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -341,7 +341,7 @@ install:
     config_super_agent_auth:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -67,6 +67,7 @@ install:
         - task: config_supervisors
         - task: config_fleet_id
         - task: config_opamp
+        - task: config_super_agent_auth
         - task: config_host_monitoring
         - task: update_otel_mem_limit
         - task: update_otel_end_point
@@ -123,6 +124,30 @@ install:
           if [ $IS_TOUCH_INSTALLED -eq 0 ] ; then
             echo "touch is required to run the newrelic install. Please install touch and re-run the installation." >&2
             exit 15
+          fi
+        - |
+          IS_CURL_INSTALLED=$(which curl | wc -l)
+          if [ $IS_CURL_INSTALLED -eq 0 ] ; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          IS_OPENSSL_INSTALLED=$(which openssl | wc -l)
+          if [ $IS_OPENSSL_INSTALLED -eq 0 ] ; then
+            echo "openssl is required to run the newrelic install. Please install openssl and re-run the installation." >&2
+            exit 17
+          fi
+        - |
+          IS_JQ_INSTALLED=$(which jq | wc -l)
+          if [ $IS_JQ_INSTALLED -eq 0 ] ; then
+            echo "jq is required to run the newrelic install. Please install jq and re-run the installation." >&2
+            exit 18
+          fi
+        - |
+          IS_MKTEMP_INSTALLED=$(which mktemp | wc -l)
+          if [ $IS_MKTEMP_INSTALLED -eq 0 ] ; then
+            echo "mktemp is required to run the newrelic install. Please install coreutils and re-run the installation." >&2
+            exit 19
           fi
         - |
           IS_INFRA_AVAILABLE=$(curl -Is {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/zypp/sles/{{.SLES_VERSION}}/x86_64/newrelic-infra.repo | grep " 2[0-9][0-9] " | wc -l)
@@ -291,16 +316,20 @@ install:
     config_opamp:
       cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] ; then
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*opamp:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*endpoint: https:\/\/opamp/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ]; then
             sed -i '/^\s*api-key:/s/^/#/' /etc/newrelic-super-agent/config.yaml
             sed -i '/^\s*headers:/s/^/#/' /etc/newrelic-super-agent/config.yaml
           else
-            sed -i 's/s*#\s*opamp:/opamp:/g' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*endpoint: https:\/\/opamp/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*api-key:/s/#//' /etc/newrelic-super-agent/config.yaml
-            sed -i '/^\s*#\s*headers:/s/#//' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*api-key:/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*headers:/s/# //' /etc/newrelic-super-agent/config.yaml
           fi
         - |
           if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
@@ -310,9 +339,97 @@ install:
           else
             sed -i 's/\(endpoint: https:\/\/opamp.\).*/\1'"service.newrelic.com\/v1\/opamp"'/' /etc/newrelic-super-agent/config.yaml
           fi
+
+    config_super_agent_auth:
+      cmds:
         - |
-          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] ; then
-            sed -i 's/api-key: API_KEY_HERE/api-key: {{.NEW_RELIC_LICENSE_KEY}}/g' /etc/newrelic-super-agent/config.yaml
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" = "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            sed -i '/^\s*auth_config: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*token_url: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*client_id: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*provider: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*private_key_path: PLACEHOLDER/s/^/#/' /etc/newrelic-super-agent/config.yaml
+          else
+            sed -i '/^\s*#\s*auth_config: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            # TODO: sed -i '/^\s*#\s*token_url: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*client_id: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*provider: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+            sed -i '/^\s*#\s*private_key_path: PLACEHOLDER/s/# //' /etc/newrelic-super-agent/config.yaml
+          fi
+        - |
+          if [ "{{.NEW_RELIC_SUPER_AGENT_FLEET_ENABLED}}" != "false" ] && [ "{{ .NEW_RELIC_ORGANIZATION }}" != "" ]; then
+            set -uo pipefail
+
+            mkdir /etc/newrelic-super-agent/keys
+            chown root:root /etc/newrelic-super-agent/keys
+            chmod 700 /etc/newrelic-super-agent/keys
+
+            TEMPORAL_FOLDER=$(mktemp -d newrelic-super-agent.XXXXXXXXXX)
+            openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096
+            openssl rsa -in "$TEMPORAL_FOLDER/key" -pubout -out "$TEMPORAL_FOLDER/pub"
+
+            if [ "{{.NEW_RELIC_REGION}}" = "STAGING" ]; then
+              REGISTRATION_ENDPOINT=https://staging-iam-service.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            elif [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+              REGISTRATION_ENDPOINT=https://iam-service.eu.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            else
+              REGISTRATION_ENDPOINT=https://iam-service.vip.cf.nr-ops.net/graphql
+              # TODO: TOKEN_RENEWAL_ENDPOINT
+            fi
+
+            NAME="System Identity for $(hostname)"
+
+            for RETRY in 1 2 3; do
+              HTTP_CODE=$(echo '{ "query":
+                  "{
+                    mutation createSystemIdentity {
+                      createSystemIdentity(
+                        name: \"'$NAME'\",
+                        organizationId: \"{{ .NEW_RELIC_ORGANIZATION }}\",
+                        publicKey: \"'$(openssl enc -base64 -A -in "$TEMPORAL_FOLDER/pub")'\"
+                      ) {
+                        clientId,
+                        id,
+                        name
+                      }
+                    }
+                  }"
+                }' | tr -d $'\n' | curl -X POST \
+                  -s -w "%{http_code}" \
+                  -H "Content-Type: application/json" \
+                  -H "api-key: {{ .NEW_RELIC_API_KEY }}" \
+                  -o "$TEMPORAL_FOLDER/response.json" \
+                  --data @- \
+                  "$REGISTRATION_ENDPOINT"
+              )
+
+              if [ $HTTP_CODE -eq 200 ]; then
+                break
+              fi
+
+              echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+              sleep 2
+            done
+
+            ERROR_MESSAGE=$(jq -r '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json")
+            if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+              echo "Error creating an identity: $ERROR_MESSAGE"
+              exit
+            fi
+
+            CLIENT_ID=$(jq 'data.createSystemIdentity.clientId' < "$TEMPORAL_FOLDER/response.json")
+            ID=$(jq 'data.createSystemIdentity.id' < "$TEMPORAL_FOLDER/response.json")
+            NAME=$(jq 'data.createSystemIdentity.name' < "$TEMPORAL_FOLDER/response.json")
+
+            mv "$TEMPORAL_FOLDER/key" "/etc/newrelic-super-agent/keys/$CLIENT_ID.key"
+            # TODO: sed -i 's/token_url: PLACEHOLDER/token_url: '"$TOKEN_RENEWAL_ENDPOINT"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/client_id: PLACEHOLDER/client_id: '"$CLIENT_ID"'/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/provider: PLACEHOLDER/provider: local/g' /etc/newrelic-super-agent/config.yaml
+            sed -i 's/private_key_path: PLACEHOLDER/private_key_path: '"/etc/newrelic-super-agent/keys/$CLIENT_ID.key"'/g' /etc/newrelic-super-agent/config.yaml
+
+            rm -rf "$TEMPORAL_FOLDER"
           fi
 
     config_host_monitoring:


### PR DESCRIPTION
This script creates the key pair and push the public one to New Relic. Also configures the super agent to use the key generated.

It fails to register the host saying that there is an error on the back end:
```
Error creating an identity: Validation error (FieldUndefined@[mutation]) : Field 'mutation' in type 'Query' is undefined
```

But we are supposing that the backend will behave correctly EOD