### PR TITLE
infra agent: enforce utf8 encoding on Windows config

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -207,24 +207,24 @@ install:
 
           $NEW_RELIC_REGION = "{{.NEW_RELIC_REGION}}"
           if ($NEW_RELIC_REGION -ilike "staging") {
-            Add-Content -Path $InfraConfig -Value "staging: true" -Force
+            Add-Content -Path $InfraConfig -Value "staging: true" -Force -Encoding utf8
           }
-          Add-Content -Path $InfraConfig -Value "enable_process_metrics: true" -Force
-          Add-Content -Path $InfraConfig -Value "status_server_enabled: true" -Force
-          Add-Content -Path $InfraConfig -Value "status_server_port: 18003" -Force
+          Add-Content -Path $InfraConfig -Value "enable_process_metrics: true" -Force -Encoding utf8
+          Add-Content -Path $InfraConfig -Value "status_server_enabled: true" -Force -Encoding utf8
+          Add-Content -Path $InfraConfig -Value "status_server_port: 18003" -Force -Encoding utf8
           if (Test-Path env:HTTPS_PROXY) {
             (Get-Content $InfraConfig) | Where-Object {
               $_ -notmatch "^proxy"
             } | Set-Content $InfraConfig
 
-            Add-Content -Path $InfraConfig -Value "proxy: $env:HTTPS_PROXY" -Force
+            Add-Content -Path $InfraConfig -Value "proxy: $env:HTTPS_PROXY" -Force -Encoding utf8
           }
 
           $customAttributes=@"
           {{.NRIA_CUSTOM_ATTRIBUTES}}
           "@
 
-          Add-Content -Path $InfraConfig -Value $customAttributes -Force
+          Add-Content -Path $InfraConfig -Value $customAttributes -Force -Encoding utf8
           '
 
     start_infra:


### PR DESCRIPTION
Infra Agent config file on Windows has ANSI Encoding by default. This PR makes it UTF8.