### PR TITLE
[NR-295076] super-agent: manually install fluent-bit for amazon linux

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -302,6 +302,10 @@ install:
 
           yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra' --enablerepo='newrelic-super-agent'
           yum -y -q install newrelic-super-agent
+
+          if [ "{{.AMAZON_LINUX_VERSION}}" == "2" ] || [ "{{.AMAZON_LINUX_VERSION}}" == "2023" ] ; then
+            yum -y -q install fluent-bit
+          fi
       vars:
         DISTRO_VERSION:
           sh: |


### PR DESCRIPTION
This PR updates the super-agent's recipe to install fluent-bit manually on Amazon linux. This is needed because the [recommends package dependency](https://github.com/newrelic/newrelic-super-agent/blob/1abc91ceec135a3e26055ba406e90cdab3f1644a/.goreleaser.yml#L174) used in the super-agent's RPM (which usually installs fluent-bit as a dependency) isn't supported in the default RPM version in the AL2 x86 base image.