### PR TITLE
[SuperAgent] remove agentType version

### DIFF
--- a/recipes/newrelic/infrastructure/super-agent/debian.yml
+++ b/recipes/newrelic/infrastructure/super-agent/debian.yml
@@ -586,11 +586,11 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           else
             if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/rhel.yml
+++ b/recipes/newrelic/infrastructure/super-agent/rhel.yml
@@ -529,11 +529,11 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           else
             if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 

--- a/recipes/newrelic/infrastructure/super-agent/suse.yml
+++ b/recipes/newrelic/infrastructure/super-agent/suse.yml
@@ -476,11 +476,11 @@ install:
           if [ "{{.NEW_RELIC_SUPER_AGENT_HOST_MONITORING_SOURCE}}" = "otel" ]; then
             echo 'is_integrations_only: true' >> /etc/newrelic-infra.yml
             mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+            cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-agent-linux.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
           else
             if [ "{{.NR_CLI_NRDOT}}" != "false" ]; then
               mkdir -p /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values
-              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway-0.1.0.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
+              cp /etc/newrelic-super-agent/examples/values-nr-otel-collector-gateway.yaml /etc/newrelic-super-agent/fleet/agents.d/nr-otel-collector/values/values.yaml
             fi
           fi
 


### PR DESCRIPTION
This should be merged right after (And not before!) the next SuperAgent release that will remove -0.1.0. 
Otherwise the recipe will stop working since it will not know where to find that file.