### PR TITLE
fix(mysql): add ubuntu version 24.4 support for mysql integration

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -17,7 +17,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "(((16|18|20|21|22)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
+    platformVersion: "(((16|18|20|21|22|24)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
 
 # keyword convention for dealing with search terms that could land someone on this instrumentation project
 keywords:


### PR DESCRIPTION
add ubuntu version 24.4 support for mysql integration

[JIRA-NR-329834](https://new-relic.atlassian.net/browse/NR-329834)


Validation results:

Before adding 24.4 Ubuntu version support

![image](https://github.com/user-attachments/assets/d3019174-2e72-47c1-a543-05638917a1a1)
output
![image](https://github.com/user-attachments/assets/d13bddcb-b4f1-483a-b022-6d6ffb99b915)




![image](https://github.com/user-attachments/assets/3fcf71d4-938b-4f15-b015-817e2674afd7)


After adding 24.4 Ubuntu version support
![image](https://github.com/user-attachments/assets/d8eac0d2-fee3-4425-a946-58b6dd4adc59)

 output


![image](https://github.com/user-attachments/assets/072ebba8-a0dd-43f1-a6d0-1234695a7a62)
![image](https://github.com/user-attachments/assets/d3b62dfa-3d74-4cda-9c4c-a00b62abfb4e)



After adding support in OIL able to install mysql-integration