### PR TITLE
fix(demo_deployer): Updated specific regex in validate_output's param

### DIFF
--- a/test/definitions-eu/apm/dotNet/linux/debian10-nginx-aspnetcore.json
+++ b/test/definitions-eu/apm/dotNet/linux/debian10-nginx-aspnetcore.json
@@ -58,7 +58,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/linux-systemd.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": ".NET Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
+++ b/test/definitions-eu/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
@@ -57,7 +57,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/linux-systemd.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": ".NET Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/dotNet/windows/iis-blank.json
+++ b/test/definitions-eu/apm/dotNet/windows/iis-blank.json
@@ -34,7 +34,7 @@
           "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
           "params": {
               "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/windows-iis.yml",
-              "validate_output": "New Relic installation complete"
+              "validate_output": ".NET Agent\\s+\\(installed\\)"
           }
       }
       ]

--- a/test/definitions-eu/apm/dotNet/windows/windows2016-iis.json
+++ b/test/definitions-eu/apm/dotNet/windows/windows2016-iis.json
@@ -44,20 +44,21 @@
         "is_core_app": "true"
       }
     }],
-  
-    "instrumentations": {
-      "resources": [
-        {
-            "id": "nr_infra",
-            "resource_ids": ["iiswindows2016"],
-            "provider": "newrelic",
-            "source_repository": "https://github.com/newrelic/open-install-library.git",
-            "deploy_script_path": "test/deploy/windows/newrelic-cli/install/roles",
-            "params": {
-                "local_recipes": true
-            }
+
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_infra",
+        "resource_ids": ["iiswindows2016"],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/windows-iis.yml",
+          "validate_output": ".NET Agent\\s+\\(installed\\)"
         }
-        ]
-    }
+      }
+    ]
+  }
   }
   

--- a/test/definitions-eu/apm/dotNet/windows/windows2019-core-only-iis.json
+++ b/test/definitions-eu/apm/dotNet/windows/windows2019-core-only-iis.json
@@ -33,20 +33,20 @@
         "is_core_app": "true"
       }
     }],
-  
-    "instrumentations": {
-      "resources": [
-        {
-            "id": "nr_infra",
-            "resource_ids": ["iiswindows2019"],
-            "provider": "newrelic",
-            "source_repository": "https://github.com/newrelic/open-install-library.git",
-            "deploy_script_path": "test/deploy/windows/newrelic-cli/install/roles",
-            "params": {
-                "local_recipes": true
-            }
-        }
-        ]
-    }
+
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_infra",
+        "resource_ids": ["iiswindows2019"],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/windows/newrelic-cli/install/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/windows-iis.yml",
+          "validate_output": ".NET Agent\\s+\\(installed\\)"            }
+      }
+    ]
+  }
   }
   

--- a/test/definitions-eu/apm/dotNet/windows/windows2019-iis.json
+++ b/test/definitions-eu/apm/dotNet/windows/windows2019-iis.json
@@ -55,7 +55,7 @@
           "deploy_script_path": "test/deploy/windows/newrelic-cli/install-recipe/roles",
           "params": {
               "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/windows.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/dotNet/windows-iis.yml",
-              "validate_output": "New Relic installation complete"
+              "validate_output": ".NET Agent\\s+\\(installed\\)"
           }
       }
     ]

--- a/test/definitions-eu/apm/java/deb10-supd-javatron.json
+++ b/test/definitions-eu/apm/java/deb10-supd-javatron.json
@@ -53,7 +53,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/deb10-sysd-custom-sh.json
+++ b/test/definitions-eu/apm/java/deb10-sysd-custom-sh.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/deb10-sysd-tomcat-cmd.json
+++ b/test/definitions-eu/apm/java/deb10-sysd-tomcat-cmd.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/deb10-sysd-tomcat-sh.json
+++ b/test/definitions-eu/apm/java/deb10-sysd-tomcat-sh.json
@@ -42,7 +42,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/deb11-apt-sysd-tomcat.json
+++ b/test/definitions-eu/apm/java/deb11-apt-sysd-tomcat.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/deb11-sysd-jboss.json
+++ b/test/definitions-eu/apm/java/deb11-sysd-jboss.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/debian.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-supd-javatron.json
+++ b/test/definitions-eu/apm/java/rhl2-supd-javatron.json
@@ -52,7 +52,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-sysd-custom-sh.json
+++ b/test/definitions-eu/apm/java/rhl2-sysd-custom-sh.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-sysd-tomcat-cmd.json
+++ b/test/definitions-eu/apm/java/rhl2-sysd-tomcat-cmd.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-sysd-tomcat-sh.json
+++ b/test/definitions-eu/apm/java/rhl2-sysd-tomcat-sh.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-yum-docker-jboss.json
+++ b/test/definitions-eu/apm/java/rhl2-yum-docker-jboss.json
@@ -47,7 +47,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/rhl2-yum-sysd-tomcat.json
+++ b/test/definitions-eu/apm/java/rhl2-yum-sysd-tomcat.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/ub20-apt-docker-jboss.json
+++ b/test/definitions-eu/apm/java/ub20-apt-docker-jboss.json
@@ -45,7 +45,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/ub20-apt-docker-tomcat.json
+++ b/test/definitions-eu/apm/java/ub20-apt-docker-tomcat.json
@@ -41,7 +41,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "Java Agent\\s+\\(installed\\)"
         }
       },
       {

--- a/test/definitions-eu/apm/java/ub20-apt-sysd-tomcat.json
+++ b/test/definitions-eu/apm/java/ub20-apt-sysd-tomcat.json
@@ -38,7 +38,7 @@
           "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
           "params": {
             "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/java/linux.yml",
-            "validate_output": "New Relic installation complete"
+            "validate_output": "Java Agent\\s+\\(installed\\)"
           }
         },
         {

--- a/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-linux2.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-linux2.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/php-agent/php-apache-wordpress-linux2.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-wordpress-linux2.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
+++ b/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-linux2.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/apm/us-php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/us-php-apache-fpm-wordpress-ubuntu18.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ubuntu.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/debian.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]

--- a/test/definitions/apm/us-php-nginx-fpm-wordpress-linux2.json
+++ b/test/definitions/apm/us-php-nginx-fpm-wordpress-linux2.json
@@ -38,7 +38,7 @@
         "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
         "params": {
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/awslinux.yml,https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/apm/php/redhat.yml",
-          "validate_output": "New Relic installation complete"
+          "validate_output": "PHP Agent\\s+\\(installed\\)"
         }
       }
     ]


### PR DESCRIPTION
**Issue:-** Currently in few of the demo deployer scripts, the validation output strings not correct, tests are showing as passed even though they are failing, due to validation output check string is not correctly entered.
[Jira Ticket](https://new-relic.atlassian.net/browse/NR-338891)

Updated the validate_output fields in the deployer scripts to use the correct regular expressions for specific agent installations.
Changes done in the variety of deployer scripts for the different agents, for example in PHP deployer scripts.

**PHP Deployer Script:**
From: "New Relic installation complete"
To: "PHP Agent\s+\(installed\)"

**Context**
The previous validate_output string, "New Relic installation complete", was too generic and indicated success for any installation. This update ensures that the validate_output specifically checks for the PHP agent installation status.

**Verification**
Verified that the new regular expression correctly identifies the PHP agent installation.

![image](https://github.com/user-attachments/assets/8064eff2-ddf3-4b83-80e0-e8ea79cce4a5)
