### PR TITLE
fix: use https for mssql integration download

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -392,7 +392,7 @@ install:
           if ($env:HTTPS_PROXY) {
             $WebClient.Proxy = New-Object System.Net.WebProxy($env:HTTPS_PROXY, $true)
           }
-          $WebClient.DownloadFile("http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/nri-mssql-amd64.msi", "$env:TEMP\nri-mssql-amd64.msi");
+          $WebClient.DownloadFile("https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/nri-mssql-amd64.msi", "$env:TEMP\nri-mssql-amd64.msi");
           msiexec.exe /qn /i "$env:TEMP\nri-mssql-amd64.msi" | Out-Null;
 
           Restart-Service newrelic-infra


### PR DESCRIPTION
### Why?
`nri-mssql` install fails to download on restricted hosts where unencrypted traffic is not allowed.