### PR TITLE
NR-361437-fix-jd-parse-error

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -524,13 +524,16 @@ install:
             # Get the L1 Access Token
             ############################################################
             if [ "{{.NEW_RELIC_AUTH_CLIENT_ID}}" != "" ] && [ "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}" != "" ]; then
+              echo Starting with L1 System Identity...
               RESPONSE_FILE=$TEMPORAL_FOLDER/response_token.json
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{"client_id": "{{.NEW_RELIC_AUTH_CLIENT_ID}}", "client_secret": "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}", "grant_type": "client_credentials"}' | tr -d $'\n' | curl \
-                  -s -w "%{http_code}" \
+                  -s -S -w "%{http_code}" \
                   -H "Content-Type: application/json" \
                   -o "$RESPONSE_FILE" \
                   --data-binary @- \
+                  --max-time 60 \
+                  --connect-timeout 10 \
                   "$TOKEN_RENEWAL_ENDPOINT"
                 )
 
@@ -538,10 +541,22 @@ install:
                   break
                 fi
           
-                ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-
-                echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
-                sleep 2
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
 
               if [ $HTTP_CODE -ne 200 ]; then
@@ -556,7 +571,8 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
-  
+              echo Starting with L2 System Identity...
+              
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
                     "mutation {
@@ -570,30 +586,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "Authorization: Bearer $ACCESS_TOKEN" \
                     -o "$TEMPORAL_FOLDER/response.json" \
                     --data-binary @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$IDENTITY_CREATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during L2 identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic System Identity L2 for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.create.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
@@ -603,7 +637,8 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
-  
+              echo Starting with Legacy System Identity...
+              
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
                     "mutation {
@@ -617,30 +652,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                     -o "$TEMPORAL_FOLDER/response.json" \
-                    --data-binary @- \
+                    --data @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$REGISTRATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during legacy identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic Legacy System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -466,13 +466,16 @@ install:
             # Get the L1 Access Token
             ############################################################
             if [ "{{.NEW_RELIC_AUTH_CLIENT_ID}}" != "" ] && [ "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}" != "" ]; then
+              echo Starting with L1 System Identity...
               RESPONSE_FILE=$TEMPORAL_FOLDER/response_token.json
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{"client_id": "{{.NEW_RELIC_AUTH_CLIENT_ID}}", "client_secret": "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}", "grant_type": "client_credentials"}' | tr -d $'\n' | curl \
-                  -s -w "%{http_code}" \
+                  -s -S -w "%{http_code}" \
                   -H "Content-Type: application/json" \
                   -o "$RESPONSE_FILE" \
                   --data-binary @- \
+                  --max-time 60 \
+                  --connect-timeout 10 \
                   "$TOKEN_RENEWAL_ENDPOINT"
                 )
 
@@ -480,10 +483,22 @@ install:
                   break
                 fi
           
-                ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-
-                echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
-                sleep 2
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
 
               if [ $HTTP_CODE -ne 200 ]; then
@@ -498,7 +513,8 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
-  
+              echo Starting with L2 System Identity...
+              
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
                     "mutation {
@@ -512,30 +528,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "Authorization: Bearer $ACCESS_TOKEN" \
                     -o "$TEMPORAL_FOLDER/response.json" \
                     --data-binary @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$IDENTITY_CREATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during L2 identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic System Identity L2 for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.create.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
@@ -545,7 +579,8 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
-  
+              echo Starting with Legacy System Identity...
+              
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
                     "mutation {
@@ -559,30 +594,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                     -o "$TEMPORAL_FOLDER/response.json" \
-                    --data-binary @- \
+                    --data @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$REGISTRATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during legacy identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic Legacy System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -413,24 +413,39 @@ install:
             # Get the L1 Access Token
             ############################################################
             if [ "{{.NEW_RELIC_AUTH_CLIENT_ID}}" != "" ] && [ "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}" != "" ]; then
+              echo Starting with L1 System Identity...
               RESPONSE_FILE=$TEMPORAL_FOLDER/response_token.json
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{"client_id": "{{.NEW_RELIC_AUTH_CLIENT_ID}}", "client_secret": "{{.NEW_RELIC_AUTH_CLIENT_SECRET}}", "grant_type": "client_credentials"}' | tr -d $'\n' | curl \
-                  -s -w "%{http_code}" \
+                  -s -S -w "%{http_code}" \
                   -H "Content-Type: application/json" \
                   -o "$RESPONSE_FILE" \
                   --data-binary @- \
+                  --max-time 60 \
+                  --connect-timeout 10 \
                   "$TOKEN_RENEWAL_ENDPOINT"
                 )
 
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-          
-                ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-
-                echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
-                sleep 2
+                                  
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.error_description // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error getting system identity auth token. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
 
               if [ $HTTP_CODE -ne 200 ]; then
@@ -445,6 +460,7 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
+              echo Starting with L2 System Identity...
   
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
@@ -459,30 +475,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "Authorization: Bearer $ACCESS_TOKEN" \
                     -o "$TEMPORAL_FOLDER/response.json" \
                     --data-binary @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$IDENTITY_CREATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during L2 identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic System Identity L2 for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.create.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )
@@ -492,6 +526,7 @@ install:
               ############################################################
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
               NAME="System Identity for $(hostname) - $DATE"
+              echo Starting with Legacy System Identity...
   
               for RETRY in 1 2 3; do
                 HTTP_CODE=$(echo '{ "query":
@@ -506,30 +541,48 @@ install:
                       }
                     }"
                   }' | tr -d $'\n' | curl \
-                    -s -w "%{http_code}" \
+                    -s -S -w "%{http_code}" \
                     -H "Content-Type: application/json" \
                     -H "API-Key: {{ .NEW_RELIC_API_KEY }}" \
                     -o "$TEMPORAL_FOLDER/response.json" \
-                    --data-binary @- \
+                    --data @- \
+                    --max-time 60 \
+                    --connect-timeout 10 \
                     "$REGISTRATION_ENDPOINT"
                 )
   
                 if [ $HTTP_CODE -eq 200 ]; then
                   break
                 fi
-  
-                echo "Error creating the new system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
-                sleep 2
+          
+                if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" -eq 0 ]; then
+                  echo "Network error occurred or no HTTP response was received during legacy identity creation. Retrying ($RETRY/3)..."
+                  sleep 2
+                  continue
+                else
+                  if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                    ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  else
+                    echo -n "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: " && cat "$TEMPORAL_FOLDER/response_token.json" | tr -d '\n' && echo " Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                fi
               done
   
               if [ $HTTP_CODE -ne 200 ]; then
                 exit 99
               fi
-  
-              ERROR_MESSAGE=$(/usr/local/bin/newrelic utils jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
-              if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
-                echo "Failed to create a New Relic System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
-                exit 100
+          
+              if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
+                ERROR_MESSAGE=$(jq '.errors[0].message // "NOERROR"' < "$TEMPORAL_FOLDER/response.json" | tr -d '"')
+                if [ "$ERROR_MESSAGE" != "NOERROR" ]; then
+                  echo "Failed to create a New Relic Legacy System Identity for Fleet Control communication authentication. Please verify that your User Key is valid and that your Account Organization has the necessary permissions to create a System Identity: $ERROR_MESSAGE"
+                  exit 100
+                fi
               fi
   
               CLIENT_ID=$(/usr/local/bin/newrelic utils jq  '.data.systemIdentityCreate.clientId' < "$TEMPORAL_FOLDER/response.json" | tr -d '"' )


### PR DESCRIPTION
Added:
- Max time 60
- Connect timeout
for identity curls calls in recipes of suse, rhel and debian.

And after modify the script into the helm for k8s to fix jq parse errores this changes are applied here too 