### PR TITLE
 fix/error concatenation message

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -607,7 +607,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else
@@ -673,7 +673,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -549,7 +549,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else
@@ -615,7 +615,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -496,7 +496,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating L2 system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else
@@ -562,7 +562,7 @@ install:
                 else
                   if jq empty "$TEMPORAL_FOLDER/response_token.json" > /dev/null 2>&1; then
                     ERROR_MESSAGE=$(jq '.errors[0].message // "invalid_request"' < "$TEMPORAL_FOLDER/response_token.json" | tr -d '"')
-                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE. Retrying ($RETRY/3)..."
+                    echo "Error creating the new legacy system identity. The API endpoint returned $HTTP_CODE: $ERROR_MESSAGE. Retrying ($RETRY/3)..."
                     sleep 2
                     continue
                   else


### PR DESCRIPTION
Add $ERROR_MESSAGE after HTTP CODE logs during L2 and legacy identity request