### PR TITLE
fix(php): PHP installation failures with al2023/rhel

### DIFF
--- a/recipes/newrelic/apm/php/redhat.yml
+++ b/recipes/newrelic/apm/php/redhat.yml
@@ -351,20 +351,25 @@ install:
 
       vars:
         AGENT_VERSION: "9.17.1.301"
-
+        
     install_rpm:
       cmds:
         - |
           echo -e "{{.ARROW}}Adding the New Relic PHP Agent repository{{.GRAY}}"
-          # The repo install command returns a non-zero return code if it is already installed
-          # Only attempt an install if it is needed
-          if rpm -q newrelic-repo-5-3.noarch > /dev/null; then
-            echo -e "The New Relic repository is already installed."
+          # Skip this task if the host machine is Amazon Linux 2023
+          if grep -q "Amazon Linux release 2023" /etc/system-release; then
+            echo -e "Skipping repository installation on Amazon Linux 2023."
           else
-            echo -e "Adding the New Relic PHP Agent repository."
-            sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
+            # The repo install command returns a non-zero return code if it is already installed
+            # Only attempt an install if it is needed
+            if rpm -q newrelic-repo-5-3.noarch > /dev/null; then
+              echo -e "The New Relic repository is already installed."
+            else
+              echo -e "Adding the New Relic PHP Agent repository."
+              sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
+            fi
+            sudo yum install -y newrelic-php5
           fi
-          sudo yum install -y newrelic-php5
 
     configure:
       cmds:


### PR DESCRIPTION
Issue:- PHP installations are failing on AL2023/RHEL with the error: **"execution failed for php-agent-installer: exit status 1: redhat-release >= 5 is required by newrelic-repo-5-3.noarch"**

[Jira Ticket](https://new-relic.atlassian.net/browse/NR-362794)

Upon investigation, it was determined that the `install_rpm` command is not supported in Al2023. When the installation recipe executed the command:

```sh
sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
```

the following error was encountered:

```sh
error: Failed dependencies: redhat-release >= 5 is needed by newrelic-repo-5-3.noarch
```
The issue was resolved after implementing the necessary changes, I tried PHP installation on Al2023/RHEL and it is working fine, see below.  

![image](https://github.com/user-attachments/assets/8f2673fb-fd2f-4276-8078-836bdc07ba6d)



