### PR TITLE
fix(python): Fixed ec2 provisioning issue

### DIFF
--- a/test/deploy/linux/python/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/python/install/rhel/roles/configure/tasks/main.yml
@@ -11,9 +11,10 @@
     - "../templates/*"
   become: true
 
-- name: Install dependencies from requirements.txt
-  ansible.builtin.pip:
-    requirements: /home/ec2-user/requirements.txt
-    umask: "0022"
+- name: Ensure pip is installed
+  ansible.builtin.command: python3 -m ensurepip --upgrade
   become: true
 
+- name: Install dependencies from requirements.txt
+  ansible.builtin.command: python3 -m pip install --user -r /home/ec2-user/requirements.txt
+  become: false

--- a/test/manual/definitions/apm/python/python-al2.json
+++ b/test/manual/definitions/apm/python/python-al2.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.small",
-      "ami_name": "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2",
+      "ami_name": "al2023-ami-2023.?.????????.?-kernel-?.?-x86_64",
       "user_name": "ec2-user"
     }
   ],


### PR DESCRIPTION
Issue: EC2 instance provisioning was failing for Python.

![image](https://github.com/user-attachments/assets/61c40d1c-bb69-4dba-a2e3-80781251997b)

After the few changes, it is working fine 

![image](https://github.com/user-attachments/assets/94debba9-d0c4-4e0d-a9fc-1c4744c08a59)

