### PR TITLE
fix(script): Escape square brackets in registry key paths

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -104,7 +104,8 @@ install:
 
               $uninstallIds = New-Object System.Collections.ArrayList
               foreach ($key in $allKeys) {
-                $keyData = Get-Item -Path HKLM:\$key
+                $escapedKey = $key -replace '\[', '`[' -replace '\]', '`]'
+                $keyData = Get-Item -Path "HKLM:\$escapedKey"
                 $name = $keyData.GetValue("DisplayName")
                 if ($name -and $name -match $Match) {
                   $keyId = Split-Path $key -Leaf
@@ -131,8 +132,7 @@ install:
             }
           }
           catch {
-            Write-Host -ForegroundColor Red "We detected you may be running an anti-virus software preventing our installation to continue. Please check your anti-virus software to allow Powershell execution while running this installation."
-            exit 131;
+            throw $_.Exception
           }
           '
 


### PR DESCRIPTION
Issue:- Mentioned in the below jira ticket.
[Jira Ticket](https://new-relic.atlassian.net/browse/NR-374495)

Fix:- Escape square brackets in registry key paths in Windows installer recipe.