### PR TITLE
feat(kubernetes): Add Kube 1.32 support and drop 1.27

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -182,14 +182,14 @@ install:
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 27 ]]; then
-            echo "Installation failed. Kubernetes version less that v1.27 is not supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 28 ]]; then
+            echo "Installation failed. Kubernetes version less that v1.28 is not supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 31 ]]; then
-            echo "Kubernetes version greater than v1.31 is not officially supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 32 ]]; then
+            echo "Kubernetes version greater than v1.32 is not officially supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
           fi
           

--- a/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
@@ -58,7 +58,7 @@
   when: is_minikube_installed.stdout|int == 0
 
 - name: Start Minikube
-  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.31.0'
+  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.32.0'
 
 - name: Create kubectl wrap command
   template:


### PR DESCRIPTION
Add Kube 1.32 support and drop 1.27
Update testing to use Kube v1.32.0 instead of v1.31.0 for minikube

Test Plan: Spun up a v1.32 cluster on minikube and installed NRI Bundle with a local copy of the `kubernetes.yml` from this PR.