### PR TITLE
fix(debian-tests): Resolve consul-debian and cassandra-debian failures

### DIFF
--- a/test/definitions/ohi/linux/consul-debian.json
+++ b/test/definitions/ohi/linux/consul-debian.json
@@ -18,7 +18,7 @@
     "services": [{
       "id": "haproxy1",
       "destinations": ["host1"],
-      "source_repository": "-b fix/debian-tests https://github.com/newrelic/open-install-library.git",
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
       "deploy_script_path": "test/deploy/linux/consul/install/debian/roles",
       "port": 8500,
       "params":{

--- a/test/definitions/ohi/linux/consul-debian.json
+++ b/test/definitions/ohi/linux/consul-debian.json
@@ -18,7 +18,7 @@
     "services": [{
       "id": "haproxy1",
       "destinations": ["host1"],
-      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "source_repository": "-b fix/debian-tests https://github.com/newrelic/open-install-library.git",
       "deploy_script_path": "test/deploy/linux/consul/install/debian/roles",
       "port": 8500,
       "params":{

--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installDependencies.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installDependencies.yml
@@ -11,6 +11,6 @@
       - dirmngr
       - gnupg
       - software-properties-common
-      - wget
+      - openjdk-11-jdk
     update_cache: true
   become: true

--- a/test/deploy/linux/consul/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/consul/install/debian/roles/configure/tasks/main.yml
@@ -19,13 +19,28 @@
     state: latest
   become: yes
 
-- name: Add official HashiCorp GPG Key
-  shell: curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-  become: true
+- name: Download HashiCorp GPG key
+  shell: |
+    curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.asc
+  args:
+    creates: /tmp/hashicorp.asc
+  become: yes
 
-- name: Add official HashiCorp Linux Repository
-  shell: apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-  become: true
+- name: Add HashiCorp GPG key to APT keyring
+  shell: |
+    gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg /tmp/hashicorp.asc
+  args:
+    creates: /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  become: yes
+
+- name: Add HashiCorp APT repository
+  vars:
+    compatible_version: bookworm
+  apt_repository:
+    repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ compatible_version }} main"
+    state: present
+    filename: hashicorp
+  become: yes
 
 - block:
   - name: Create consul config directory


### PR DESCRIPTION
### Description

This PR aims to resolve consul-debian and cassandra-debian failures

### Fixes: 
- The method of adding a repository GPG key using apt-key is deprecated. To solve this issue, we have added the GPG key directly to the trusted keyrings directory.
- Added signed-by to reference the GPG key, ensuring APT trusts the repository using the specified GPG key.
- Configured `openjdk-11-jdk` separately before installing cassandra.