### PR TITLE
fix(account-credentials): Update account credentials for nonregression-eu workflow

### DIFF
--- a/.github/workflows/nonregression-eu.yml
+++ b/.github/workflows/nonregression-eu.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Write Test Definition File JSON to file
         env:
-          USER_JSON: ${{ secrets.GIT_DEPLOYER_DOCKER_USER_CONFIG_EU }}
+          USER_JSON: ${{ secrets.GIT_DEPLOYER_DOCKER_USER_CONFIG_EU_TEST_AC }}
         run: |
           echo "$USER_JSON" > configs/gitusdkreu${{ github.run_id }}.json
 


### PR DESCRIPTION
### Description

This PR aims to update account credentials for `nonregression-eu.yml` workflow

**Context**: Earlier for running `non-regression-eu` tests we were using the `GIT_DEPLOYER_DOCKER_USER_CONFIG_EU` secret. But the creds that is used in the secret is not having `Authentication Domain Manager` Access which is required for Agent control tests to be executed successfully.

**Solution**:  Created a new secret named `GIT_DEPLOYER_DOCKER_USER_CONFIG_EU_TEST_AC` which is using different creds which already have `Authentication Domain manager` access and used the same secret to execute the nonregression-eu tests, which are successful after this update. 

📓 Request to get `Authentication Domain Manger` role for the previous creds are already raised in this slack [thread](https://newrelic.slack.com/archives/C05SU1EBZUZ/p1741875639226729). 