### PR TITLE
fix: Update recipe to automate nagios plugin install

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -102,7 +102,7 @@ install:
               tar -xzf nagios-plugins.tar.gz || { echo "Failed to extract plugins." >&2; exit 2; }
           
               # Extract version from filename to use in cd command
-              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
+              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+(\.[0-9]+)?).tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
               cd "nagios-plugins-$VERSION" || { echo "Failed to enter directory." >&2; exit 2; }
           
               # Install prerequisites if missing

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -64,9 +64,61 @@ install:
           fi
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
-          if [ $PLUGINS_EXIST -eq 0 ] ; then
-            echo "check_users plugin not found in /usr/local/nagios/libexec/ - Please make sure that the plugins are installed." >&2
-            exit 2
+          if [ $PLUGINS_EXIST -eq 0 ]; then
+            echo "[INFO] Nagios plugins not found - downloading latest version..." >&2
+          
+            # Fetch the download page content, following redirects
+            DOWNLOAD_PAGE_URL="https://nagios-plugins.org/download/"
+            DOWNLOAD_PAGE=$(curl -sL "$DOWNLOAD_PAGE_URL")
+          
+            # Extract the latest version and download URL using grep with -E for extended regex
+            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+          
+            # Check if DOWNLOAD_URL is empty
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Failed to fetch the latest Nagios plugins version from the download page." >&2
+              exit 2
+            fi
+          
+            # Construct the full download URL
+            DOWNLOAD_URL="https://nagios-plugins.org/download/$DOWNLOAD_URL"
+          
+            # Download and install plugins
+            if curl -sL "$DOWNLOAD_URL" -o nagios-plugins.tar.gz; then
+              tar -xzf nagios-plugins.tar.gz || { echo "Failed to extract plugins." >&2; exit 2; }
+          
+              # Extract version from filename to use in cd command
+              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
+              cd "nagios-plugins-$VERSION" || { echo "Failed to enter directory." >&2; exit 2; }
+          
+              # Install prerequisites if missing
+              echo "[INFO] Installing prerequisites... Please wait, this may take some time."
+              sudo apt update > /dev/null 2>&1 && sudo apt install -y gcc make > /dev/null 2>&1 || {
+                echo "Failed to install prerequisites using apt." >&2
+                exit 1
+              }
+          
+              # Run setup if configure is missing
+              if [ ! -f "./configure" ]; then
+                echo "Configure script not found, running setup..."
+                ./tools/setup || { echo "Failed to run setup." >&2; exit 2; }
+              fi
+          
+              # Compile and install plugins
+              if ./configure --with-nagios-user=nagios --with-nagios-group=nagios --prefix=/usr/local/nagios > /dev/null 2>&1 && \
+                make > /dev/null 2>&1 && \
+                sudo make install > /dev/null 2>&1; then
+                echo "[INFO] Nagios plugins installed successfully."
+              else
+                echo "Failed to build and install Nagios plugins." >&2
+                exit 2
+              fi       
+            else
+              echo "Failed to download Nagios plugins." >&2
+              exit 2;
+            fi
+          else
+            echo "Nagios plugins are already installed."
           fi
 
     setup:

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -86,7 +86,7 @@ install:
             DOWNLOAD_PAGE=$(curl -sL "$DOWNLOAD_PAGE_URL")
           
             # Extract the latest version and download URL using grep with -E for extended regex
-            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+(\.[0-9]+)?).tar\.gz' | head -n 1)
           
             # Check if DOWNLOAD_URL is empty
             if [ -z "$DOWNLOAD_URL" ]; then

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -63,19 +63,20 @@ install:
             exit 1
           fi
         - |
+          NEW_RELIC_ASSUME_YES="{{.NEW_RELIC_ASSUME_YES}}"
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ]; then
             echo "[INFO] Nagios plugins not found. Nagios plugins are a prerequisite for this integration." >&2
-          
-            # Prompt user for confirmation
-            printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
-            read -r USER_CONFIRMATION
-            USER_CONFIRMATION=${USER_CONFIRMATION:-y}
-          
-            # Check user response
-            if [ "$USER_CONFIRMATION" != "y" ]; then
-            echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
-            exit 3
+                    
+            if [[ "$NEW_RELIC_ASSUME_YES" != "true" ]] ; then                       
+              printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
+              read -r USER_CONFIRMATION
+              USER_CONFIRMATION=${USER_CONFIRMATION:-y}
+            
+              if [ "$USER_CONFIRMATION" != "y" ]; then
+                echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
+                exit 3
+              fi
             fi
           
             echo "[INFO] Proceeding with Nagios plugins download..." >&2

--- a/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/debian.yml
@@ -65,7 +65,20 @@ install:
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ]; then
-            echo "[INFO] Nagios plugins not found - downloading latest version..." >&2
+            echo "[INFO] Nagios plugins not found. Nagios plugins are a prerequisite for this integration." >&2
+          
+            # Prompt user for confirmation
+            printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
+            read -r USER_CONFIRMATION
+            USER_CONFIRMATION=${USER_CONFIRMATION:-y}
+          
+            # Check user response
+            if [ "$USER_CONFIRMATION" != "y" ]; then
+            echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
+            exit 3
+            fi
+          
+            echo "[INFO] Proceeding with Nagios plugins download..." >&2
           
             # Fetch the download page content, following redirects
             DOWNLOAD_PAGE_URL="https://nagios-plugins.org/download/"

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -102,7 +102,7 @@ install:
               tar -xzf nagios-plugins.tar.gz || { echo "Failed to extract plugins." >&2; exit 2; }
           
               # Extract version from filename to use in cd command
-              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
+              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+(\.[0-9]+)?).tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
               cd "nagios-plugins-$VERSION" || { echo "Failed to enter directory." >&2; exit 2; }
           
               # Install prerequisites if missing

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -86,7 +86,7 @@ install:
             DOWNLOAD_PAGE=$(curl -sL "$DOWNLOAD_PAGE_URL")
           
             # Extract the latest version and download URL using grep with -E for extended regex
-            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+(\.[0-9]+)?).tar\.gz' | head -n 1)
           
             # Check if DOWNLOAD_URL is empty
             if [ -z "$DOWNLOAD_URL" ]; then

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -65,7 +65,20 @@ install:
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ]; then
-            echo "[INFO] Nagios plugins not found - downloading latest version..." >&2
+            echo "[INFO] Nagios plugins not found. Nagios plugins are a prerequisite for this integration." >&2
+          
+            # Prompt user for confirmation
+            printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
+            read -r USER_CONFIRMATION
+            USER_CONFIRMATION=${USER_CONFIRMATION:-y}
+    
+            # Check user response
+            if [ "$USER_CONFIRMATION" != "y" ]; then
+            echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
+            exit 3
+            fi
+    
+            echo "[INFO] Proceeding with Nagios plugins download..." >&2
           
             # Fetch the download page content, following redirects
             DOWNLOAD_PAGE_URL="https://nagios-plugins.org/download/"

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -64,9 +64,58 @@ install:
           fi
         - |
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
-          if [ $PLUGINS_EXIST -eq 0 ] ; then
-            echo "check_users plugin not found in /usr/local/nagios/libexec/ - Please make sure that the plugins are installed." >&2
-            exit 2
+          if [ $PLUGINS_EXIST -eq 0 ]; then
+            echo "[INFO] Nagios plugins not found - downloading latest version..." >&2
+          
+            # Fetch the download page content, following redirects
+            DOWNLOAD_PAGE_URL="https://nagios-plugins.org/download/"
+            DOWNLOAD_PAGE=$(curl -sL "$DOWNLOAD_PAGE_URL")
+          
+            # Extract the latest version and download URL using grep with -E for extended regex
+            DOWNLOAD_URL=$(echo "$DOWNLOAD_PAGE" | grep -oE 'nagios-plugins-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+          
+            # Check if DOWNLOAD_URL is empty
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Failed to fetch the latest Nagios plugins version from the download page." >&2
+              exit 2
+            fi
+          
+            # Construct the full download URL
+            DOWNLOAD_URL="https://nagios-plugins.org/download/$DOWNLOAD_URL"
+          
+            # Download and install plugins
+            if curl -sL "$DOWNLOAD_URL" -o nagios-plugins.tar.gz; then
+              tar -xzf nagios-plugins.tar.gz || { echo "Failed to extract plugins." >&2; exit 2; }
+          
+              # Extract version from filename to use in cd command
+              VERSION=$(echo "$DOWNLOAD_URL" | grep -oE 'nagios-plugins-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz' | sed 's/nagios-plugins-//' | sed 's/.tar.gz//')
+              cd "nagios-plugins-$VERSION" || { echo "Failed to enter directory." >&2; exit 2; }
+          
+              # Install prerequisites if missing
+              echo "[INFO] Installing prerequisites... Please wait, this may take some time."
+              sudo yum install -y gcc make > /dev/null 2>&1
+          
+              # Run setup if configure is missing
+              if [ ! -f "./configure" ]; then
+                echo "Configure script not found, running setup..."
+                ./tools/setup || { echo "Failed to run setup." >&2; exit 2; }
+              fi
+          
+              # Compile and install plugins
+              if ./configure --with-nagios-user=nagios --with-nagios-group=nagios --prefix=/usr/local/nagios > /dev/null 2>&1 && \
+                make > /dev/null 2>&1 && \
+                sudo make install > /dev/null 2>&1; then
+                echo "[INFO] Nagios plugins installed successfully."
+              else
+                echo "Failed to build and install Nagios plugins." >&2
+                exit 2
+              fi       
+            else
+              echo "Failed to download Nagios plugins." >&2
+              exit 2;
+            fi
+          else
+            echo "Nagios plugins are already installed."
           fi
 
     setup:

--- a/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/nagios/rhel.yml
@@ -63,19 +63,20 @@ install:
             exit 1
           fi
         - |
+          NEW_RELIC_ASSUME_YES="{{.NEW_RELIC_ASSUME_YES}}"
           PLUGINS_EXIST=$(ls /usr/local/nagios/libexec | grep check_users | wc -l)
           if [ $PLUGINS_EXIST -eq 0 ]; then
             echo "[INFO] Nagios plugins not found. Nagios plugins are a prerequisite for this integration." >&2
           
-            # Prompt user for confirmation
-            printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
-            read -r USER_CONFIRMATION
-            USER_CONFIRMATION=${USER_CONFIRMATION:-y}
-    
-            # Check user response
-            if [ "$USER_CONFIRMATION" != "y" ]; then
-            echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
-            exit 3
+            if [[ "$NEW_RELIC_ASSUME_YES" != "true" ]] ; then 
+              printf "Do you want to proceed with downloading and installing Nagios plugins? This involves downloading third-party software not hosted by New Relic. y/n (default: y): "
+              read -r USER_CONFIRMATION
+              USER_CONFIRMATION=${USER_CONFIRMATION:-y}
+      
+              if [ "$USER_CONFIRMATION" != "y" ]; then
+                echo "Nagios plugins are required for this integration. Please install them and re-run the installation." >&2
+                exit 3
+              fi
             fi
     
             echo "[INFO] Proceeding with Nagios plugins download..." >&2

--- a/test/manual/readme.MD
+++ b/test/manual/readme.MD
@@ -40,19 +40,19 @@ docker run -it \
 ```
 
 | Recipe        | Prompt Values                                                                                                                                                                                                                   |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Apache        | Status URL: http://127.0.0.1/server-status?auto                                                                                                                                                                                 |
 | Cassandra     | Username: newrelic <br>Password: Virtuoso4all! <br>Hostname: localhost <br>Port: 7199                                                                                                                                           |
 | Elasticsearch | Username: newrelic <br>Password: Virtuoso4all! <br>Hostname: localhost <br>Port: 9200 <br>Config file: /etc/elasticsearch/elasticsearch.yml <br>Use SSL to connect? (true/false): false <br>Default the rest (just press enter) |
 | JMX (JBoss)   | Username: newrelic <br>Password: Virtuoso4all! <br>Hostname: localhost <br>Port: 9990 <br>Are you using SSL? (y/n): n <br>Default the rest (just press enter)                                                                   |
 | MySQL         | Username: newrelic <br>Password: Virtuoso4all! <br>Hostname: localhost <br>Port: 3306 <br>Database Name: MysqlSample                                                                                                            |
-| MS SQL        | Username: newrelic <br>Password: the RDP password used to logon <br>Hostname: 127.0.0.1 <br>Port: 1433                                                                                                                                           |
+| MS SQL        | Username: newrelic <br>Password: the RDP password used to logon <br>Hostname: 127.0.0.1 <br>Port: 1433                                                                                                                          |
 | Nginx         | NGINX status URL: http://127.0.0.1/status                                                                                                                                                                                       |
 | Redis         | Hostname: localhost <br>Password: Virtuoso4all! <br>Port: 6379 <br>Keyspace Metrics: '{}'                                                                                                                                       |
 
 ## Windows
 
-For the Windows host, you'll want to get the password from the AWS Console. While on the EC2 UI, right click the Windows instance, and click Connect. Then use your pem key to decrypt the password.
+For the Windows host, you'll want to get the password from the AWS Console. While on the EC2 UI, right-click the Windows instance, and click Connect. Then use your pem key to decrypt the password.
 Once you have the password, use a `Remote Desktop Connection` client with the credential `Administrator` and the password you've decrypted in AWS.
 
 ## Tearing down
@@ -100,11 +100,11 @@ Once started, there are two forms of access:
 - ssh: while in the macos-catalina folder, run: `vagrant ssh`
 - GUI: open the VirtualBox application, select the macos-catalina host and click Show (the vagrant user has password: `vagrant`)
 
-This method of running a macOS host uses a [public GitHub project](https://github.com/ramsey/macos-vagrant-box) based off [macinbox](https://github.com/bacongravy/macinbox).
+This method of running a macOS host uses a [public GitHub project](https://github.com/ramsey/macos-vagrant-box) based off [mac inbox](https://github.com/bacongravy/macinbox).
 
 ## Ansible install scripts with Vagrant
 
-Our install scripts can be used locally through the following steps.
+Our installation scripts can be used locally through the following steps.
 
 Create a working directory:
 ```


### PR DESCRIPTION
JIRA - https://new-relic.atlassian.net/browse/NR-380307

This PR automates the installation of Nagios plugins if they are not present on the user's host. We have noticed numerous installation failures due to missing plugins, even though this requirement is mentioned as a prerequisite in the installation UI.

### Test Results

- RHEL tests when plugins are not found.

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/a803b0fa-d44d-46d9-96cf-87c320c01076" />

- RHEL tests when plugins are already installed.

<img width="1695" alt="image" src="https://github.com/user-attachments/assets/b80b86c7-0ee7-4ad5-9246-466214b7b481" />

- Debian tests when plugins are not found.

<img width="1691" alt="image" src="https://github.com/user-attachments/assets/b12fb6bc-cdcc-407a-853c-63b20acd48f4" />

- Debian tests when plugins are already installed.

<img width="1541" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/5a02bf35-359e-4977-8bb6-078654ced399" />


