### PR TITLE
fix(varnish): Added default values for instance_name and params config file

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -40,8 +40,10 @@ validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 mi
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"
     prompt: "Instance Name (used to identify data in New Relic)"
+    default: "new_relic"
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
     prompt: "Location of varnish.params (omit to check defaults)"
+    default: "/etc/default/varnish/varnish.params"
 
 preInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/debian.yml
@@ -39,10 +39,10 @@ validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 mi
 
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"
-    prompt: "Instance Name (used to identify data in New Relic)"
+    prompt: "Instance Name (used to identify data in New Relic, default name is : new_relic)"
     default: "new_relic"
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
-    prompt: "Location of varnish.params (omit to check defaults)"
+    prompt: "Location of varnish.params (omit to check defaults) default location is : /etc/default/varnish/varnish.params"
     default: "/etc/default/varnish/varnish.params"
 
 preInstall:

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -43,10 +43,10 @@ validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 mi
 
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"
-    prompt: "Instance Name (used to identify data in New Relic)"
+    prompt: "Instance Name (used to identify data in New Relic, default name is : new_relic)"
     default: "new_relic"
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
-    prompt: "Location of varnish.params (omit to check defaults)"
+    prompt: "Location of varnish.params (omit to check defaults) default location is : /etc/default/varnish/varnish.params"
     default: "/etc/default/varnish/varnish.params"
 
 preInstall:

--- a/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/varnish/rhel.yml
@@ -44,8 +44,10 @@ validationNrql: "SELECT count(*) from VarnishSample FACET entityGuid SINCE 10 mi
 inputVars:
   - name: "NR_CLI_INSTANCE_NAME"
     prompt: "Instance Name (used to identify data in New Relic)"
+    default: "new_relic"
   - name: "NR_CLI_PARAMS_CONFIG_FILE"
     prompt: "Location of varnish.params (omit to check defaults)"
+    default: "/etc/default/varnish/varnish.params"
 
 preInstall:
   info: |2


### PR DESCRIPTION
**Issue :-** The INSTANCE_NAME variable in the Varnish Cache integration recipe was not correctly defaulting to new_relic when the user did not explicitly define it. This resulted in the following error during installation:

**Error:-**

> `DEBUG validation error encountered: exit status 1: [ERR] Error input validation failure: instance_name must not be blank
> `

[Jira Ticket](https://new-relic.atlassian.net/browse/NR-386250)

**Resolution:** 

- The issue has been resolved by explicitly handling the default value for INSTANCE_NAME in the recipe. The updated recipe ensures that the variable is never blank and defaults to new_relic when not provided.

- After fixing the recipe, varnish-cache-open-source-integration is installing successfully when user don’t define the value for instance_name.

**Testing after the fix:**

- Verified that the INSTANCE_NAME defaults to new_relic when not explicitly defined by the user.

- Confirmed that the /etc/newrelic-infra/integrations.d/varnish-config.yml file is correctly populated with the default value.

- Ensured that the error no longer occurs during installation.

**Case 1:-** When user don’t input the instance_name, default value  'new_relic' will be set, I tested this scenario, integration was successfully, please see below.

![image](https://github.com/user-attachments/assets/4ffe3976-cedd-491d-be21-fd6b873c7ae5)

**Case 2:-** When user input the instance_name, I tested this scenario, integration was successfully, please see below.

![image](https://github.com/user-attachments/assets/142a23dc-d29b-4b29-b2b3-4729eb925975)

**Case 3:-**  When user select ‘Yes(-y)’ flag to set all prompts as Yes.

![image](https://github.com/user-attachments/assets/6d5870e1-c8d9-410b-9098-13fab0465d83)

