### PR TITLE
fix(script): Fixed error with Infra Guided Install on windows hosts

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -55,8 +55,6 @@ install:
           powershell -command '
           $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
           $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-
-
           if(-not ($isAdmin))
           {
             Write-Host -ForegroundColor Red "Powershell needs to be started in Administrator permissions. Please restart Powershell in Administrator, and re-run the newrelic-cli command."
@@ -103,13 +101,14 @@ install:
               $allKeys = $baseKeys + $wowKeys
 
               $uninstallIds = New-Object System.Collections.ArrayList
-              foreach ($key in $allKeys) {
-                $escapedKey = $key -replace '\[', '`[' -replace '\]', '`]'
-                $keyData = Get-Item -Path "HKLM:\$escapedKey"
-                $name = $keyData.GetValue("DisplayName")
-                if ($name -and $name -match $Match) {
-                  $keyId = Split-Path $key -Leaf
-                  $uninstallIds.Add($keyId) | Out-Null
+              foreach ($key in $allKeys) {       
+                $keyData = Get-Item -LiteralPath "HKLM:\$key" -ErrorAction SilentlyContinue
+                if ($keyData) {
+                  $name = $keyData.GetValue("DisplayName")
+                  if ($name -and $name -match $Match) {
+                    $keyId = Split-Path $key -Leaf
+                    $uninstallIds.Add($keyId) | Out-Null
+                  }
                 }
               }
 
@@ -168,7 +167,7 @@ install:
             exit $errorCode
           }
           '
-
+    
     install_infra:
       cmds:
         - |


### PR DESCRIPTION
Issue mentioned in the [Jira Ticket](https://new-relic.atlassian.net/browse/NR-400198)

**Resolution done:-**

I updated the script code that removes the old logic that manually escaped square brackets ([, ]) in registry keys using -replace. This was unnecessary because PowerShell's -LiteralPath parameter can handle special characters in paths without requiring manual escaping. The old logic was error-prone and introduced parsing issues, such as "Missing type name after '['." By replacing it with -LiteralPath, the updated code simplifies the implementation, avoids these errors, and ensures compatibility with registry keys containing special characters. This change improves both the reliability and maintainability of the function.

I tested my changes after creating few test registery keys with the square brackets.

![image](https://github.com/user-attachments/assets/78ef74b3-4f84-452c-b752-e857db6dcb9e)
