### PR TITLE
chore(ac): update AC HTTP server payload parse

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -380,7 +380,7 @@ install:
             fi
           fi
       vars:
-        NEW_RELIC_AGENT_VERSION: "0.35.0"
+        NEW_RELIC_AGENT_VERSION: "0.36.1"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control
@@ -753,7 +753,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -322,7 +322,7 @@ install:
         DISTRO_VERSION:
           sh: |
             rpm -E %{rhel}
-        NEW_RELIC_AGENT_VERSION: "0.35.0"
+        NEW_RELIC_AGENT_VERSION: "0.36.1"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control
@@ -694,7 +694,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -272,7 +272,7 @@ install:
       vars:
         SLES_VERSION:
           sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release
-        NEW_RELIC_AGENT_VERSION: "0.35.0"
+        NEW_RELIC_AGENT_VERSION: "0.36.1"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control
@@ -644,7 +644,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break


### PR DESCRIPTION
Adapt AC status response check to the new format.

Cannot be merged until the next release of the AC has been done.
