### PR TITLE
Fix: Address infra agent warnings related to legacy trusted.gpg keyring

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -228,7 +228,11 @@ install:
     add_gpg_key:
       cmds:
         - |
-          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | apt-key add -
+          # Remove the key from the legacy keyring if it exists
+          sudo rm -f /etc/apt/trusted.gpg.d/newrelic-infra.gpg 2>/dev/null
+          sudo rm -f /etc/apt/trusted.gpg 2>/dev/null
+          # Add the key to the correct directory
+          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | sudo gpg --dearmor --batch --yes -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
       silent: true
 
     add_nr_source:

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -210,7 +210,11 @@ install:
     add_gpg_key:
       cmds:
         - |
-          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | apt-key add -
+          # Remove the key from the legacy keyring if it exists
+          sudo rm -f /etc/apt/trusted.gpg.d/newrelic-infra.gpg 2>/dev/null
+          sudo rm -f /etc/apt/trusted.gpg 2>/dev/null
+          # Add the key to the correct directory
+          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | sudo gpg --dearmor --batch --yes -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
       silent: true
 
     add_nr_source:


### PR DESCRIPTION
This PR addresses the issue of infra agent warnings during the guided install process. The warnings indicate that the GPG key is stored in the legacy trusted.gpg keyring, which is deprecated. The changes ensure that the GPG key is added to the /etc/apt/trusted.gpg.d/ directory and remove any existing keys from the legacy keyring.

Changes Made
Update add_gpg_key Task:
Remove the key from the legacy keyring if it exists, suppressing any error messages.
Add the key to the /etc/apt/trusted.gpg.d/ directory using gpg --dearmor.
Validation:
Please find details in [this](https://new-relic.atlassian.net/browse/NR-377335)