### PR TITLE
fix:[install-recipe] Add option to install FIPS package

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -203,9 +203,18 @@ install:
             echo "newrelic infrastructure agent is not available for this architecture "{{.ARCH}}". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi
-          curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
-          yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
-          yum -y -q install newrelic-infra
+          # Check NEW_RELIC_FIPS_ENABLED flag
+          if [ "${NEW_RELIC_FIPS_ENABLED:-false}" = "true" ]; then
+            echo "FIPS mode enabled. Installing newrelic-infra-fips..."
+            curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
+            yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
+            yum -y -q install newrelic-infra-fips
+          else
+            echo "FIPS mode not enabled. Installing newrelic-infra..."
+            curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
+            yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
+            yum -y -q install newrelic-infra
+          fi
       silent: true
 
     restart:

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -181,9 +181,18 @@ install:
             echo "newrelic infrastructure agent is not available for this architecture "$ARCH". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi
-          curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
-          yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
-          yum -y -q install newrelic-infra
+          # Check NEW_RELIC_FIPS_ENABLED flag
+          if [ "${NEW_RELIC_FIPS_ENABLED:-false}" = "true" ]; then
+            echo "FIPS mode enabled. Installing newrelic-infra-fips..."
+            curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
+            yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
+            yum -y -q install newrelic-infra-fips
+          else
+            echo "FIPS mode not enabled. Installing newrelic-infra..."
+            curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
+            yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
+            yum -y -q install newrelic-infra
+          fi
       vars:
         DISTRO_VERSION:
           sh: |

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -274,7 +274,14 @@ install:
           if [ ! -z "$HTTPS_PROXY" ]; then
             OPTIONS="$OPTIONS -o Acquire::Http::Proxy={{.HTTPS_PROXY}}"
           fi
-          apt-get $OPTIONS install newrelic-infra -y -qq
+          # Check NEW_RELIC_FIPS_ENABLED flag
+          if [ "${NEW_RELIC_FIPS_ENABLED:-false}" = "true" ]; then
+            echo "FIPS mode enabled. Installing newrelic-infra-fips..."
+            apt-get $OPTIONS install newrelic-infra-fips -y -qq
+          else
+            echo "FIPS mode not enabled. Installing newrelic-infra..."
+            apt-get $OPTIONS install newrelic-infra -y -qq
+          fi
           # Check the exit status of the previous command
           if [ $? -ne 0 ]; then
             echo "Error: newrelic-infra installation failed"

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -178,7 +178,7 @@ install:
             exit 131
           fi
           # Check NEW_RELIC_FIPS_ENABLED flag
-          FIPS_ENABLED="${.NEW_RELIC_FIPS_ENABLED:-false}"
+          FIPS_ENABLED="${NEW_RELIC_FIPS_ENABLED:-false}"
 
           if [ "$FIPS_ENABLED" = "true" ]; then
             echo "FIPS mode enabled. Installing newrelic-infra-fips..."

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -177,12 +177,26 @@ install:
             echo "newrelic infrastructure agent is not available for this architecture "$ARCH". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi
-          curl -s $REPO_URL -o /etc/zypp/repos.d/newrelic-infra.repo
-        - curl -s -L {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_rpm_key_current.gpg > newrelic_rpm_key_current.gpg
-        - rpm --import newrelic_rpm_key_current.gpg
-        - zypper -n --quiet ref -r newrelic-infra
-        - zypper -n --quiet install newrelic-infra
-        - rm newrelic_rpm_key_current.gpg
+          # Check NEW_RELIC_FIPS_ENABLED flag
+          FIPS_ENABLED="${.NEW_RELIC_FIPS_ENABLED:-false}"
+
+          if [ "$FIPS_ENABLED" = "true" ]; then
+            echo "FIPS mode enabled. Installing newrelic-infra-fips..."
+            curl -s $REPO_URL -o /etc/zypp/repos.d/newrelic-infra.repo
+            curl -s -L {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_rpm_key_current.gpg > newrelic_rpm_key_current.gpg
+            rpm --import newrelic_rpm_key_current.gpg
+            zypper -n --quiet ref -r newrelic-infra
+            zypper -n --quiet install newrelic-infra-fips
+            rm newrelic_rpm_key_current.gpg
+          else
+            echo "FIPS mode not enabled. Installing newrelic-infra..."
+            curl -s $REPO_URL -o /etc/zypp/repos.d/newrelic-infra.repo
+            curl -s -L {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_rpm_key_current.gpg > newrelic_rpm_key_current.gpg
+            rpm --import newrelic_rpm_key_current.gpg
+            zypper -n --quiet ref -r newrelic-infra
+            zypper -n --quiet install newrelic-infra
+            rm newrelic_rpm_key_current.gpg
+          fi
       vars:
         SLES_VERSION:
           sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -250,7 +250,13 @@ install:
           if [ ! -z "$HTTPS_PROXY" ]; then
             OPTIONS="$OPTIONS -o Acquire::Http::Proxy={{.HTTPS_PROXY}}"
           fi
-          apt-get $OPTIONS install newrelic-infra -y -qq
+          if [ "{{.NEW_RELIC_FIPS_ENABLED}}" = "true" ]; then
+            echo "FIPS mode enabled. Installing newrelic-infra-fips..."
+            apt-get $OPTIONS install newrelic-infra-fips -y -qq
+          else
+            echo "FIPS mode not enabled. Installing newrelic-infra..."
+            apt-get $OPTIONS install newrelic-infra -y -qq
+          fi
       silent: true
 
     restart:


### PR DESCRIPTION
### Description

**Context:**  
We now publish FIPS-compatible packages for the New Relic Infrastructure Agent on Linux. Customers can install these packages via their package manager using the new package name `newrelic-infra-fips` (instead of `newrelic-infra`).

**Scope:**  
This update introduces support for a new environment variable `NEW_RELIC_FIPS_ENABLED` in the Linux installation recipes.

**Changes:**  
- Added support for the `NEW_RELIC_FIPS_ENABLED` flag in the following recipes:
  - `ubuntu.yml`
  - `suse.yml`
  - `debian.yml`
  - `awslinux.yml`
  - `centos.yml`
- **Default Behavior:** If the flag is not set or set to `false`, the recipes will install the default `newrelic-infra` package (no changes to existing flows).
- **FIPS Mode:** If the flag is set to `true`, the recipes will install the FIPS-compatible package `newrelic-infra-fips`.

**Impact:**  
This change ensures flexibility for customers who require FIPS-compliant packages while maintaining backward compatibility for existing installations.