### PR TITLE
fix(Cassandra-test): fix failing Cassandra gpg key error.

### DIFF
--- a/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
+++ b/test/deploy/linux/cassandra/install/debian/roles/prepare/tasks/installCassandra.yml
@@ -1,13 +1,23 @@
 ---
 - debug:
     msg: Install Cassandra
+# The steps outlined in official cassandra documentation for installing on Debian is used in this ansible script.
+# https://cassandra.apache.org/doc/latest/getting_started/installing.html#debian
+
+# Step 1: Ensure the /etc/apt/keyrings directory exists
+- name: Ensure /etc/apt/keyrings directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
 
 - name: Add cassandra repo
-  shell: echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+  shell: echo "deb [signed-by=/etc/apt/keyrings/apache-cassandra.asc] https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
   become: true
 
 - name: add cassandra keys
-  shell: wget -q -O - https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
+  shell: curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
   become: true
 
 - name: Install cassandra


### PR DESCRIPTION
Context:
Cassandra test was failing because the apt package was not able to find the gpg key as it was being added using `apt-key add` method which is an old method of gpg key addition, which has been deprecated in Cassandra. 
Fix:
Updated the gpg key addition method and correct Cassandra repository path. Followed the steps provided in Cassandra [official doc](https://cassandra.apache.org/doc/latest/getting_started/installing.html#debian) for installing Cassandra and updated the ansible script according to that.

Local test success validation:
![image](https://github.com/user-attachments/assets/5f2a20bc-5d49-46b9-8221-ccc520a33f10)
