### PR TITLE
fix(linux): Updated infra install command to include upgrade as well

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -205,7 +205,7 @@ install:
           fi
           curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
           yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
-          yum -y -q install newrelic-infra
+          yum list installed newrelic-infra >/dev/null 2>&1 && sudo yum update newrelic-infra -y -q || sudo yum install newrelic-infra -y -q
       silent: true
 
     restart:

--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -205,7 +205,7 @@ install:
           fi
           curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
           yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
-          yum list installed newrelic-infra >/dev/null 2>&1 && sudo yum update newrelic-infra -y -q || sudo yum install newrelic-infra -y -q
+          yum list installed newrelic-infra >/dev/null 2>&1 && yum update newrelic-infra -y -q || yum install newrelic-infra -y -q
       silent: true
 
     restart:


### PR DESCRIPTION
GSTE: https://new-relic.atlassian.net/browse/NR-404232

### Changes:
- This PR addresses a bug in the New Relic Infrastructure agent installation process for Linux. The current command (yum -y -q install newrelic-infra) fails to upgrade the agent on AWS linux hosts where an older version is already installed. Instead, it only installs the agent when it's not present. To ensure correct behavior, the installation process has been modified. The revised command now checks for the agent's presence and either upgrades it or installs the latest version appropriately:

`yum list installed newrelic-infra >/dev/null 2>&1 && yum update newrelic-infra -y -q || yum install newrelic-infra -y -q`

This fix will ensure the agent is either upgraded or installed consistently.


<img width="1396" alt="image" src="https://github.com/user-attachments/assets/650d5e40-51ff-468e-b737-7fde567b03a9" />
