### PR TITLE
fix(RHEL8): Updated deprecated AMI images with new ones

### DIFF
--- a/test/definitions-eu/agent-control/logs/redhat8-agent-control-logs-eu.json
+++ b/test/definitions-eu/agent-control/logs/redhat8-agent-control-logs-eu.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+      "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
     }
   ],
 

--- a/test/definitions-eu/infra-agent/rhel/redhat8x-infra.json
+++ b/test/definitions-eu/infra-agent/rhel/redhat8x-infra.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+        "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
     }],
 
     "instrumentations": {

--- a/test/definitions/agent-control/logs/redhat8-agent-control-logs.json
+++ b/test/definitions/agent-control/logs/redhat8-agent-control-logs.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+      "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
     }
   ],
 

--- a/test/definitions/logging/redhat8-logs.json
+++ b/test/definitions/logging/redhat8-logs.json
@@ -12,7 +12,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+        "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
       }
     ],
   

--- a/test/definitions/smoke/redhat84-infra.json
+++ b/test/definitions/smoke/redhat84-infra.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+        "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
     }],
 
     "instrumentations": {

--- a/test/manual/definitions/infra-agent/redhat8-infra.json
+++ b/test/manual/definitions/infra-agent/redhat8-infra.json
@@ -11,6 +11,6 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "RHEL_HA-8.4.?_HVM-????????-x86_64-??-Hourly2-GP2"
+        "ami_name": "RHEL_HA-8.8.?_HVM-????????-x86_64-????-Hourly2-GP3"
     }]
 }


### PR DESCRIPTION
### Changes:
- Updated the deprecated RHEL8 AMI images to new ones.


Before changes Error:
<img width="1961" alt="image" src="https://github.com/user-attachments/assets/282232ab-ea51-4412-a240-d3d8469bed3a" />
