### PR TITLE
fix(ac): revert AC HTTP server health payload change

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -753,7 +753,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -694,7 +694,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -644,7 +644,7 @@ install:
               # so jq doesn't fail if empty
               statusCheckOutput="{}"
             fi
-            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.health_info.healthy')
+            STATUS=$(echo $statusCheckOutput | /usr/local/bin/newrelic utils jq '.agent_control.healthy')
             if [ "$STATUS" == "true" ]; then
               echo "Agent status check ok."
               break


### PR DESCRIPTION
Revert change made to check AC health.

Payload:
```yaml
{
  "agent_control": {
    "healthy": true
  },
  "fleet": {
    "enabled": true,
    "endpoint": "https://opamp.service.newrelic.com/v1/opamp",
    "reachable": true
  },
  "sub_agents": {
    "nr-infra": {
      "agent_id": "nr-infra",
      "agent_type": "newrelic/com.newrelic.infrastructure:0.1.0",
      "agent_start_time_unix_nano": 1745410137922303000,
      "health_info": {
        "healthy": true,
        "status": "{\"healthy\":true}",
        "start_time_unix_nano": 1745410137911429600,
        "status_time_unix_nano": 1745410175247852800
      }
    }
  }
}
```