### PR TITLE
fix: Replaced deprecated ubuntu18.04 AMI images with alt ones

### DIFF
--- a/test/definitions-eu/agent-control/debians/ubuntu18-agent-control-eu.json
+++ b/test/definitions-eu/agent-control/debians/ubuntu18-agent-control-eu.json
@@ -10,8 +10,8 @@
       "id": "host1",
       "provider": "aws",
       "type": "ec2",
-      "size": "t3.nano",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "size": "t2.micro",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/definitions-eu/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/infra-agent/debians/ubuntu18-infra.json
+++ b/test/definitions-eu/infra-agent/debians/ubuntu18-infra.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.nano",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/definitions/agent-control/debians/ubuntu18-agent-control.json
+++ b/test/definitions/agent-control/debians/ubuntu18-agent-control.json
@@ -10,8 +10,8 @@
       "id": "host1",
       "provider": "aws",
       "type": "ec2",
-      "size": "t3.nano",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "size": "t2.micro",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions/apm/us-php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/definitions/apm/us-php-apache-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions/ohi/linux/nginx-ubuntu.json
+++ b/test/definitions/ohi/linux/nginx-ubuntu.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-apache-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
+++ b/test/manual/definitions/apm/php-agent/php-nginx-fpm-wordpress-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/infra-agent/ubuntu18-infra.json
+++ b/test/manual/definitions/infra-agent/ubuntu18-infra.json
@@ -10,8 +10,8 @@
         "id": "infraubuntu18",
         "provider": "aws",
         "type": "ec2",
-        "size": "t3.nano",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "size": "t2.micro",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }]
 }

--- a/test/manual/definitions/ohi-auto-config/linux/apache-mysql-ubuntu18-auto.json
+++ b/test/manual/definitions/ohi-auto-config/linux/apache-mysql-ubuntu18-auto.json
@@ -11,7 +11,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.micro",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
 

--- a/test/manual/definitions/ohi/linux/apache-mysql-ubuntu18.json
+++ b/test/manual/definitions/ohi/linux/apache-mysql-ubuntu18.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 


### PR DESCRIPTION
### Changes:
- Replaced deprecated ubuntu18.04 AMI images with alternative ones