### PR TITLE
Add mariaDb support for mysql integration

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/debian.yml
@@ -28,6 +28,7 @@ keywords:
 # Examine Infrastructure events for correlated data
 processMatch:
   - mysqld
+  - mariadbd
 
 preInstall:
   requireAtDiscovery: |
@@ -133,6 +134,9 @@ install:
           if [[ "$NEW_RELIC_MYSQL_PASSWORD" == "" ]]; then
             NEW_RELIC_MYSQL_PASSWORD=$(echo -n $(date +%s | sha256sum | base64 | head -c 16); echo "oO0$")
           fi
+
+          # Detect if MariaDB is being used
+          IS_MARIADB=$(mysql --version | grep -i mariadb | wc -l)
           
           # Check the Query monitoring status in previous installation
           QUERY_MONITORING_PREVIOUSLY_ENABLED=0
@@ -238,16 +242,26 @@ install:
               read -r USERNAME
               USERNAME=${USERNAME:-root}
           
-              printf "Enter password: "
+              printf "Enter password (leave blank if none): "
               stty -echo
               read -r NEW_RELIC_MYSQL_ROOT_PASSWORD
               stty echo
               printf "\n"
+              
+              # Defaults to socket-based authentication for MariaDB if no password is provided, otherwise uses password-based authentication.
+              # For more details, see: https://mariadb.com/kb/en/authentication-plugin-unix-socket/
+              if [[ -z "$NEW_RELIC_MYSQL_ROOT_PASSWORD" && $IS_MARIADB -eq 1 ]]; then
+                # Use socket-based authentication for MariaDB if no password is provided
+                sudo mysql -u "$USERNAME" < /tmp/sql-drop-user.sql &> /dev/null ||:
+                EXEC_OUTPUT=$(eval sudo mysql -u "$USERNAME" < /tmp/sql-create-user.sql 2>&1)
+              else
+                # Use password-based authentication for other cases
+                sudo mysql -u "$USERNAME" --port "$NEW_RELIC_MYSQL_PORT" -p"$NEW_RELIC_MYSQL_ROOT_PASSWORD" < /tmp/sql-drop-user.sql &> /dev/null ||:
+                EXEC_OUTPUT=$(eval sudo mysql -u "$USERNAME" --port "$NEW_RELIC_MYSQL_PORT" -p"$NEW_RELIC_MYSQL_ROOT_PASSWORD" < /tmp/sql-create-user.sql 2>&1)
+              fi
 
-              sudo mysql -u $USERNAME --port $NEW_RELIC_MYSQL_PORT -p$NEW_RELIC_MYSQL_ROOT_PASSWORD < /tmp/sql-drop-user.sql &> /dev/null ||:
-              EXEC_OUTPUT=$(eval sudo mysql -u $USERNAME --port $NEW_RELIC_MYSQL_PORT -p$NEW_RELIC_MYSQL_ROOT_PASSWORD < /tmp/sql-create-user.sql 2>&1)
-              echo "MySqlOutput:"$EXEC_OUTPUT | sudo tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
-              SQL_OUTPUT_ERROR=$(echo -n $EXEC_OUTPUT | grep "ERROR" | wc -l)
+              echo "MySqlOutput: $EXEC_OUTPUT" | sudo tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
+              SQL_OUTPUT_ERROR=$(echo -n "$EXEC_OUTPUT" | grep "ERROR" | wc -l)
               ((TRIES++))
             done
 

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -31,6 +31,7 @@ keywords:
 # Examine Infrastructure events for correlated data
 processMatch:
   - mysqld
+  - mariadbd
 
 preInstall:
   requireAtDiscovery: |
@@ -227,14 +228,23 @@ install:
               read -r USERNAME
               USERNAME=${USERNAME:-root}
           
-              printf "Enter password: "
+              printf "Enter password (leave blank if none): "
               stty -echo
               read -r NEW_RELIC_MYSQL_ROOT_PASSWORD
               stty echo
               printf "\n"
               
-              sudo mysql -u $USERNAME --port $NEW_RELIC_MYSQL_PORT -p$NEW_RELIC_MYSQL_ROOT_PASSWORD < /tmp/sql-drop-user.sql &> /dev/null ||:
-              EXEC_OUTPUT=$(eval sudo mysql -u $USERNAME --port $NEW_RELIC_MYSQL_PORT -p$NEW_RELIC_MYSQL_ROOT_PASSWORD < /tmp/sql-create-user.sql 2>&1)
+               # Check if the password is blank
+              if [[ -z "$NEW_RELIC_MYSQL_ROOT_PASSWORD" ]]; then
+                # Use socket-based authentication for MariaDB
+                sudo mysql -u "$USERNAME" < /tmp/sql-drop-user.sql &> /dev/null ||:
+                EXEC_OUTPUT=$(eval sudo mysql -u "$USERNAME" < /tmp/sql-create-user.sql 2>&1)
+              else
+                # Use password-based authentication for other cases
+                sudo mysql -u "$USERNAME" --port "$NEW_RELIC_MYSQL_PORT" -p"$NEW_RELIC_MYSQL_ROOT_PASSWORD" < /tmp/sql-drop-user.sql &> /dev/null ||:
+                EXEC_OUTPUT=$(eval sudo mysql -u "$USERNAME" --port "$NEW_RELIC_MYSQL_PORT" -p"$NEW_RELIC_MYSQL_ROOT_PASSWORD" < /tmp/sql-create-user.sql 2>&1)
+              fi
+
               echo "MySqlOutput:"$EXEC_OUTPUT | sudo tee -a {{.NEW_RELIC_CLI_LOG_FILE_PATH}} > /dev/null
               SQL_OUTPUT_ERROR=$(echo -n $EXEC_OUTPUT | grep "ERROR" | wc -l)
               ((TRIES++))

--- a/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml
@@ -123,6 +123,8 @@ install:
           if [[ "$NEW_RELIC_MYSQL_PASSWORD" == "" ]]; then
             NEW_RELIC_MYSQL_PASSWORD=$(echo -n $(date +%s | sha256sum | base64 | head -c 16); echo "oO0$")
           fi
+          # Detect if MariaDB is being used
+          IS_MARIADB=$(mysql --version | grep -i mariadb | wc -l)
           
           # Check the Query monitoring status in previous installation
           QUERY_MONITORING_PREVIOUSLY_ENABLED=0
@@ -234,8 +236,9 @@ install:
               stty echo
               printf "\n"
               
-               # Check if the password is blank
-              if [[ -z "$NEW_RELIC_MYSQL_ROOT_PASSWORD" ]]; then
+              # Defaults to socket-based authentication for MariaDB if no password is provided, otherwise uses password-based authentication.
+              # For more details, see: https://mariadb.com/kb/en/authentication-plugin-unix-socket/
+              if [[ -z "$NEW_RELIC_MYSQL_ROOT_PASSWORD" && $IS_MARIADB -eq 1 ]]; then
                 # Use socket-based authentication for MariaDB
                 sudo mysql -u "$USERNAME" < /tmp/sql-drop-user.sql &> /dev/null ||:
                 EXEC_OUTPUT=$(eval sudo mysql -u "$USERNAME" < /tmp/sql-create-user.sql 2>&1)

--- a/test/definitions/ohi/windows/ms-sql-server2019Standard.json
+++ b/test/definitions/ohi/windows/ms-sql-server2019Standard.json
@@ -1,4 +1,4 @@
-{
+  {
   "global_tags": {
       "owning_team": "virtuoso",
       "Environment": "development",

--- a/test/definitions/ohi/windows/ms-sql-server2019Standard.json
+++ b/test/definitions/ohi/windows/ms-sql-server2019Standard.json
@@ -1,4 +1,4 @@
-  {
+{
   "global_tags": {
       "owning_team": "virtuoso",
       "Environment": "development",


### PR DESCRIPTION
Added mariaDb support for mysql integration. 
mariaDb is a next version of mysql that is built on top of mysql and have some extra capability. The existing mysql recipe was failing with error as ` No process matching mysqld` as mariaDB have process name as `mariaDBd` 
Another difference in mariaDB was that it uses socket based authetication as the default auth method of Db authentication in which root password is not required and also port number is also not required as it skips any network calls for authentication. More details can be found [here](https://mariadb.com/kb/en/authentication-plugin-unix-socket/). SO added a condition to use socket based auth if the user input a blank password which state that there is no password for the root user. Else the flow will use the previous i.e password based authentication.

Changes had been tested in below OS which the recipe supports as of now
1. Ubuntu 24.04
2. Debian 9
3. Amazon linux 2
4 RedHat 9

Test results can be validated in [this](https://new-relic.atlassian.net/browse/NR-418023) sub-task.

These changes are done as part of [this](https://github.com/newrelic/open-install-library/issues/1125) GIT issue and [this](https://new-relic.atlassian.net/browse/NR-413061) jira ticket

