### PR TITLE
chore: bump agent control version to 0.39.0

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -380,7 +380,7 @@ install:
             fi
           fi
       vars:
-        NEW_RELIC_AGENT_VERSION: "0.38.0"
+        NEW_RELIC_AGENT_VERSION: "0.39.0"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -322,7 +322,7 @@ install:
         DISTRO_VERSION:
           sh: |
             rpm -E %{rhel}
-        NEW_RELIC_AGENT_VERSION: "0.38.0"
+        NEW_RELIC_AGENT_VERSION: "0.39.0"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -272,7 +272,7 @@ install:
       vars:
         SLES_VERSION:
           sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release
-        NEW_RELIC_AGENT_VERSION: "0.38.0"
+        NEW_RELIC_AGENT_VERSION: "0.39.0"
       silent: true
 
     # If configured to do so, migrate the newrelic-infra configuration for usage with New Relic Agent Control


### PR DESCRIPTION
bump agent control version to 0.39.0