### PR TITLE
fix: Update APT repo configuration steps in dotnet linux recipe

### DIFF
--- a/recipes/newrelic/apm/dotNet/linux-systemd.yml
+++ b/recipes/newrelic/apm/dotNet/linux-systemd.yml
@@ -267,8 +267,8 @@ install:
           IS_YUM_INSTALLED=$(which yum 2>&1 || true)
           if [[ -z "$IS_YUM_INSTALLED" ]]
           then
-            echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list > /dev/null
-            wget -q -O- {{.NEW_RELIC_DOWNLOAD_URL}}548C16BF.gpg | sudo apt-key add -
+            echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list > /dev/null
+            wget -q -O- {{.NEW_RELIC_DOWNLOAD_URL}}NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg
             sudo apt-get -o Acquire::Check-Valid-Until=false update >/dev/null
             sudo apt-get install newrelic-dotnet-agent -y -qq > /dev/null
           else


### PR DESCRIPTION
This PR updates the .NET agent Linux install recipe to use a new public signing key and also replace the use of `apt-key add` (which is deprecated) with the current best practice of saving the key to a specific file and configuring the APT repo definition to be signed by that file.

Note: this is in draft status until the .NET agent does it's next release, which we plan to do early this week.