### PR TITLE
chore(recipes/php): update debian recipe

### DIFF
--- a/recipes/newrelic/apm/php/debian.yml
+++ b/recipes/newrelic/apm/php/debian.yml
@@ -354,13 +354,13 @@ install:
     add_nr_source:
       cmds:
         - |
-          echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+          echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
       silent: true
 
     add_gpg_key:
       cmds:
         - |
-          curl -s https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
+          curl -s https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/download.newrelic.com-newrelic.gpg
       silent: true
 
     update_apt_nr_source:


### PR DESCRIPTION
Update PHP's debian recipe to avoid using deprecated `apt-key` utility as well as legacy public key that uses week algorithm. This aligns the recipe with Debian/Ubuntu install instructions provided to customers in public facing documentation.