### PR TITLE
fix: Updated deprecated AMIs to fix test failures

### DIFF
--- a/test/definitions-eu/agent-control/debians/ubuntu20-agent-control-eu.json
+++ b/test/definitions-eu/agent-control/debians/ubuntu20-agent-control-eu.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.nano",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-2023*",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/agent-control/logs/ubuntu20-agent-control-logs-eu.json
+++ b/test/definitions-eu/agent-control/logs/ubuntu20-agent-control-logs-eu.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions-eu/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
+++ b/test/definitions-eu/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/definitions-eu/apm/java/ub20-apt-docker-jboss.json
+++ b/test/definitions-eu/apm/java/ub20-apt-docker-jboss.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/definitions-eu/apm/java/ub20-apt-docker-tomcat.json
+++ b/test/definitions-eu/apm/java/ub20-apt-docker-tomcat.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.micro",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/definitions-eu/apm/java/ub20-apt-sysd-tomcat.json
+++ b/test/definitions-eu/apm/java/ub20-apt-sysd-tomcat.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
       }
     ],

--- a/test/definitions-eu/infra-agent/debians/ubuntu20-infra.json
+++ b/test/definitions-eu/infra-agent/debians/ubuntu20-infra.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.nano",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-2023*",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/definitions-eu/smoke/ubuntu20-infra.json
+++ b/test/definitions-eu/smoke/ubuntu20-infra.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.nano",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-2023*",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/definitions/agent-control/debians/ubuntu20-agent-control.json
+++ b/test/definitions/agent-control/debians/ubuntu20-agent-control.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.nano",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-2023*",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions/agent-control/logs/ubuntu20-agent-control-logs.json
+++ b/test/definitions/agent-control/logs/ubuntu20-agent-control-logs.json
@@ -12,7 +12,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
     }
   ],

--- a/test/definitions/logging/ubuntu20-logs.json
+++ b/test/definitions/logging/ubuntu20-logs.json
@@ -12,7 +12,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
       }
     ],

--- a/test/manual/definitions/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
+++ b/test/manual/definitions/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/dotNet/linux/ubuntu20-nginx-aspnetcore.json
+++ b/test/manual/definitions/apm/dotNet/linux/ubuntu20-nginx-aspnetcore.json
@@ -11,7 +11,7 @@
         "provider": "aws",
         "type": "ec2",
         "size": "t3.micro",
-        "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+        "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
         "user_name": "ubuntu"
     }],
 

--- a/test/manual/definitions/apm/java/linux/jboss/docker/ub20-apt-docker.json
+++ b/test/manual/definitions/apm/java/linux/jboss/docker/ub20-apt-docker.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/jboss/docker/ub20-docker-rest.json
+++ b/test/manual/definitions/apm/java/linux/jboss/docker/ub20-docker-rest.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/jboss/docker/ub20-dockertomcat-jboss.json
+++ b/test/manual/definitions/apm/java/linux/jboss/docker/ub20-dockertomcat-jboss.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/jboss/docker/ub20-tomcat-jboss.json
+++ b/test/manual/definitions/apm/java/linux/jboss/docker/ub20-tomcat-jboss.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/tomcat/docker/ub20-apt-docker-tomcat.json
+++ b/test/manual/definitions/apm/java/linux/tomcat/docker/ub20-apt-docker-tomcat.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.micro",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/tomcat/docker/ub20-docker-rest.json
+++ b/test/manual/definitions/apm/java/linux/tomcat/docker/ub20-docker-rest.json
@@ -10,7 +10,7 @@
     "provider": "aws",
     "type": "ec2",
     "size": "t3.medium",
-    "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+    "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
     "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/apm/java/linux/tomcat/systemd/ub20-apt-sysd-tomcat.json
+++ b/test/manual/definitions/apm/java/linux/tomcat/systemd/ub20-apt-sysd-tomcat.json
@@ -10,7 +10,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.micro",
-      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+      "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
       "user_name": "ubuntu"
   }],
   "services": [

--- a/test/manual/definitions/infra-agent/ubuntu20-infra-crowdstrike.json
+++ b/test/manual/definitions/infra-agent/ubuntu20-infra-crowdstrike.json
@@ -11,7 +11,7 @@
             "provider": "aws",
             "type": "ec2",
             "size": "t3.nano",
-            "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+            "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
             "user_name": "ubuntu"
         }
     ],

--- a/test/manual/definitions/infra-agent/ubuntu20-infra.json
+++ b/test/manual/definitions/infra-agent/ubuntu20-infra.json
@@ -11,7 +11,7 @@
             "provider": "aws",
             "type": "ec2",
             "size": "t3.nano",
-            "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+            "ami_name": "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-????????",
             "user_name": "ubuntu"
         }
     ]


### PR DESCRIPTION
Jira - https://new-relic.atlassian.net/browse/NR-430253

### Background context on the changes

Currently few of our regression tests (US/EU) are [failing](https://github.com/newrelic/open-install-library/actions/runs/15924746136/job/44919373861) because they rely on images that were deprecated around May 31, 2025. I've earlier raised this [pull request](https://github.com/newrelic/open-install-library/pull/1237) to update these to the latest AMI images and see the tests are now passing, which should unblock the current test failures. However, this is a temporary/short term solution. Ubuntu has officially announced the end of standard support for version 20.04, meaning we'll soon need to consider a more permanent solution, such as upgrading to version 24.04 version or subscribing to Ubuntu Pro servers to continue using 20.04 with support. 

More details here [Ubuntu 20.04 LTS Standard Support has ended. Here’s how to prepare.  | Ubuntu](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) 

We currently have good chunk of tests still using 20.04 version AMI images, i’m trying to upgrade them to Pro servers and look for a long term solution to avoid such recurring failures via this PR.

#### Sample failing tests as of now - 
[Non Regression Testing (EU) · newrelic/open-install-library@f45e4f6](https://github.com/newrelic/open-install-library/actions/runs/15924746136/job/44919374294) 
[Non Regression Testing (EU) · newrelic/open-install-library@f45e4f6](https://github.com/newrelic/open-install-library/actions/runs/15924746136/job/44919372948) 
[Non Regression Testing (EU) · newrelic/open-install-library@f45e4f6](https://github.com/newrelic/open-install-library/actions/runs/15924746136/job/44919373861)