### PR TITLE
fix(crowdstrike-fix): Fix crowdstrike installation on the provisioned host.

### DIFF
--- a/.github/workflows/nonregression-eu.yml
+++ b/.github/workflows/nonregression-eu.yml
@@ -159,11 +159,18 @@ jobs:
 
       - name: Run deployer
         id: deployerRun
+        env:
+          CROWDSTRIKE_CLIENT_ID: ${{ secrets.CROWDSTRIKE_CLIENT_ID }}
+          CROWDSTRIKE_CLIENT_SECRET: ${{ secrets.CROWDSTRIKE_CLIENT_SECRET }}
+          CROWDSTRIKE_CUSTOMER_ID: ${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}
         run: |
           set -e
           testDefinitionFile=$(echo $MATRIX | jq -c -r '.testDefinitionFile')
           echo $testDefinitionFile
           docker run -i\
+            -e CROWDSTRIKE_CUSTOMER_ID=$CROWDSTRIKE_CUSTOMER_ID\
+            -e CROWDSTRIKE_CLIENT_ID=$CROWDSTRIKE_CLIENT_ID\
+            -e CROWDSTRIKE_CLIENT_SECRET=$CROWDSTRIKE_CLIENT_SECRET\
             -v ${{ github.workspace }}/configs/:/mnt/deployer/configs/\
             -v ${{ github.workspace }}/test/:/mnt/deployer/test/\
             --entrypoint ruby newrelic/deployer:latest main.rb -c configs/gitusdkreu${{ github.run_id }}.json -d $testDefinitionFile -l debug

--- a/.github/workflows/nonregression.yml
+++ b/.github/workflows/nonregression.yml
@@ -170,11 +170,18 @@ jobs:
 
       - name: Run deployer
         id: deployerRun
+        env:
+          CROWDSTRIKE_CLIENT_ID: ${{ secrets.CROWDSTRIKE_CLIENT_ID }}
+          CROWDSTRIKE_CLIENT_SECRET: ${{ secrets.CROWDSTRIKE_CLIENT_SECRET }}
+          CROWDSTRIKE_CUSTOMER_ID: ${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}
         run: |
           set -e
           testDefinitionFile=$(echo $MATRIX | jq -c -r '.testDefinitionFile')
           echo $testDefinitionFile
           docker run -i\
+            -e CROWDSTRIKE_CUSTOMER_ID=$CROWDSTRIKE_CUSTOMER_ID\
+            -e CROWDSTRIKE_CLIENT_ID=$CROWDSTRIKE_CLIENT_ID\
+            -e CROWDSTRIKE_CLIENT_SECRET=$CROWDSTRIKE_CLIENT_SECRET\
             -v ${{ github.workspace }}/configs/:/mnt/deployer/configs/\
             -v ${{ github.workspace }}/test/:/mnt/deployer/test/\
             --entrypoint ruby newrelic/deployer:latest main.rb -c configs/gitusdkr${{ github.run_id }}.json -d $testDefinitionFile -l debug


### PR DESCRIPTION
The regression test in OIL is using deployer to provision the host and perform service installation and instrumentations to test for the New relic integrations.
For security concerns Crowdstrike is required on every provisioned Ec2 instanc. Installation of crowdstrike is handled by the deployer image. 
As part of OIL we need to include the crowdstrike install role and pass the creds stored in GIT for the. deployer image to install crowdstrike on the provisioned host

Find more details on this [ticket](https://new-relic.atlassian.net/browse/NR-314081)

Tests can found in this [sub-task](https://new-relic.atlassian.net/browse/NR-436590)

Confluence page : https://newrelic.atlassian.net/wiki/spaces/VIRTUOSO/pages/edit-v2/4474799913?draftShareId=c5c4d459-0239-46f1-a3b4-4dabade973ea
