### PR TITLE
feat: update logic, comments, config to add support for k8s 1.33 and remove for 1.28

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -158,7 +158,7 @@ install:
           SHORT_FLAG_ERROR=false
 
           # Check if $KUBECTL_VERSION contains an error with unknown flag --short
-          # run again without --short flag since it was deprecated in kubectl version 1.28
+          # run again without --short flag since it was deprecated in kubectl version 1.29
           if echo "$KUBECTL_VERSION" | grep -q "unknown flag: --short"
           then
             SHORT_FLAG_ERROR=true
@@ -188,14 +188,14 @@ install:
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 28 ]]; then
-            echo "Installation failed. Kubernetes version less that v1.28 is not supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -lt 1 ]] || [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -lt 29 ]]; then
+            echo "Installation failed. Kubernetes version less that v1.29 is not supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
             exit 131
           fi
 
-          if [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 32 ]]; then
-            echo "Kubernetes version greater than v1.32 is not officially supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
+          if [[ "$SERVER_MAJOR_VERSION" -eq 1 && "$SERVER_MINOR_VERSION" -gt 33 ]]; then
+            echo "Kubernetes version greater than v1.33 is not officially supported, found v${SERVER_MAJOR_VERSION}.${SERVER_MINOR_VERSION}" >&2
             echo "{\"Metadata\":{\"UnsupportedReason\":\"Unsupported k8s version - found $SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\", \"K8sClientVersion\":\"$CLIENT_MAJOR_VERSION.$CLIENT_MINOR_VERSION\", \"K8sServerVersion\":\"$SERVER_MAJOR_VERSION.$SERVER_MINOR_VERSION\"}}" | tee -a {{.NR_CLI_OUTPUT}}
           fi
           
@@ -392,7 +392,7 @@ install:
             fi
 
             # SHORT_FLAG_ERROR will be true if it returned an --short flag error earlier in the script
-            # if SHORT_FLAG_ERROR is true, run KUBECTL version without --short flag since it was deprecated in kubectl version 1.28
+            # if SHORT_FLAG_ERROR is true, run KUBECTL version without --short flag since it was deprecated in kubectl version 1.29
             if $SHORT_FLAG_ERROR == true; then
               K8S_VERSION=$($SUDO $KUBECTL version | grep "Server Version")
             else

--- a/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
+++ b/test/deploy/linux/kubernetes/minikube/roles/prepare/tasks/main.yml
@@ -58,7 +58,7 @@
   when: is_minikube_installed.stdout|int == 0
 
 - name: Start Minikube
-  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.32.0'
+  shell: 'minikube start --memory 8192 --cpus 4 --kubernetes-version=v1.33.0'
 
 - name: Create kubectl wrap command
   template:


### PR DESCRIPTION
Update testing to use K8s v1.33.0 instead of v1.32.0 for minikube

Test Plan: Spun up a v1.33 cluster on minikube and installed NRI Bundle with a local copy of the kubernetes.yml from this PR.