### PR TITLE
fix: Skip CrowdStrike installation to unblock onboarding tests

### DIFF
--- a/test/deploy/crowdstrike/roles/configure/tasks/main.yml
+++ b/test/deploy/crowdstrike/roles/configure/tasks/main.yml
@@ -1,29 +1,4 @@
 ---
-- name: Install CrowdStrike Falcon Sensor (Linux)
-  become: true
-  block:
-    - include_role:
-        name: newrelic.crowdstrike_provision.install_crowdstrike_falcon
-  vars:
-    falcon_client_id: "{{ lookup('env', 'CROWDSTRIKE_CLIENT_ID') }}"
-    falcon_client_secret: "{{ lookup('env', 'CROWDSTRIKE_CLIENT_SECRET') }}"
-    falcon_customer_id: "{{ lookup('env', 'CROWDSTRIKE_CUSTOMER_ID') }}"
-    api_base_url: "https://api.laggar.gcw.crowdstrike.com"
-  when: ansible_facts['os_family'] != 'Windows'
-
-- name: Install CrowdStrike Falcon Sensor (Windows)
-  become: true
-  become_method: runas
-  become_user: SYSTEM
-  block:
-    - ansible.windows.win_file:
-        path: C:\\Users\ansible\Downloads
-        state: directory
-    - include_role:
-        name: newrelic.crowdstrike_provision.install_crowdstrike_falcon
-  vars:
-    falcon_client_id: "{{ lookup('env', 'CROWDSTRIKE_CLIENT_ID') }}"
-    falcon_client_secret: "{{ lookup('env', 'CROWDSTRIKE_CLIENT_SECRET') }}"
-    falcon_customer_id: "{{ lookup('env', 'CROWDSTRIKE_CUSTOMER_ID') }}"
-    api_base_url: "https://api.laggar.gcw.crowdstrike.com"
-  when: ansible_facts['os_family'] == 'Windows'
+- name: Skipping CrowdStrike Falcon Sensor installation
+  debug:
+    msg: "Skipping CrowdStrike Falcon Sensor installation."


### PR DESCRIPTION
Currently onboarding-e2e-tests are failing during the provisioning of EC2 instances. The failure is due to an error during the CrowdStrike installation, which is likely caused by an expired hash. Given that we are in the process of deprecating CrowdStrike, this pull request (PR) is a temporary fix to bypass the installation and confirm a successful deployment. A subsequent PR will address all necessary changes to fully deprecate the CrowdStrike installation.