### PR TITLE
fix(ebpf): Recreate eBPF config on agent upgrade

### DIFF
--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -660,7 +660,8 @@ install:
           yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
           yum -y -q install newrelic-ebpf-agent
 
-          if [[ systemctl status newrelic-ebpf-agent.service | grep inactive ]]; then
+          GREP_OUTPUT=$(systemctl status newrelic-ebpf-agent.service | grep "Active:" | grep inactive)
+          if [[ $GREP_OUTPUT ]]; then
             if [[ ! -f "$CONFIG_FILE" ]]; then
               # Check if CONFIG_FILE_PATH is set and not empty
               if [[ -z "$CONFIG_FILE_PATH" ]]; then

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -56,6 +56,7 @@ install:
       cmds:
         - task: assert_pre_req
         - task: check_config_file
+        - task: install_linux_headers
         - task: install_ebpf_agent
 
     assert_pre_req:
@@ -407,6 +408,20 @@ install:
           else
               echo "TLS is disabled. Skipping certificate generation and validation."
           fi
+    
+    install_linux_headers:
+      cmds:
+        - |
+          KERNEL_VERSION=$(uname -r)
+          echo "Installing kernel headers for kernel version: $KERNEL_VERSION"
+          if ! yum install -y "kernel-devel-$KERNEL_VERSION" "kernel-headers-$KERNEL_VERSION"; then
+            echo ""
+            echo -e "\e[31mERROR:\e[0m Failed to install kernel headers for kernel $KERNEL_VERSION. Please ensure the correct headers are available and try again."
+            echo ""
+            exit 20
+          fi
+          echo "Kernel headers installed successfully for kernel $KERNEL_VERSION."ignore_error: true
+      ignore_error: true
 
     install_ebpf_agent:
       cmds:

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -163,11 +163,7 @@ install:
           NEW_RELIC_LOG_LEVEL=INFO
           # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
           NEW_RELIC_LOG_FILE_PATH=""
-          # -- Comma separated string of identifiers to exclude from process monitoring.
-          # Supported values:
-          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
-          # Process Name: Name of the process you want to ignore.
-          # Process Working Directory: Absolute path to directory from which the process is running.
+          # Regular expression pattern to match the specific name(s) of the entity set that you wish to exclude.
           DROP_DATA_FOR_ENTITY=""
           # -- Enable TLS communication between the eBPF client and agent.
           TLS_ENABLED="true"
@@ -184,6 +180,11 @@ install:
           TLS_CA_FILE=""
           # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
           TABLE_STORE_DATA_LIMIT_MB=250
+          # Sets the path of the directory where the required linux headers are downloaded and placed for the eBPF agent to use. 
+          # This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.
+          DOWNLOADED_PACKAGED_HEADERS_PATH=""
+          # Sets the path of the installed distribution linux headers. This is useful when auto discovery of distribution linux headers path fails.
+          DISTRO_KERNEL_HEADERS_PATH=""
 
           # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
           # Each protocol has the flexibility to selectively enable the type of data to export.
@@ -448,11 +449,7 @@ install:
           NEW_RELIC_LOG_LEVEL=INFO
           # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
           NEW_RELIC_LOG_FILE_PATH=""
-          # -- Comma separated string of identifiers to exclude from process monitoring.
-          # Supported values:
-          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
-          # Process Name: Name of the process you want to ignore.
-          # Process Working Directory: Absolute path to directory from which the process is running.
+          # Regular expression pattern to match the specific name(s) of the entity set that you wish to exclude.
           DROP_DATA_FOR_ENTITY=""
           # -- Enable TLS communication between the eBPF client and agent.
           TLS_ENABLED="true"
@@ -469,6 +466,11 @@ install:
           TLS_CA_FILE=""
           # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
           TABLE_STORE_DATA_LIMIT_MB=250
+          # Sets the path of the directory where the required linux headers are downloaded and placed for the eBPF agent to use. 
+          # This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.
+          DOWNLOADED_PACKAGED_HEADERS_PATH=""
+          # Sets the path of the installed distribution linux headers. This is useful when auto discovery of distribution linux headers path fails.
+          DISTRO_KERNEL_HEADERS_PATH=""
 
           # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
           # Each protocol has the flexibility to selectively enable the type of data to export.

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -94,10 +94,12 @@ install:
             exit 15
           fi
         - |
+          IS_GPG_AGENT_INSTALLED=$(which gpg-agent | wc -l)
+          IS_GPG_CONNECT_AGENT_INSTALLED=$(which gpg-connect-agent | wc -l)
           IS_GPG_INSTALLED=$(which gpg | wc -l)
-          if [ $IS_GPG_INSTALLED -eq 0 ] ; then
+          if [ $IS_GPG_AGENT_INSTALLED -eq 0 ] || [ $IS_GPG_CONNECT_AGENT_INSTALLED -eq 0 ] || [ $IS_GPG_INSTALLED -eq 0 ]; then
             echo ""
-            echo -e "\e[31mERROR:\e[0m gpg is required to run the newrelic install. Please install gpg and re-run the installation." >&2
+            echo -e "\e[31mERROR:\e[0m GnuPG suite is required to run the newrelic install. Please install gnupg suite and re-run the installation." >&2
             echo ""
             exit 15
           fi
@@ -110,15 +112,15 @@ install:
             exit 15
           fi
         - |
-          if [[ ! -d "$PX_DIR" ]]; then
-            if ! sudo mkdir -p /px; then
+          if [[ ! -d "/px" ]]; then
+            if ! sudo mkdir -p "/px"; then
               echo ""
               echo -e "\e[31mERROR:\e[0m Failed to create /px directory. Aborting installation."
               echo ""
               exit 16
             fi
           else
-            echo "Directory /px already exists. Continuing with installation."  
+            echo "Directory /px already exists. Continuing with installation."
           fi
 
     check_config_file:
@@ -418,7 +420,6 @@ install:
             echo ""
             echo -e "\e[31mERROR:\e[0m Failed to install kernel headers for kernel $KERNEL_VERSION. Please ensure the correct headers are available and try again."
             echo ""
-            exit 20
           fi
           echo "Kernel headers installed successfully for kernel $KERNEL_VERSION."ignore_error: true
       ignore_error: true

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -410,6 +410,7 @@ install:
     install_ebpf_agent:
       cmds:
         - |
+          CONFIG_FILE="/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.conf"
           ARCH=$(uname -m)
           REPO_URL=$(echo -n "https://download.newrelic.com/preview/linux/yum/el/{{.DISTRO_VERSION}}/$ARCH/newrelic-infra.repo")
           IS_NEWRELIC_AVAILABLE=$(curl -Ls $REPO_URL | grep "\[newrelic-infra\]" | wc -l)
@@ -417,10 +418,274 @@ install:
             echo "newrelic infrastructure agent is not available for this architecture "$ARCH". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi
+
+          create_default_config_file(){
+          
+              echo "Creating default configuration file at $CONFIG_FILE..."
+              # Ensure the directory exists
+              if [[ ! -d "/etc/newrelic-ebpf-agent/" ]]; then
+                echo "Creating directory /etc/newrelic-ebpf-agent/..."
+                sudo mkdir -p "/etc/newrelic-ebpf-agent/" || log_error_and_exit "Failed to create directory /etc/newrelic-ebpf-agent/."
+              fi
+
+              if [[ "$NEW_RELIC_REGION" == "staging" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="staging-otlp.nr-data.net:4317"
+              elif [[ "$NEW_RELIC_REGION" == "EU" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="otlp.eu01.nr-data.net:4317"
+              elif [[ "$NEW_RELIC_REGION" == "US" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="otlp.nr-data.net:4317"
+              fi       
+
+              # Create the default configuration file
+              sudo tee "$CONFIG_FILE" > /dev/null << EOS
+          # -- The license key to use.
+          NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY:-}"
+          # -- Unique name for the deployment to identify data posting via eBPF Agent
+          DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-}"
+          # -- Endpoint to export data to Newrelic
+          OTLP_ENDPOINT="${NEW_RELIC_OTLP_ENDPOINT:-}"
+          # -- To configure the log level in increasing order of verboseness. [OFF, FATAL, ERROR, WARNING, INFO, DEBUG]
+          NEW_RELIC_LOG_LEVEL=INFO
+          # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
+          NEW_RELIC_LOG_FILE_PATH=""
+          # -- Comma separated string of identifiers to exclude from process monitoring.
+          # Supported values:
+          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
+          # Process Name: Name of the process you want to ignore.
+          # Process Working Directory: Absolute path to directory from which the process is running.
+          DROP_DATA_FOR_ENTITY=""
+          # -- Enable TLS communication between the eBPF client and agent.
+          TLS_ENABLED="true"
+          # -- TLS Certificate Option 1: This must be enabled to create a self-signed cert and secret for you.
+          TLS_AUTOGENERATE_CERT_ENABLED="true"
+          # -- Certificates path.
+          TLS_CERT_PATH="/etc/newrelic-ebpf-agent/certs/"
+          # TLS Certificate Option 2: Use your own self-signed certificate. TLS_AUTOGENERATE_CERT_ENABLED must be disabled, and TLS_CERT_FILE, TLS_KEY_FILE, and TLS_CA_FILE must be set.
+          # -- Path to your own PEM-encoded certificate.
+          TLS_CERT_FILE=""
+          # -- Path to your own PEM-encoded private key.
+          TLS_KEY_FILE=""
+          # -- Path to the CA cert.
+          TLS_CA_FILE=""
+          # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
+          TABLE_STORE_DATA_LIMIT_MB=250
+
+          # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
+          # Each protocol has the flexibility to selectively enable the type of data to export.
+          # Metrics are sent by default when a protocol is enabled and it supports metrics. Note: AMQP, Kafka, DNS do not report metrics.
+          # PROTOCOLS_<protocol-name>_SPANS_SAMPLING_LATENCY represents the sampling latency threshold for the spans to export. [Options: p1, p10, p50, p90, p99].
+
+          # -- To Enable/Disable the metrics, spans, sampling of latency and error rate of HTTP
+          PROTOCOLS_HTTP_ENABLED="true"
+          PROTOCOLS_HTTP_SPANS_ENABLED="true"
+          PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY="p50"
+          # PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE represents the error rate threshold for an HTTP route where surpassing it would mean the corresponds spans of the route are exported. [Options: 1-100]
+          PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of MySQL DB
+          PROTOCOLS_MYSQL_ENABLED="true"
+          PROTOCOLS_MYSQL_SPANS_ENABLED="false"
+          PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of PostgreSQL DB
+          PROTOCOLS_PGSQL_ENABLED="true"
+          PROTOCOLS_PGSQL_SPANS_ENABLED="false"
+          PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of Cassandra DB
+          PROTOCOLS_CASS_ENABLED="true"
+          PROTOCOLS_CASS_SPANS_ENABLED="false"
+          PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of Redis DB
+          PROTOCOLS_REDIS_ENABLED="true"
+          PROTOCOLS_REDIS_SPANS_ENABLED="false"
+          PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of MongoDB
+          PROTOCOLS_MONGODB_ENABLED="true"
+          PROTOCOLS_MONGODB_SPANS_ENABLED="false"
+          PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of Kafka
+          PROTOCOLS_KAFKA_SPANS_ENABLED="false"
+          PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of AMQP
+          PROTOCOLS_AMQP_SPANS_ENABLED="false"
+          PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of DNS
+          PROTOCOLS_DNS_SPANS_ENABLED="false"
+          PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY=""
+          EOS
+
+              source "$CONFIG_FILE"
+              echo "Default configuration file created successfully at $CONFIG_FILE."
+
+          }
+
+          check_custom_config_file() {
+              FILE_PATH="$1"
+              if [[ -f "$FILE_PATH" ]]; then
+                  echo "Custom configuration file exists at $FILE_PATH. Proceeding with installation."
+
+                  # Ensure the directory exists
+                  if [[ ! -d "/etc/newrelic-ebpf-agent/" ]]; then
+                      echo "Creating directory /etc/newrelic-ebpf-agent/..."
+                      sudo mkdir -p "/etc/newrelic-ebpf-agent/" || log_error_and_exit "Failed to create directory /etc/newrelic-ebpf-agent/."
+                  fi
+
+                  if [[ "$(realpath "$FILE_PATH")" == "$(realpath "$CONFIG_FILE")" ]]; then
+                    echo "Custom config file and target config file are the same. Skipping symlink creation."
+                  else
+                    # Create a symbolic link
+                    echo "Creating symbolic link from $FILE_PATH to $CONFIG_FILE..."
+                    sudo ln -sf "$(realpath "$FILE_PATH")" "$CONFIG_FILE" || log_error_and_exit "Failed to create symbolic link from $(realpath "$FILE_PATH") to $CONFIG_FILE."
+                    echo "Symbolic link created successfully."
+                  fi
+
+                source "$CONFIG_FILE"
+              else
+                  log_error_and_exit "Custom configuration file $FILE_PATH does not exist or is not a valid file. Aborting installation."
+              fi
+          }
+
+          check_and_autogenerate_cert() {
+
+              echo "Checking if TLS certificate autogeneration is enabled..."
+              # Check if TLS_AUTOGENERATE_CERT_ENABLED is set to null or empty
+              if [[ -z "$TLS_AUTOGENERATE_CERT_ENABLED" ]]; then
+                  echo "TLS_AUTOGENERATE_CERT_ENABLED is not set. Defaulting to true."
+                  TLS_AUTOGENERATE_CERT_ENABLED="true"
+              fi
+
+              # Check if TLS_AUTOGENERATE_CERT_ENABLED is set to True/true
+              if [[ "$TLS_AUTOGENERATE_CERT_ENABLED" == "True" || "$TLS_AUTOGENERATE_CERT_ENABLED" == "true" ]]; then
+                  generate_tls_cert
+              else
+                  echo "Autogenerating TLS certificate skipped..."
+                  validate_and_copy_tls_files
+              fi
+          }
+
+          ensure_tls_certs_directory(){
+              # Check if TLS_CERT_PATH is null or empty
+              if [[ -z "$TLS_CERT_PATH" ]]; then
+                  echo "TLS_CERT_PATH is not set or is empty. Placing certs in the directory /etc/newrelic-ebpf-agent/certs/"
+                  TLS_CERT_PATH="/etc/newrelic-ebpf-agent/certs/"
+              fi
+
+              # Create the directory if it does not exist
+              if [[ ! -d "$TLS_CERT_PATH" ]]; then
+                  echo "Creating directory for certificates: $TLS_CERT_PATH"
+                  sudo mkdir -p "$TLS_CERT_PATH" || log_error_and_exit "Failed to create directory $TLS_CERT_PATH."
+              fi
+          }
+
+          generate_tls_cert() {
+
+              ensure_tls_certs_directory
+              echo "Autogenerating TLS certificates in $TLS_CERT_PATH."
+
+              # Create an OpenSSL configuration file for generating certificates
+              sudo tee "$TLS_CERT_PATH/ssl.conf" > /dev/null << EOS
+          [ req ]
+          default_bits       = 4096
+          distinguished_name = req_distinguished_name
+          req_extensions     = req_ext
+
+          [ req_distinguished_name ]
+
+          [ req_ext ]
+          subjectAltName = @alt_names
+
+          [alt_names]
+          DNS.1   = localhost
+          EOS
+
+              # Generate a private key for the Certificate Authority (CA)
+              sudo openssl genrsa -out "$TLS_CERT_PATH/ca.key" 4096 || log_error_and_exit "Failed to generate CA private key."
+
+              # Create a self-signed certificate for the CA
+              sudo openssl req -new -x509 -sha256 -days 730 -key "$TLS_CERT_PATH/ca.key" -out "$TLS_CERT_PATH/ca.crt" -subj "/O=eBPF/CN=localhost" || log_error_and_exit "Failed to generate CA certificate."
+
+              # Generate a private key for the server
+              sudo openssl genrsa -out "$TLS_CERT_PATH/tls.key" 4096 || log_error_and_exit "Failed to generate server private key."
+
+              # Create a certificate signing request (CSR) for the server
+              sudo openssl req -new -sha256 -key "$TLS_CERT_PATH/tls.key" -out "$TLS_CERT_PATH/server.csr" -config "$TLS_CERT_PATH/ssl.conf" -subj "/O=eBPF/CN=localhost" || log_error_and_exit "Failed to generate server CSR."
+
+              # Sign the server CSR with the CA certificate to create the server certificate
+              sudo openssl x509 -req -sha256 -days 730 -in "$TLS_CERT_PATH/server.csr" -CA "$TLS_CERT_PATH/ca.crt" -CAkey "$TLS_CERT_PATH/ca.key" -set_serial 01 \
+                  -out "$TLS_CERT_PATH/tls.crt" -extensions req_ext -extfile "$TLS_CERT_PATH/ssl.conf" || log_error_and_exit "Failed to generate server certificate."
+
+              echo "TLS certificates generated successfully in $TLS_CERT_PATH."
+          }
+
+
+          validate_and_copy_tls_files() {
+              echo "Validating TLS environment variables..."
+
+              # Check if any of the variables are empty
+              if [[ -z "$TLS_CERT_FILE" || -z "$TLS_KEY_FILE" || -z "$TLS_CA_FILE" ]]; then
+                  log_error_and_exit "All three environment variables (TLS_CERT_FILE, TLS_KEY_FILE, TLS_CA_FILE) are required if $TLS_AUTOGENERATE_CERT_ENABLED is not set to True/true."
+              fi
+
+              # Check if the file paths provided in the variables are valid
+              if [[ ! -f "$TLS_CERT_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_CERT_FILE ($TLS_CERT_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              if [[ ! -f "$TLS_KEY_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_KEY_FILE ($TLS_KEY_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              if [[ ! -f "$TLS_CA_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_CA_FILE ($TLS_CA_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              ensure_tls_certs_directory
+
+              # Copy the files to the destination directory
+              echo "Copying TLS certificate files to $TLS_CERT_PATH..."
+              sudo cp "$TLS_CERT_FILE" "$TLS_CERT_PATH/tls.crt" || log_error_and_exit "Failed to copy TLS_CERT_FILE to $TLS_CERT_PATH/tls.crt."
+              sudo cp "$TLS_KEY_FILE" "$TLS_CERT_PATH/tls.key" || log_error_and_exit "Failed to copy TLS_KEY_FILE to $TLS_CERT_PATH/tls.key."
+              sudo cp "$TLS_CA_FILE" "$TLS_CERT_PATH/ca.crt" || log_error_and_exit "Failed to copy TLS_CA_FILE to $TLS_CERT_PATH/tls.key."
+
+              echo "TLS certificate files copied successfully."
+          }
           
           curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
           yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
           yum -y -q install newrelic-ebpf-agent
+
+          if [[ systemctl status newrelic-ebpf-agent.service | grep inactive ]]; then
+            if [[ ! -f "$CONFIG_FILE" ]]; then
+              # Check if CONFIG_FILE_PATH is set and not empty
+              if [[ -z "$CONFIG_FILE_PATH" ]]; then
+                create_default_config_file
+              else
+                check_custom_config_file $CONFIG_FILE_PATH
+              fi
+
+              if [[ -z "$TLS_ENABLED" ]]; then
+                  echo "TLS_ENABLED is not set in the configuration file. Setting it to true by default."
+                  TLS_ENABLED="true"
+              fi
+
+              if [[ "$TLS_ENABLED" == "True" || "$TLS_ENABLED" == "true" ]]; then
+                  check_and_autogenerate_cert
+              else
+                  echo "TLS is disabled. Skipping certificate generation and validation."
+              fi
+
+              sudo mkdir -p /px;
+              sleep 5s;
+              systemctl restart newrelic-ebpf-agent.service
+              systemctl restart newrelic-ebpf-agent-client.service
+            fi
+          fi
       vars:
         DISTRO_VERSION:
           sh: |

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -462,6 +462,7 @@ install:
             exit 20
           fi
           echo "Linux headers installed successfully for kernel $KERNEL_VERSION."
+      ignore_error: true
 
     install_ebpf_agent:
       cmds:
@@ -733,7 +734,7 @@ install:
               systemctl restart newrelic-ebpf-agent.service
               systemctl restart newrelic-ebpf-agent-client.service
             else
-              echo "Error: newrelic-infra installation failed"
+              echo "Error: newrelic-ebpf-agent installation failed"
               echo "Attempting to configure the packages again"
               dpkg --configure -a
               # Check if there was an error

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -86,10 +86,12 @@ install:
             exit 15
           fi
         - |
+          IS_GPG_AGENT_INSTALLED=$(which gpg-agent | wc -l)
+          IS_GPG_CONNECT_AGENT_INSTALLED=$(which gpg-connect-agent | wc -l)
           IS_GPG_INSTALLED=$(which gpg | wc -l)
-          if [ $IS_GPG_INSTALLED -eq 0 ] ; then
+          if [ $IS_GPG_AGENT_INSTALLED -eq 0 ] || [ $IS_GPG_CONNECT_AGENT_INSTALLED -eq 0 ] || [ $IS_GPG_INSTALLED -eq 0 ]; then
             echo ""
-            echo -e "\e[31mERROR:\e[0m gpg is required to run the newrelic install. Please install gpg and re-run the installation." >&2
+            echo -e "\e[31mERROR:\e[0m GnuPG suite is required to run the newrelic install. Please install gnupg suite and re-run the installation." >&2
             echo ""
             exit 15
           fi
@@ -102,8 +104,8 @@ install:
             exit 15
           fi
         - |
-          if [[ ! -d "$PX_DIR" ]]; then
-            if ! sudo mkdir -p /px; then
+          if [[ ! -d "/px" ]]; then
+            if ! sudo mkdir -p "/px"; then
               echo ""
               echo -e "\e[31mERROR:\e[0m Failed to create /px directory. Aborting installation."
               echo ""

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -48,6 +48,7 @@ install:
         - task: add_gpg_key
         - task: add_nr_source
         - task: update_apt_nr_source
+        - task: install_linux_headers
         - task: install_ebpf_agent
 
     assert_pre_req:
@@ -449,11 +450,25 @@ install:
       # apt will return an error if fails to update any of its sources. Ignore these errors and let the "install_infra" task fail.
       ignore_error: true
 
+    install_linux_headers:
+      cmds:
+        - |
+          KERNEL_VERSION=$(uname -r)
+          echo "Installing linux headers for kernel version: $KERNEL_VERSION"
+          if ! apt-get install -yq --no-install-recommends "linux-headers-$KERNEL_VERSION"; then
+            echo ""
+            echo -e "\e[31mERROR:\e[0m Failed to install linux headers for kernel $KERNEL_VERSION. Please ensure the correct headers are available and try again."
+            echo ""
+            exit 20
+          fi
+          echo "Linux headers installed successfully for kernel $KERNEL_VERSION."
+
     install_ebpf_agent:
       cmds:
         - |
           export DEBIAN_FRONTEND=noninteractive
           CONFIG_FILE="/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.conf"
+          OPTIONS="-o DPkg::Lock::Timeout=60"
 
           create_default_config_file(){
           
@@ -693,39 +708,54 @@ install:
               echo "TLS certificate files copied successfully."
           }
 
-          apt-get install -yq --no-install-recommends newrelic-ebpf-agent || {
-            echo "Resolving missing dependencies for the eBPF agent..."
-            apt-get update -yq || echo -e "\e[31mERROR:\e[0m Failed to perform apt-get update."
-            apt-get install -f -yq || echo -e "\e[31mERROR:\e[0m Failed to resolve dependencies for the eBPF agent."
-            apt-get install -yq --no-install-recommends newrelic-ebpf-agent || {
-              echo -e "\e[31mERROR:\e[0m Failed to install the eBPF agent after resolving dependencies."
-              
-              if [[ ! -f "$CONFIG_FILE" ]]; then
-                # Check if CONFIG_FILE_PATH is set and not empty
-                if [[ -z "$CONFIG_FILE_PATH" ]]; then
-                  create_default_config_file
-                else
-                  check_custom_config_file $CONFIG_FILE_PATH
-                fi
-
-                if [[ -z "$TLS_ENABLED" ]]; then
-                  echo "TLS_ENABLED is not set in the configuration file. Setting it to true by default."
-                  TLS_ENABLED="true"
-                fi
-
-                if [[ "$TLS_ENABLED" == "True" || "$TLS_ENABLED" == "true" ]]; then
-                    check_and_autogenerate_cert
-                else
-                    echo "TLS is disabled. Skipping certificate generation and validation."
-                fi
-
-                sudo mkdir -p /px;
-                sleep 5s;
-                systemctl restart newrelic-ebpf-agent.service
-                systemctl restart newrelic-ebpf-agent-client.service
+          apt-get $OPTIONS install -yq --no-install-recommends newrelic-ebpf-agent || {
+            if [[ ! -f "$CONFIG_FILE" ]]; then
+              # Check if CONFIG_FILE_PATH is set and not empty
+              if [[ -z "$CONFIG_FILE_PATH" ]]; then
+                create_default_config_file
+              else
+                check_custom_config_file $CONFIG_FILE_PATH
               fi
-            }
+
+              if [[ -z "$TLS_ENABLED" ]]; then
+                echo "TLS_ENABLED is not set in the configuration file. Setting it to true by default."
+                TLS_ENABLED="true"
+              fi
+
+              if [[ "$TLS_ENABLED" == "True" || "$TLS_ENABLED" == "true" ]]; then
+                  check_and_autogenerate_cert
+              else
+                  echo "TLS is disabled. Skipping certificate generation and validation."
+              fi
+
+              sudo mkdir -p /px;
+              sleep 5s;
+              systemctl restart newrelic-ebpf-agent.service
+              systemctl restart newrelic-ebpf-agent-client.service
+            else
+              echo "Error: newrelic-infra installation failed"
+              echo "Attempting to configure the packages again"
+              dpkg --configure -a
+              # Check if there was an error
+              if [ $? -ne 0 ]; then
+                echo "Error found while reconfiguring dpkg database"
+                # Force-Install the Software
+                echo "Attempting to install any missing dependencies or fixes broken packages."
+                apt-get $OPTIONS install -f
+                if [ $? -ne 0 ]; then 
+                  exit 1
+                fi
+                echo "Installation is successful"
+              fi
+            fi
           }
+
+
+            
+        
+      
+
+
       silent: true
 
 postInstall:

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -112,7 +112,7 @@ install:
               exit 16
             fi
           else
-            echo "Directory /px already exists. Continuing with installation."  
+            echo "Directory /px already exists. Continuing with installation."
           fi
 
     check_config_file:

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -155,11 +155,7 @@ install:
           NEW_RELIC_LOG_LEVEL=INFO
           # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
           NEW_RELIC_LOG_FILE_PATH=""
-          # -- Comma separated string of identifiers to exclude from process monitoring.
-          # Supported values:
-          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
-          # Process Name: Name of the process you want to ignore.
-          # Process Working Directory: Absolute path to directory from which the process is running.
+          # Regular expression pattern to match the specific name(s) of the entity set that you wish to exclude.
           DROP_DATA_FOR_ENTITY=""
           # -- Enable TLS communication between the eBPF client and agent.
           TLS_ENABLED="true"
@@ -176,6 +172,11 @@ install:
           TLS_CA_FILE=""
           # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
           TABLE_STORE_DATA_LIMIT_MB=250
+          # Sets the path of the directory where the required linux headers are downloaded and placed for the eBPF agent to use. 
+          # This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.
+          DOWNLOADED_PACKAGED_HEADERS_PATH=""
+          # Sets the path of the installed distribution linux headers. This is useful when auto discovery of distribution linux headers path fails.
+          DISTRO_KERNEL_HEADERS_PATH=""
 
           # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
           # Each protocol has the flexibility to selectively enable the type of data to export.
@@ -483,11 +484,7 @@ install:
           NEW_RELIC_LOG_LEVEL=INFO
           # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
           NEW_RELIC_LOG_FILE_PATH=""
-          # -- Comma separated string of identifiers to exclude from process monitoring.
-          # Supported values:
-          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
-          # Process Name: Name of the process you want to ignore.
-          # Process Working Directory: Absolute path to directory from which the process is running.
+          # Regular expression pattern to match the specific name(s) of the entity set that you wish to exclude.
           DROP_DATA_FOR_ENTITY=""
           # -- Enable TLS communication between the eBPF client and agent.
           TLS_ENABLED="true"
@@ -504,6 +501,11 @@ install:
           TLS_CA_FILE=""
           # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
           TABLE_STORE_DATA_LIMIT_MB=250
+          # Sets the path of the directory where the required linux headers are downloaded and placed for the eBPF agent to use. 
+          # This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.
+          DOWNLOADED_PACKAGED_HEADERS_PATH=""
+          # Sets the path of the installed distribution linux headers. This is useful when auto discovery of distribution linux headers path fails.
+          DISTRO_KERNEL_HEADERS_PATH=""
 
           # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
           # Each protocol has the flexibility to selectively enable the type of data to export.

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -452,11 +452,277 @@ install:
       cmds:
         - |
           export DEBIAN_FRONTEND=noninteractive
+          CONFIG_FILE="/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.conf"
+
+          create_default_config_file(){
+          
+              echo "Creating default configuration file at $CONFIG_FILE..."
+              # Ensure the directory exists
+              if [[ ! -d "/etc/newrelic-ebpf-agent/" ]]; then
+                echo "Creating directory /etc/newrelic-ebpf-agent/..."
+                sudo mkdir -p "/etc/newrelic-ebpf-agent/" || log_error_and_exit "Failed to create directory /etc/newrelic-ebpf-agent/."
+              fi
+
+              if [[ "$NEW_RELIC_REGION" == "staging" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="staging-otlp.nr-data.net:4317"
+              elif [[ "$NEW_RELIC_REGION" == "EU" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="otlp.eu01.nr-data.net:4317"
+              elif [[ "$NEW_RELIC_REGION" == "US" ]]; then
+                NEW_RELIC_OTLP_ENDPOINT="otlp.nr-data.net:4317"
+              fi       
+
+              # Create the default configuration file
+              sudo tee "$CONFIG_FILE" > /dev/null << EOS
+          # -- The license key to use.
+          NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY:-}"
+          # -- Unique name for the deployment to identify data posting via eBPF Agent
+          DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-}"
+          # -- Endpoint to export data to Newrelic
+          OTLP_ENDPOINT="${NEW_RELIC_OTLP_ENDPOINT:-}"
+          # -- To configure the log level in increasing order of verboseness. [OFF, FATAL, ERROR, WARNING, INFO, DEBUG]
+          NEW_RELIC_LOG_LEVEL=INFO
+          # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
+          NEW_RELIC_LOG_FILE_PATH=""
+          # -- Comma separated string of identifiers to exclude from process monitoring.
+          # Supported values:
+          # Entity Name: Specific name of the entity set via NEW_RELIC_APP_NAME that you wish to exclude.
+          # Process Name: Name of the process you want to ignore.
+          # Process Working Directory: Absolute path to directory from which the process is running.
+          DROP_DATA_FOR_ENTITY=""
+          # -- Enable TLS communication between the eBPF client and agent.
+          TLS_ENABLED="true"
+          # -- TLS Certificate Option 1: This must be enabled to create a self-signed cert and secret for you.
+          TLS_AUTOGENERATE_CERT_ENABLED="true"
+          # -- Certificates path.
+          TLS_CERT_PATH="/etc/newrelic-ebpf-agent/certs/"
+          # TLS Certificate Option 2: Use your own self-signed certificate. TLS_AUTOGENERATE_CERT_ENABLED must be disabled, and TLS_CERT_FILE, TLS_KEY_FILE, and TLS_CA_FILE must be set.
+          # -- Path to your own PEM-encoded certificate.
+          TLS_CERT_FILE=""
+          # -- Path to your own PEM-encoded private key.
+          TLS_KEY_FILE=""
+          # -- Path to the CA cert.
+          TLS_CA_FILE=""
+          # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
+          TABLE_STORE_DATA_LIMIT_MB=250
+
+          # To toggle the protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
+          # Each protocol has the flexibility to selectively enable the type of data to export.
+          # Metrics are sent by default when a protocol is enabled and it supports metrics. Note: AMQP, Kafka, DNS do not report metrics.
+          # PROTOCOLS_<protocol-name>_SPANS_SAMPLING_LATENCY represents the sampling latency threshold for the spans to export. [Options: p1, p10, p50, p90, p99].
+
+          # -- To Enable/Disable the metrics, spans, sampling of latency and error rate of HTTP
+          PROTOCOLS_HTTP_ENABLED="true"
+          PROTOCOLS_HTTP_SPANS_ENABLED="true"
+          PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY="p50"
+          # PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE represents the error rate threshold for an HTTP route where surpassing it would mean the corresponds spans of the route are exported. [Options: 1-100]
+          PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of MySQL DB
+          PROTOCOLS_MYSQL_ENABLED="true"
+          PROTOCOLS_MYSQL_SPANS_ENABLED="false"
+          PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of PostgreSQL DB
+          PROTOCOLS_PGSQL_ENABLED="true"
+          PROTOCOLS_PGSQL_SPANS_ENABLED="false"
+          PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of Cassandra DB
+          PROTOCOLS_CASS_ENABLED="true"
+          PROTOCOLS_CASS_SPANS_ENABLED="false"
+          PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of Redis DB
+          PROTOCOLS_REDIS_ENABLED="true"
+          PROTOCOLS_REDIS_SPANS_ENABLED="false"
+          PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the metrics, spans, sampling latency rate of MongoDB
+          PROTOCOLS_MONGODB_ENABLED="true"
+          PROTOCOLS_MONGODB_SPANS_ENABLED="false"
+          PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of Kafka
+          PROTOCOLS_KAFKA_SPANS_ENABLED="false"
+          PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of AMQP
+          PROTOCOLS_AMQP_SPANS_ENABLED="false"
+          PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY=""
+
+          # -- To Enable/Disable the spans and sampling latency of DNS
+          PROTOCOLS_DNS_SPANS_ENABLED="false"
+          PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY=""
+          EOS
+
+              source "$CONFIG_FILE"
+              echo "Default configuration file created successfully at $CONFIG_FILE."
+
+          }
+
+          check_custom_config_file() {
+              FILE_PATH="$1"
+              if [[ -f "$FILE_PATH" ]]; then
+                  echo "Custom configuration file exists at $FILE_PATH. Proceeding with installation."
+
+                  # Ensure the directory exists
+                  if [[ ! -d "/etc/newrelic-ebpf-agent/" ]]; then
+                      echo "Creating directory /etc/newrelic-ebpf-agent/..."
+                      sudo mkdir -p "/etc/newrelic-ebpf-agent/" || log_error_and_exit "Failed to create directory /etc/newrelic-ebpf-agent/."
+                  fi
+
+                  if [[ "$(realpath "$FILE_PATH")" == "$(realpath "$CONFIG_FILE")" ]]; then
+                    echo "Custom config file and target config file are the same. Skipping symlink creation."
+                  else
+                    # Create a symbolic link
+                    echo "Creating symbolic link from $FILE_PATH to $CONFIG_FILE..."
+                    sudo ln -sf "$(realpath "$FILE_PATH")" "$CONFIG_FILE" || log_error_and_exit "Failed to create symbolic link from $(realpath "$FILE_PATH") to $CONFIG_FILE."
+                    echo "Symbolic link created successfully."
+                  fi
+
+                source "$CONFIG_FILE"
+              else
+                  log_error_and_exit "Custom configuration file $FILE_PATH does not exist or is not a valid file. Aborting installation."
+              fi
+          }
+
+          check_and_autogenerate_cert() {
+
+              echo "Checking if TLS certificate autogeneration is enabled..."
+              # Check if TLS_AUTOGENERATE_CERT_ENABLED is set to null or empty
+              if [[ -z "$TLS_AUTOGENERATE_CERT_ENABLED" ]]; then
+                  echo "TLS_AUTOGENERATE_CERT_ENABLED is not set. Defaulting to true."
+                  TLS_AUTOGENERATE_CERT_ENABLED="true"
+              fi
+
+              # Check if TLS_AUTOGENERATE_CERT_ENABLED is set to True/true
+              if [[ "$TLS_AUTOGENERATE_CERT_ENABLED" == "True" || "$TLS_AUTOGENERATE_CERT_ENABLED" == "true" ]]; then
+                  generate_tls_cert
+              else
+                  echo "Autogenerating TLS certificate skipped..."
+                  validate_and_copy_tls_files
+              fi
+          }
+
+          ensure_tls_certs_directory(){
+              # Check if TLS_CERT_PATH is null or empty
+              if [[ -z "$TLS_CERT_PATH" ]]; then
+                  echo "TLS_CERT_PATH is not set or is empty. Placing certs in the directory /etc/newrelic-ebpf-agent/certs/"
+                  TLS_CERT_PATH="/etc/newrelic-ebpf-agent/certs/"
+              fi
+
+              # Create the directory if it does not exist
+              if [[ ! -d "$TLS_CERT_PATH" ]]; then
+                  echo "Creating directory for certificates: $TLS_CERT_PATH"
+                  sudo mkdir -p "$TLS_CERT_PATH" || log_error_and_exit "Failed to create directory $TLS_CERT_PATH."
+              fi
+          }
+
+          generate_tls_cert() {
+
+              ensure_tls_certs_directory
+              echo "Autogenerating TLS certificates in $TLS_CERT_PATH."
+
+              # Create an OpenSSL configuration file for generating certificates
+              sudo tee "$TLS_CERT_PATH/ssl.conf" > /dev/null << EOS
+          [ req ]
+          default_bits       = 4096
+          distinguished_name = req_distinguished_name
+          req_extensions     = req_ext
+
+          [ req_distinguished_name ]
+
+          [ req_ext ]
+          subjectAltName = @alt_names
+
+          [alt_names]
+          DNS.1   = localhost
+          EOS
+
+              # Generate a private key for the Certificate Authority (CA)
+              sudo openssl genrsa -out "$TLS_CERT_PATH/ca.key" 4096 || log_error_and_exit "Failed to generate CA private key."
+
+              # Create a self-signed certificate for the CA
+              sudo openssl req -new -x509 -sha256 -days 730 -key "$TLS_CERT_PATH/ca.key" -out "$TLS_CERT_PATH/ca.crt" -subj "/O=eBPF/CN=localhost" || log_error_and_exit "Failed to generate CA certificate."
+
+              # Generate a private key for the server
+              sudo openssl genrsa -out "$TLS_CERT_PATH/tls.key" 4096 || log_error_and_exit "Failed to generate server private key."
+
+              # Create a certificate signing request (CSR) for the server
+              sudo openssl req -new -sha256 -key "$TLS_CERT_PATH/tls.key" -out "$TLS_CERT_PATH/server.csr" -config "$TLS_CERT_PATH/ssl.conf" -subj "/O=eBPF/CN=localhost" || log_error_and_exit "Failed to generate server CSR."
+
+              # Sign the server CSR with the CA certificate to create the server certificate
+              sudo openssl x509 -req -sha256 -days 730 -in "$TLS_CERT_PATH/server.csr" -CA "$TLS_CERT_PATH/ca.crt" -CAkey "$TLS_CERT_PATH/ca.key" -set_serial 01 \
+                  -out "$TLS_CERT_PATH/tls.crt" -extensions req_ext -extfile "$TLS_CERT_PATH/ssl.conf" || log_error_and_exit "Failed to generate server certificate."
+
+              echo "TLS certificates generated successfully in $TLS_CERT_PATH."
+          }
+
+
+          validate_and_copy_tls_files() {
+              echo "Validating TLS environment variables..."
+
+              # Check if any of the variables are empty
+              if [[ -z "$TLS_CERT_FILE" || -z "$TLS_KEY_FILE" || -z "$TLS_CA_FILE" ]]; then
+                  log_error_and_exit "All three environment variables (TLS_CERT_FILE, TLS_KEY_FILE, TLS_CA_FILE) are required if $TLS_AUTOGENERATE_CERT_ENABLED is not set to True/true."
+              fi
+
+              # Check if the file paths provided in the variables are valid
+              if [[ ! -f "$TLS_CERT_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_CERT_FILE ($TLS_CERT_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              if [[ ! -f "$TLS_KEY_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_KEY_FILE ($TLS_KEY_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              if [[ ! -f "$TLS_CA_FILE" ]]; then
+                  log_error_and_exit "The file path specified in TLS_CA_FILE ($TLS_CA_FILE) is invalid, does not exist, or is a directory."
+              fi
+
+              ensure_tls_certs_directory
+
+              # Copy the files to the destination directory
+              echo "Copying TLS certificate files to $TLS_CERT_PATH..."
+              sudo cp "$TLS_CERT_FILE" "$TLS_CERT_PATH/tls.crt" || log_error_and_exit "Failed to copy TLS_CERT_FILE to $TLS_CERT_PATH/tls.crt."
+              sudo cp "$TLS_KEY_FILE" "$TLS_CERT_PATH/tls.key" || log_error_and_exit "Failed to copy TLS_KEY_FILE to $TLS_CERT_PATH/tls.key."
+              sudo cp "$TLS_CA_FILE" "$TLS_CERT_PATH/ca.crt" || log_error_and_exit "Failed to copy TLS_CA_FILE to $TLS_CERT_PATH/tls.key."
+
+              echo "TLS certificate files copied successfully."
+          }
+
           apt-get install -yq --no-install-recommends newrelic-ebpf-agent || {
             echo "Resolving missing dependencies for the eBPF agent..."
             apt-get update -yq || echo -e "\e[31mERROR:\e[0m Failed to perform apt-get update."
             apt-get install -f -yq || echo -e "\e[31mERROR:\e[0m Failed to resolve dependencies for the eBPF agent."
-            apt-get install -yq --no-install-recommends newrelic-ebpf-agent || echo -e "\e[31mERROR:\e[0m Failed to install the eBPF agent after resolving dependencies."
+            apt-get install -yq --no-install-recommends newrelic-ebpf-agent || {
+              echo -e "\e[31mERROR:\e[0m Failed to install the eBPF agent after resolving dependencies."
+              
+              if [[ ! -f "$CONFIG_FILE" ]]; then
+                # Check if CONFIG_FILE_PATH is set and not empty
+                if [[ -z "$CONFIG_FILE_PATH" ]]; then
+                  create_default_config_file
+                else
+                  check_custom_config_file $CONFIG_FILE_PATH
+                fi
+
+                if [[ -z "$TLS_ENABLED" ]]; then
+                  echo "TLS_ENABLED is not set in the configuration file. Setting it to true by default."
+                  TLS_ENABLED="true"
+                fi
+
+                if [[ "$TLS_ENABLED" == "True" || "$TLS_ENABLED" == "true" ]]; then
+                    check_and_autogenerate_cert
+                else
+                    echo "TLS is disabled. Skipping certificate generation and validation."
+                fi
+
+                sudo mkdir -p /px;
+                sleep 5s;
+                systemctl restart newrelic-ebpf-agent.service
+                systemctl restart newrelic-ebpf-agent-client.service
+              fi
+            }
           }
       silent: true
 

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -459,7 +459,6 @@ install:
             echo ""
             echo -e "\e[31mERROR:\e[0m Failed to install linux headers for kernel $KERNEL_VERSION. Please ensure the correct headers are available and try again."
             echo ""
-            exit 20
           fi
           echo "Linux headers installed successfully for kernel $KERNEL_VERSION."
       ignore_error: true


### PR DESCRIPTION
This PR has the following changes:
- 2 new env's are introduced in the config - `DOWNLOADED_PACKAGED_HEADERS_PATH` and `DISTRO_KERNEL_HEADERS_PATH`
- Updated description for `DROP_DATA_FOR_ENTITY` env.
- Add new task to install linux headers.
- Recreate config and TLS certs in case of a agent upgrade.