### PR TITLE
chore: add windows to k8s integration privilege check

### DIFF
--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -107,6 +107,7 @@ install:
 
           NR_CLI_LOW_DATA_MODE="{{.NR_CLI_LOW_DATA_MODE}}"
           NR_CLI_PRIVILEGED="{{.NR_CLI_PRIVILEGED}}"
+          NR_CLI_WINDOWS_PRIVILEGED="{{.NR_CLI_WINDOWS_PRIVILEGED}}"
           NR_CLI_BETA="{{.NR_CLI_BETA}}"
 
           # Deploys New Relic Pixie integration which
@@ -326,6 +327,7 @@ install:
 
           NR_CLI_LOW_DATA_MODE=${NR_CLI_LOW_DATA_MODE:-true}
           NR_CLI_PRIVILEGED=${NR_CLI_PRIVILEGED:-true}
+          NR_CLI_WINDOWS_PRIVILEGED=${NR_CLI_WINDOWS_PRIVILEGED:-true}
           NR_CLI_BETA="${NR_CLI_BETA:-false}"
 
           # Check the Linux kernel version for compatibility if Pixie is set to be installed on cluster
@@ -470,6 +472,7 @@ install:
             echo "Failed to deploy a privileged container to the Kubernetes cluster." >&2
             echo -e "\033[0;31mReverting to unprivileged mode for this installation. Turning off Logging and Pixie.\033[0m" >&2
             NR_CLI_PRIVILEGED=false
+            NR_CLI_WINDOWS_PRIVILEGED=false
             PIXIE_SUPPORTED=false
             NR_CLI_LOGGING=false
           fi
@@ -616,6 +619,7 @@ install:
             ARGS="${ARGS} --set ksm.enabled=${NR_CLI_KSM}"
             ARGS="${ARGS} --set k8s-agents-operator.enabled=${NR_CLI_AGENT_OPERATOR}"
             ARGS="${ARGS} --set newrelic-infrastructure.enableWindows=${NR_CLI_WINDOWS}"
+            ARGS="${ARGS} --set newrelic-infrastructure.windows.privileged=${NR_CLI_WINDOWS_PRIVILEGED}"
             ARGS="${ARGS} --set newrelic-logging.enableWindows=${NR_CLI_LOGGING_WINDOWS}"
 
             # if installing in GKE Autopilot, set the Provider to GKE_AUTOPILOT
@@ -749,6 +753,7 @@ install:
             BODY="${BODY},\"ksm.enabled\":\"${NR_CLI_KSM}\""
             BODY="${BODY},\"k8s-agents-operator.enabled\":\"${NR_CLI_AGENT_OPERATOR}\""
             BODY="${BODY},\"newrelic-infrastructure.enableWindows\":\"${NR_CLI_WINDOWS}\""
+            BODY="${BODY},\"newrelic-infrastructure.windows.privileged\":\"${NR_CLI_WINDOWS_PRIVILEGED}\""
             BODY="${BODY},\"newrelic-logging.enableWindows\":\"${NR_CLI_LOGGING_WINDOWS}\""
 
             # if installing in GKE Autopilot, set Provider to GKE_AUTOPILOT


### PR DESCRIPTION
FOR WINDOWS GA 

- Adds `NR_CLI_WINDOWS_PRIVILEGED` to cli options
- If privilege check fails, also sets `NR_CLI_WINDOWS_PRIVILEGED` to false
- Adds flag to Helm & manifest install paths (default is true, like for Linux)

Do not merge until Windows GA is announced.