### PR TITLE
fix: Updated nrdot kafka ansible files to reflect upstream changes

### DIFF
--- a/test/deploy/linux/nrdot-kafka/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-kafka/install/debian/roles/configure/tasks/main.yml
@@ -72,7 +72,7 @@
             - "host.docker.internal:host-gateway"
           volumes:
             - otel-agent:/opt/otel-agent:ro
-            - ./jmx-custom-config.yaml:/etc/kafka/jmx-custom-config.yaml:ro
+            - ./kafka-jmx-complete-config.yaml:/etc/kafka/kafka-jmx-complete-config.yaml:ro
           environment:
             CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
             KAFKA_NODE_ID: "1"
@@ -93,7 +93,7 @@
             KAFKA_OPTS: >-
               -javaagent:/opt/otel-agent/opentelemetry-javaagent.jar
               -Dotel.jmx.enabled=true
-              -Dotel.jmx.config=/etc/kafka/jmx-custom-config.yaml
+              -Dotel.jmx.config=/etc/kafka/kafka-jmx-complete-config.yaml
               -Dotel.instrumentation.runtime-telemetry.enabled=false
               -Dotel.resource.attributes=broker.id=1
               -Dotel.exporter.otlp.endpoint=http://host.docker.internal:4317

--- a/test/deploy/linux/nrdot-kafka/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-kafka/install/rhel/roles/configure/tasks/main.yml
@@ -103,7 +103,7 @@
             - "host.docker.internal:host-gateway"
           volumes:
             - otel-agent:/opt/otel-agent:ro
-            - ./jmx-custom-config.yaml:/etc/kafka/jmx-custom-config.yaml:ro
+            - ./kafka-jmx-complete-config.yaml:/etc/kafka/kafka-jmx-complete-config.yaml:ro
           environment:
             CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
             KAFKA_NODE_ID: "1"
@@ -124,7 +124,7 @@
             KAFKA_OPTS: >-
               -javaagent:/opt/otel-agent/opentelemetry-javaagent.jar
               -Dotel.jmx.enabled=true
-              -Dotel.jmx.config=/etc/kafka/jmx-custom-config.yaml
+              -Dotel.jmx.config=/etc/kafka/kafka-jmx-complete-config.yaml
               -Dotel.instrumentation.runtime-telemetry.enabled=false
               -Dotel.resource.attributes=broker.id=1
               -Dotel.exporter.otlp.endpoint=http://host.docker.internal:4317


### PR DESCRIPTION
### Changes:
- Rename jmx-custom-config.yaml → kafka-jmx-complete-config.yaml in volume mounts and -Dotel.jmx.config flag
- Updated in both debian and rhel configure task roles
- Aligns with the rename in [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/other-examples/collector/kafka/self-host-kafka/docker-compose.yaml)