### PR TITLE
feat(rabbitmq): add rabbitmq nrdot recipes

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
@@ -1,0 +1,295 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+
+name: nrdot-rabbitmq
+displayName: NRDOT RabbitMQ
+description: New Relic install recipe for RabbitMQ monitoring via NRDOT Collector on Debian/Ubuntu.
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platformFamily: debian
+  - type: host
+    os: linux
+    platform: ubuntu
+
+keywords:
+  - RabbitMQ
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Messaging
+  - Queue
+  - Linux
+  - Debian
+  - Ubuntu
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+
+inputVars:
+  - name: NR_CLI_RABBITMQ_DEPLOYMENT_NAME
+    prompt: "RabbitMQ deployment name (used to identify this instance in New Relic): "
+  - name: NR_CLI_RABBITMQ_ENDPOINT
+    prompt: "RabbitMQ management API endpoint (e.g. http://localhost:15672): "
+    default: "http://localhost:15672"
+  - name: NR_CLI_RABBITMQ_USERNAME
+    prompt: "RabbitMQ username: "
+    default: "admin"
+  - name: NR_CLI_RABBITMQ_PASSWORD
+    prompt: "RabbitMQ password: "
+    secret: true
+
+validationNrql: "SELECT count(*) FROM Metric SINCE 10 minutes ago WHERE metricName LIKE 'rabbitmq.%' AND instrumentation.provider = 'opentelemetry' AND rabbitmq.deployment.name = '{{.NR_CLI_RABBITMQ_DEPLOYMENT_NAME}}'"
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+    NRDOT_ARCH:
+      sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi
+    NRDOT_VERSION:
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
+    COLLECTOR_DISTRO: "nrdot-collector"
+    CONFIG_DIR: "/etc/nrdot-collector"
+
+  tasks:
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: install_nrdot
+        - task: create_collector_config
+        - task: configure_service
+        - task: restart_nrdot
+        - task: assert_nrdot_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 3
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    install_nrdot:
+      cmds:
+        - |
+          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
+          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb"
+          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb" \
+            --location --output "$NRDOT_DEB" 2>/dev/null
+          dpkg -i "$NRDOT_DEB" > /dev/null
+          if [ $? -ne 0 ]; then
+            dpkg --configure -a > /dev/null
+            apt-get -o DPkg::Lock::Timeout=60 install -f -y > /dev/null
+            if [ $? -ne 0 ]; then
+              echo "Failed to install NRDOT Collector package." >&2
+              exit 1
+            fi
+          fi
+          rm -f "$NRDOT_DEB"
+          mkdir -p {{.CONFIG_DIR}}
+          grep -q "^NEW_RELIC_LICENSE_KEY" {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf 2>/dev/null && \
+            sed -i 's|^NEW_RELIC_LICENSE_KEY=.*|NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}|' \
+              {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf || \
+            echo "NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}" | \
+              tee -a {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf > /dev/null
+
+    create_collector_config:
+      cmds:
+        - |
+          COLLECTOR_CONFIG="{{.CONFIG_DIR}}/rabbitmq-collector-config.yaml"
+          ENV_FILE="{{.CONFIG_DIR}}/rabbitmq-env.conf"
+
+          echo "Creating RabbitMQ collector configuration..."
+          cat > "$COLLECTOR_CONFIG" << 'EOF'
+          receivers:
+            rabbitmq:
+              endpoint: ${RABBITMQ_ENDPOINT}
+              username: ${RABBITMQ_USERNAME}
+              password: ${RABBITMQ_PASSWORD}
+              collection_interval: 30s
+              metrics:
+                rabbitmq.consumer.count:
+                  enabled: true
+                rabbitmq.message.delivered:
+                  enabled: true
+                rabbitmq.message.published:
+                  enabled: true
+                rabbitmq.message.acknowledged:
+                  enabled: true
+                rabbitmq.message.dropped:
+                  enabled: true
+                rabbitmq.message.current:
+                  enabled: true
+                rabbitmq.node.disk_free:
+                  enabled: true
+                rabbitmq.node.disk_free_limit:
+                  enabled: true
+                rabbitmq.node.disk_free_alarm:
+                  enabled: true
+                rabbitmq.node.mem_used:
+                  enabled: true
+                rabbitmq.node.mem_limit:
+                  enabled: true
+                rabbitmq.node.mem_alarm:
+                  enabled: true
+                rabbitmq.node.fd_used:
+                  enabled: true
+                rabbitmq.node.fd_total:
+                  enabled: true
+                rabbitmq.node.sockets_used:
+                  enabled: true
+                rabbitmq.node.sockets_total:
+                  enabled: true
+                rabbitmq.node.proc_used:
+                  enabled: true
+                rabbitmq.node.proc_total:
+                  enabled: true
+                rabbitmq.node.uptime:
+                  enabled: true
+                rabbitmq.node.run_queue:
+                  enabled: true
+          processors:
+            resourcedetection:
+              detectors: [system]
+              system:
+                resource_attributes:
+                  host.name:
+                    enabled: true
+                  host.id:
+                    enabled: true
+            resource:
+              attributes:
+                - action: upsert
+                  key: instrumentation.provider
+                  value: opentelemetry
+                - action: upsert
+                  key: rabbitmq.server.endpoint
+                  value: ${RABBITMQ_ENDPOINT}
+                - action: upsert
+                  key: rabbitmq.deployment.name
+                  value: ${RABBITMQ_DEPLOYMENT_NAME}
+            batch:
+              timeout: 30s
+              send_batch_size: 512
+            transform/rabbitmq_metrics:
+              metric_statements:
+                - context: resource
+                  statements:
+                    - set(attributes["rabbitmq.display.name"], Concat(["server", attributes["rabbitmq.deployment.name"]], ":"))
+            transform/metadata_nullify:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(description, "")
+                    - set(unit, "")
+          exporters:
+            otlphttp:
+              endpoint: ${NEW_RELIC_OTLP_ENDPOINT}
+              headers:
+                api-key: ${NEW_RELIC_LICENSE_KEY}
+              compression: gzip
+          extensions:
+            health_check:
+              endpoint: 0.0.0.0:13133
+          service:
+            extensions: [health_check]
+            pipelines:
+              metrics:
+                receivers: [rabbitmq]
+                processors: [resourcedetection, resource, batch, transform/rabbitmq_metrics, transform/metadata_nullify]
+                exporters: [otlphttp]
+          EOF
+
+          printf "RABBITMQ_ENDPOINT=%s\n" "{{.NR_CLI_RABBITMQ_ENDPOINT}}" > "$ENV_FILE"
+          printf "RABBITMQ_USERNAME=%s\n" "{{.NR_CLI_RABBITMQ_USERNAME}}" >> "$ENV_FILE"
+          printf "RABBITMQ_PASSWORD=%s\n" "{{.NR_CLI_RABBITMQ_PASSWORD}}" >> "$ENV_FILE"
+          printf "RABBITMQ_DEPLOYMENT_NAME=%s\n" "{{.NR_CLI_RABBITMQ_DEPLOYMENT_NAME}}" >> "$ENV_FILE"
+
+          if [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            OTLP_ENDPOINT="https://otlp.eu01.nr-data.net"
+          elif [ "{{.NEW_RELIC_REGION}}" = "staging" ]; then
+            OTLP_ENDPOINT="https://staging-otlp.nr-data.net"
+          else
+            OTLP_ENDPOINT="https://otlp.nr-data.net"
+          fi
+          printf "NEW_RELIC_OTLP_ENDPOINT=%s\n" "$OTLP_ENDPOINT" >> "$ENV_FILE"
+          printf "NEW_RELIC_LICENSE_KEY=%s\n" "{{.NEW_RELIC_LICENSE_KEY}}" >> "$ENV_FILE"
+
+          echo "Collector config written to $COLLECTOR_CONFIG"
+
+    configure_service:
+      cmds:
+        - |
+          DROPIN_DIR="/etc/systemd/system/{{.COLLECTOR_DISTRO}}.service.d"
+          mkdir -p "$DROPIN_DIR"
+          NRDOT_BIN=$(command -v nrdot-collector 2>/dev/null || echo "/usr/bin/nrdot-collector")
+          {
+            printf '[Service]\n'
+            printf 'EnvironmentFile={{.CONFIG_DIR}}/rabbitmq-env.conf\n'
+            printf 'ExecStart=\n'
+            printf 'ExecStart=%s --config {{.CONFIG_DIR}}/rabbitmq-collector-config.yaml\n' "$NRDOT_BIN"
+          } > "$DROPIN_DIR/rabbitmq-config.conf"
+          echo "Systemd drop-in configured."
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl daemon-reload
+          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+
+    assert_nrdot_status_ok:
+      cmds:
+        - |
+          MAX_RETRIES=30
+          TRIES=0
+          echo "Waiting for NRDOT Collector to start..."
+          while [ $TRIES -lt $MAX_RETRIES ]; do
+            TRIES=$((TRIES + 1))
+            if systemctl is-active --quiet {{.COLLECTOR_DISTRO}}.service; then
+              echo "NRDOT Collector is running."
+              echo ""
+              echo "Configuration: {{.CONFIG_DIR}}/rabbitmq-collector-config.yaml"
+              echo "Environment:   {{.CONFIG_DIR}}/rabbitmq-env.conf"
+              echo ""
+              echo "Useful commands:"
+              echo "  Check status:  sudo systemctl status nrdot-collector"
+              echo "  View logs:     sudo journalctl -u nrdot-collector -f"
+              echo "  Restart:       sudo systemctl restart nrdot-collector"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "NRDOT Collector did not start in time." >&2
+          journalctl -u {{.COLLECTOR_DISTRO}}.service --no-pager -n 50 >&2
+          exit 31
+
+postInstall:
+  info: |2
+      RabbitMQ OTel Collector config: /etc/nrdot-collector/rabbitmq-collector-config.yaml
+      Service status: systemctl status nrdot-collector
+      View logs: journalctl -u nrdot-collector -f

--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
@@ -34,6 +34,7 @@ preInstall:
 inputVars:
   - name: NR_CLI_RABBITMQ_DEPLOYMENT_NAME
     prompt: "RabbitMQ deployment name (used to identify this instance in New Relic): "
+    default: "rabbitmq-server"
   - name: NR_CLI_RABBITMQ_ENDPOINT
     prompt: "RabbitMQ management API endpoint (e.g. http://localhost:15672): "
     default: "http://localhost:15672"
@@ -56,7 +57,7 @@ install:
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi
     NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.13.0"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
 

--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
@@ -1,0 +1,300 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+
+name: nrdot-rabbitmq
+displayName: NRDOT RabbitMQ
+description: New Relic install recipe for RabbitMQ monitoring via NRDOT Collector on RHEL/CentOS/Amazon Linux.
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platform: amazon
+  - type: host
+    os: linux
+    platform: centos
+  - type: host
+    os: linux
+    platform: oracle
+  - type: host
+    os: linux
+    platform: redhat
+
+keywords:
+  - RabbitMQ
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Messaging
+  - Queue
+  - Linux
+  - RHEL
+  - CentOS
+  - Amazon Linux
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+
+inputVars:
+  - name: NR_CLI_RABBITMQ_DEPLOYMENT_NAME
+    prompt: "RabbitMQ deployment name (used to identify this instance in New Relic): "
+  - name: NR_CLI_RABBITMQ_ENDPOINT
+    prompt: "RabbitMQ management API endpoint (e.g. http://localhost:15672): "
+    default: "http://localhost:15672"
+  - name: NR_CLI_RABBITMQ_USERNAME
+    prompt: "RabbitMQ username: "
+    default: "admin"
+  - name: NR_CLI_RABBITMQ_PASSWORD
+    prompt: "RabbitMQ password: "
+    secret: true
+
+validationNrql: "SELECT count(*) FROM Metric SINCE 10 minutes ago WHERE metricName LIKE 'rabbitmq.%' AND instrumentation.provider = 'opentelemetry' AND rabbitmq.deployment.name = '{{.NR_CLI_RABBITMQ_DEPLOYMENT_NAME}}'"
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+    NRDOT_ARCH:
+      sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi
+    NRDOT_VERSION:
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
+    COLLECTOR_DISTRO: "nrdot-collector"
+    CONFIG_DIR: "/etc/nrdot-collector"
+
+  tasks:
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: install_nrdot
+        - task: create_collector_config
+        - task: configure_service
+        - task: restart_nrdot
+        - task: assert_nrdot_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 3
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    install_nrdot:
+      cmds:
+        - |
+          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
+          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm"
+          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm" \
+            --location --output "$NRDOT_RPM" 2>/dev/null
+          rpm -i "$NRDOT_RPM" > /dev/null 2>&1 || \
+            (which dnf >/dev/null 2>&1 && dnf install -y "$NRDOT_RPM" > /dev/null) || \
+            yum install -y "$NRDOT_RPM" > /dev/null
+          if [ $? -ne 0 ]; then
+            echo "Failed to install NRDOT Collector package." >&2
+            exit 1
+          fi
+          rm -f "$NRDOT_RPM"
+          mkdir -p {{.CONFIG_DIR}}
+          grep -q "^NEW_RELIC_LICENSE_KEY" {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf 2>/dev/null && \
+            sed -i 's|^NEW_RELIC_LICENSE_KEY=.*|NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}|' \
+              {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf || \
+            echo "NEW_RELIC_LICENSE_KEY={{.NEW_RELIC_LICENSE_KEY}}" | \
+              tee -a {{.CONFIG_DIR}}/{{.COLLECTOR_DISTRO}}.conf > /dev/null
+
+    create_collector_config:
+      cmds:
+        - |
+          COLLECTOR_CONFIG="{{.CONFIG_DIR}}/rabbitmq-collector-config.yaml"
+          ENV_FILE="{{.CONFIG_DIR}}/rabbitmq-env.conf"
+
+          echo "Creating RabbitMQ collector configuration..."
+          cat > "$COLLECTOR_CONFIG" << 'EOF'
+          receivers:
+            rabbitmq:
+              endpoint: ${RABBITMQ_ENDPOINT}
+              username: ${RABBITMQ_USERNAME}
+              password: ${RABBITMQ_PASSWORD}
+              collection_interval: 30s
+              metrics:
+                rabbitmq.consumer.count:
+                  enabled: true
+                rabbitmq.message.delivered:
+                  enabled: true
+                rabbitmq.message.published:
+                  enabled: true
+                rabbitmq.message.acknowledged:
+                  enabled: true
+                rabbitmq.message.dropped:
+                  enabled: true
+                rabbitmq.message.current:
+                  enabled: true
+                rabbitmq.node.disk_free:
+                  enabled: true
+                rabbitmq.node.disk_free_limit:
+                  enabled: true
+                rabbitmq.node.disk_free_alarm:
+                  enabled: true
+                rabbitmq.node.mem_used:
+                  enabled: true
+                rabbitmq.node.mem_limit:
+                  enabled: true
+                rabbitmq.node.mem_alarm:
+                  enabled: true
+                rabbitmq.node.fd_used:
+                  enabled: true
+                rabbitmq.node.fd_total:
+                  enabled: true
+                rabbitmq.node.sockets_used:
+                  enabled: true
+                rabbitmq.node.sockets_total:
+                  enabled: true
+                rabbitmq.node.proc_used:
+                  enabled: true
+                rabbitmq.node.proc_total:
+                  enabled: true
+                rabbitmq.node.uptime:
+                  enabled: true
+                rabbitmq.node.run_queue:
+                  enabled: true
+          processors:
+            resourcedetection:
+              detectors: [system]
+              system:
+                resource_attributes:
+                  host.name:
+                    enabled: true
+                  host.id:
+                    enabled: true
+            resource:
+              attributes:
+                - action: upsert
+                  key: instrumentation.provider
+                  value: opentelemetry
+                - action: upsert
+                  key: rabbitmq.server.endpoint
+                  value: ${RABBITMQ_ENDPOINT}
+                - action: upsert
+                  key: rabbitmq.deployment.name
+                  value: ${RABBITMQ_DEPLOYMENT_NAME}
+            batch:
+              timeout: 30s
+              send_batch_size: 512
+            transform/rabbitmq_metrics:
+              metric_statements:
+                - context: resource
+                  statements:
+                    - set(attributes["rabbitmq.display.name"], Concat(["server", attributes["rabbitmq.deployment.name"]], ":"))
+            transform/metadata_nullify:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(description, "")
+                    - set(unit, "")
+          exporters:
+            otlphttp:
+              endpoint: ${NEW_RELIC_OTLP_ENDPOINT}
+              headers:
+                api-key: ${NEW_RELIC_LICENSE_KEY}
+              compression: gzip
+          extensions:
+            health_check:
+              endpoint: 0.0.0.0:13133
+          service:
+            extensions: [health_check]
+            pipelines:
+              metrics:
+                receivers: [rabbitmq]
+                processors: [resourcedetection, resource, batch, transform/rabbitmq_metrics, transform/metadata_nullify]
+                exporters: [otlphttp]
+          EOF
+
+          printf "RABBITMQ_ENDPOINT=%s\n" "{{.NR_CLI_RABBITMQ_ENDPOINT}}" > "$ENV_FILE"
+          printf "RABBITMQ_USERNAME=%s\n" "{{.NR_CLI_RABBITMQ_USERNAME}}" >> "$ENV_FILE"
+          printf "RABBITMQ_PASSWORD=%s\n" "{{.NR_CLI_RABBITMQ_PASSWORD}}" >> "$ENV_FILE"
+          printf "RABBITMQ_DEPLOYMENT_NAME=%s\n" "{{.NR_CLI_RABBITMQ_DEPLOYMENT_NAME}}" >> "$ENV_FILE"
+
+          if [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            OTLP_ENDPOINT="https://otlp.eu01.nr-data.net"
+          elif [ "{{.NEW_RELIC_REGION}}" = "staging" ]; then
+            OTLP_ENDPOINT="https://staging-otlp.nr-data.net"
+          else
+            OTLP_ENDPOINT="https://otlp.nr-data.net"
+          fi
+          printf "NEW_RELIC_OTLP_ENDPOINT=%s\n" "$OTLP_ENDPOINT" >> "$ENV_FILE"
+          printf "NEW_RELIC_LICENSE_KEY=%s\n" "{{.NEW_RELIC_LICENSE_KEY}}" >> "$ENV_FILE"
+
+          echo "Collector config written to $COLLECTOR_CONFIG"
+
+    configure_service:
+      cmds:
+        - |
+          DROPIN_DIR="/etc/systemd/system/{{.COLLECTOR_DISTRO}}.service.d"
+          mkdir -p "$DROPIN_DIR"
+          NRDOT_BIN=$(command -v nrdot-collector 2>/dev/null || echo "/usr/bin/nrdot-collector")
+          {
+            printf '[Service]\n'
+            printf 'EnvironmentFile={{.CONFIG_DIR}}/rabbitmq-env.conf\n'
+            printf 'ExecStart=\n'
+            printf 'ExecStart=%s --config {{.CONFIG_DIR}}/rabbitmq-collector-config.yaml\n' "$NRDOT_BIN"
+          } > "$DROPIN_DIR/rabbitmq-config.conf"
+          echo "Systemd drop-in configured."
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl daemon-reload
+          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+
+    assert_nrdot_status_ok:
+      cmds:
+        - |
+          MAX_RETRIES=30
+          TRIES=0
+          echo "Waiting for NRDOT Collector to start..."
+          while [ $TRIES -lt $MAX_RETRIES ]; do
+            TRIES=$((TRIES + 1))
+            if systemctl is-active --quiet {{.COLLECTOR_DISTRO}}.service; then
+              echo "NRDOT Collector is running."
+              echo ""
+              echo "Configuration: {{.CONFIG_DIR}}/rabbitmq-collector-config.yaml"
+              echo "Environment:   {{.CONFIG_DIR}}/rabbitmq-env.conf"
+              echo ""
+              echo "Useful commands:"
+              echo "  Check status:  sudo systemctl status nrdot-collector"
+              echo "  View logs:     sudo journalctl -u nrdot-collector -f"
+              echo "  Restart:       sudo systemctl restart nrdot-collector"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "NRDOT Collector did not start in time." >&2
+          journalctl -u {{.COLLECTOR_DISTRO}}.service --no-pager -n 50 >&2
+          exit 31
+
+postInstall:
+  info: |2
+      RabbitMQ OTel Collector config: /etc/nrdot-collector/rabbitmq-collector-config.yaml
+      Service status: systemctl status nrdot-collector
+      View logs: journalctl -u nrdot-collector -f

--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
@@ -41,6 +41,7 @@ preInstall:
 inputVars:
   - name: NR_CLI_RABBITMQ_DEPLOYMENT_NAME
     prompt: "RabbitMQ deployment name (used to identify this instance in New Relic): "
+    default: "rabbitmq-server"
   - name: NR_CLI_RABBITMQ_ENDPOINT
     prompt: "RabbitMQ management API endpoint (e.g. http://localhost:15672): "
     default: "http://localhost:15672"
@@ -63,7 +64,7 @@ install:
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi
     NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.13.0"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
 

--- a/test/definitions/nrdot/rabbitmq/al2023-amd64.json
+++ b/test/definitions/nrdot/rabbitmq/al2023-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "al2023-ami-2023.*-x86_64",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "rabbitmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-rabbitmq/install/rhel/roles",
+      "port": 15672
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_rabbitmq_al2023_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/rabbitmq-recipe-changes/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml",
+          "recipe_targeted": "nrdot-rabbitmq",
+          "validate_output": "NRDOT RabbitMQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_RABBITMQ_ENDPOINT=http://localhost:15672 NR_CLI_RABBITMQ_USERNAME=admin NR_CLI_RABBITMQ_PASSWORD=admin NR_CLI_RABBITMQ_DEPLOYMENT_NAME=rabbitmq-al2023-amd64"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/rabbitmq/rhel9-amd64.json
+++ b/test/definitions/nrdot/rabbitmq/rhel9-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "RHEL-9.0.0_HVM-2024????-x86_64-39-Hourly2-GP3",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "rabbitmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-rabbitmq/install/rhel/roles",
+      "port": 15672
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_rabbitmq_rhel9_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml",
+          "recipe_targeted": "nrdot-rabbitmq",
+          "validate_output": "NRDOT RabbitMQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_RABBITMQ_ENDPOINT=http://localhost:15672 NR_CLI_RABBITMQ_USERNAME=admin NR_CLI_RABBITMQ_PASSWORD=admin NR_CLI_RABBITMQ_DEPLOYMENT_NAME=rabbitmq-rhel9-amd64"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/rabbitmq/ubuntu22-amd64.json
+++ b/test/definitions/nrdot/rabbitmq/ubuntu22-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*",
+      "user_name": "ubuntu"
+    }
+  ],
+  "services": [
+    {
+      "id": "rabbitmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-rabbitmq/install/debian/roles",
+      "port": 15672
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_rabbitmq_ubuntu22_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml",
+          "recipe_targeted": "nrdot-rabbitmq",
+          "validate_output": "NRDOT RabbitMQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_RABBITMQ_ENDPOINT=http://localhost:15672 NR_CLI_RABBITMQ_USERNAME=admin NR_CLI_RABBITMQ_PASSWORD=admin NR_CLI_RABBITMQ_DEPLOYMENT_NAME=rabbitmq-ubuntu22-amd64"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/rabbitmq/ubuntu24-amd64.json
+++ b/test/definitions/nrdot/rabbitmq/ubuntu24-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "services": [
+    {
+      "id": "rabbitmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-rabbitmq/install/debian/roles",
+      "port": 15672
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_rabbitmq_ubuntu24_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml",
+          "recipe_targeted": "nrdot-rabbitmq",
+          "validate_output": "NRDOT RabbitMQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_RABBITMQ_ENDPOINT=http://localhost:15672 NR_CLI_RABBITMQ_USERNAME=admin NR_CLI_RABBITMQ_PASSWORD=admin NR_CLI_RABBITMQ_DEPLOYMENT_NAME=rabbitmq-ubuntu24-amd64"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- name: install dependencies
+  apt:
+    name:
+      - curl
+      - gnupg
+      - apt-transport-https
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: add rabbitmq team signing key
+  shell: |
+    curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor -o /usr/share/keyrings/com.rabbitmq.team.gpg
+  become: yes
+
+- name: detect ubuntu codename
+  shell: lsb_release -cs
+  register: ubuntu_codename
+  become: yes
+
+- name: add rabbitmq apt repositories
+  copy:
+    dest: /etc/apt/sources.list.d/rabbitmq.list
+    content: |
+      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb1.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
+      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb2.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
+      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
+      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
+  become: yes
+
+- name: install erlang and rabbitmq-server
+  apt:
+    name:
+      - erlang-base
+      - erlang-asn1
+      - erlang-crypto
+      - erlang-eldap
+      - erlang-ftp
+      - erlang-inets
+      - erlang-mnesia
+      - erlang-os-mon
+      - erlang-parsetools
+      - erlang-public-key
+      - erlang-runtime-tools
+      - erlang-snmp
+      - erlang-ssl
+      - erlang-syntax-tools
+      - erlang-tftp
+      - erlang-tools
+      - erlang-xmerl
+      - rabbitmq-server
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: enable rabbitmq management plugin
+  shell: rabbitmq-plugins enable rabbitmq_management
+  become: yes
+
+- name: create rabbitmq admin user
+  shell: |
+    rabbitmqctl add_user admin admin 2>/dev/null || true
+    rabbitmqctl set_user_tags admin administrator
+    rabbitmqctl set_permissions -p / admin ".*" ".*" ".*"
+  become: yes
+
+- name: start and enable rabbitmq
+  systemd:
+    name: rabbitmq-server
+    state: restarted
+    enabled: yes
+  become: yes
+
+- name: wait for management API to be ready
+  shell: |
+    for i in $(seq 1 30); do
+      if curl -sf -u admin:admin http://localhost:15672/api/overview > /dev/null 2>&1; then
+        exit 0
+      fi
+      sleep 2
+    done
+    exit 1
+  become: yes

--- a/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
@@ -1,20 +1,16 @@
 ---
 - name: install docker
-  shell: |
-    if command -v docker &>/dev/null; then
-      echo "Docker already installed"
-      exit 0
-    fi
-    apt-get update -y
-    apt-get install -y ca-certificates curl
-    install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-    chmod a+r /etc/apt/keyrings/docker.asc
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-    apt-get update -y
-    apt-get install -y docker-ce docker-ce-cli containerd.io
-    systemctl start docker
-    systemctl enable docker
+  apt:
+    name: docker.io
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: start and enable docker
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
   become: yes
 
 - name: run rabbitmq container with management plugin

--- a/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-rabbitmq/install/debian/roles/configure/tasks/main.yml
@@ -1,75 +1,31 @@
 ---
-- name: install dependencies
-  apt:
-    name:
-      - curl
-      - gnupg
-      - apt-transport-https
-    state: present
-    update_cache: yes
-  become: yes
-
-- name: add rabbitmq team signing key
+- name: install docker
   shell: |
-    curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor -o /usr/share/keyrings/com.rabbitmq.team.gpg
+    if command -v docker &>/dev/null; then
+      echo "Docker already installed"
+      exit 0
+    fi
+    apt-get update -y
+    apt-get install -y ca-certificates curl
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get update -y
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+    systemctl start docker
+    systemctl enable docker
   become: yes
 
-- name: detect ubuntu codename
-  shell: lsb_release -cs
-  register: ubuntu_codename
-  become: yes
-
-- name: add rabbitmq apt repositories
-  copy:
-    dest: /etc/apt/sources.list.d/rabbitmq.list
-    content: |
-      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb1.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
-      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb2.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
-      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
-      deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/{{ ubuntu_codename.stdout }} {{ ubuntu_codename.stdout }} main
-  become: yes
-
-- name: install erlang and rabbitmq-server
-  apt:
-    name:
-      - erlang-base
-      - erlang-asn1
-      - erlang-crypto
-      - erlang-eldap
-      - erlang-ftp
-      - erlang-inets
-      - erlang-mnesia
-      - erlang-os-mon
-      - erlang-parsetools
-      - erlang-public-key
-      - erlang-runtime-tools
-      - erlang-snmp
-      - erlang-ssl
-      - erlang-syntax-tools
-      - erlang-tftp
-      - erlang-tools
-      - erlang-xmerl
-      - rabbitmq-server
-    state: present
-    update_cache: yes
-  become: yes
-
-- name: enable rabbitmq management plugin
-  shell: rabbitmq-plugins enable rabbitmq_management
-  become: yes
-
-- name: create rabbitmq admin user
+- name: run rabbitmq container with management plugin
   shell: |
-    rabbitmqctl add_user admin admin 2>/dev/null || true
-    rabbitmqctl set_user_tags admin administrator
-    rabbitmqctl set_permissions -p / admin ".*" ".*" ".*"
-  become: yes
-
-- name: start and enable rabbitmq
-  systemd:
-    name: rabbitmq-server
-    state: restarted
-    enabled: yes
+    docker run -d \
+      --name rabbitmq \
+      -p 5672:5672 \
+      -p 15672:15672 \
+      -e RABBITMQ_DEFAULT_USER=admin \
+      -e RABBITMQ_DEFAULT_PASS=admin \
+      rabbitmq:3-management
   become: yes
 
 - name: wait for management API to be ready

--- a/test/deploy/linux/nrdot-rabbitmq/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-rabbitmq/install/rhel/roles/configure/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: install rabbitmq signing keys and repos
+  shell: |
+    curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | bash
+    curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | bash
+  become: yes
+
+- name: install erlang and rabbitmq-server
+  shell: |
+    yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_erlang' --enablerepo='rabbitmq_rabbitmq-server' || true
+    yum install -y --enablerepo='rabbitmq_erlang' --enablerepo='rabbitmq_rabbitmq-server' erlang rabbitmq-server
+  become: yes
+
+- name: enable rabbitmq management plugin
+  shell: rabbitmq-plugins enable rabbitmq_management
+  become: yes
+
+- name: create rabbitmq admin user
+  shell: |
+    systemctl start rabbitmq-server
+    rabbitmqctl add_user admin admin 2>/dev/null || true
+    rabbitmqctl set_user_tags admin administrator
+    rabbitmqctl set_permissions -p / admin ".*" ".*" ".*"
+  become: yes
+
+- name: start and enable rabbitmq
+  systemd:
+    name: rabbitmq-server
+    state: restarted
+    enabled: yes
+  become: yes
+
+- name: wait for management API to be ready
+  shell: |
+    for i in $(seq 1 30); do
+      if curl -sf -u admin:admin http://localhost:15672/api/overview > /dev/null 2>&1; then
+        exit 0
+      fi
+      sleep 2
+    done
+    exit 1
+  become: yes

--- a/test/deploy/linux/nrdot-rabbitmq/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-rabbitmq/install/rhel/roles/configure/tasks/main.yml
@@ -1,33 +1,35 @@
 ---
-- name: install rabbitmq signing keys and repos
+- name: install docker
   shell: |
-    curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | bash
-    curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | bash
+    if command -v docker &>/dev/null; then
+      echo "Docker already installed"
+      exit 0
+    fi
+    if [ -f /etc/os-release ]; then
+      . /etc/os-release
+      if [ "$ID" = "amzn" ]; then
+        yum install -y docker
+        systemctl start docker
+        systemctl enable docker
+      else
+        yum install -y yum-utils
+        yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        yum install -y docker-ce docker-ce-cli containerd.io
+        systemctl start docker
+        systemctl enable docker
+      fi
+    fi
   become: yes
 
-- name: install erlang and rabbitmq-server
+- name: run rabbitmq container with management plugin
   shell: |
-    yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_erlang' --enablerepo='rabbitmq_rabbitmq-server' || true
-    yum install -y --enablerepo='rabbitmq_erlang' --enablerepo='rabbitmq_rabbitmq-server' erlang rabbitmq-server
-  become: yes
-
-- name: enable rabbitmq management plugin
-  shell: rabbitmq-plugins enable rabbitmq_management
-  become: yes
-
-- name: create rabbitmq admin user
-  shell: |
-    systemctl start rabbitmq-server
-    rabbitmqctl add_user admin admin 2>/dev/null || true
-    rabbitmqctl set_user_tags admin administrator
-    rabbitmqctl set_permissions -p / admin ".*" ".*" ".*"
-  become: yes
-
-- name: start and enable rabbitmq
-  systemd:
-    name: rabbitmq-server
-    state: restarted
-    enabled: yes
+    docker run -d \
+      --name rabbitmq \
+      -p 5672:5672 \
+      -p 15672:15672 \
+      -e RABBITMQ_DEFAULT_USER=admin \
+      -e RABBITMQ_DEFAULT_PASS=admin \
+      rabbitmq:3-management
   become: yes
 
 - name: wait for management API to be ready


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                 
  - Add NRDOT Collector recipes for RabbitMQ monitoring on Debian/Ubuntu and RHEL/CentOS/Amazon Linux                                                                                                                                                                               
  - Add deployer test definitions and Ansible deploy scripts for CI validation                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Test coverage                                                                                                                                                                                                                                                           
  - `rhel9-amd64` — RHEL 9                                                                                                                                                                                                                                                   
  - `ubuntu22-amd64` — Ubuntu 22.04                                                                                                                                                                                                                                          
  - `ubuntu24-amd64` — Ubuntu 24.04
  - `al2023-amd64` — Amazon Linux 2023                                                                                                                                                                                                                                       