### PR TITLE
fix: add targeted discoveryMode to nginx otel recipe

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/nginx-plus/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/nginx-plus/debian.yml
@@ -32,6 +32,8 @@ processMatch:
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'nginxplus_%' SINCE 10 minutes ago"
 
 preInstall:
+  discoveryMode:
+    - targeted
   info: |2
       To capture data from the NGINX Plus integration, you'll first need to install
       and run the NGINX Prometheus Exporter before running this install.

--- a/recipes/newrelic/infrastructure/nrdot/nginx-plus/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/nginx-plus/rhel.yml
@@ -49,6 +49,8 @@ processMatch:
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'nginxplus_%' SINCE 10 minutes ago"
 
 preInstall:
+  discoveryMode:
+    - targeted
   info: |2
       To capture data from the NGINX Plus integration, you'll first need to install
       and run the NGINX Prometheus Exporter before running this install.

--- a/recipes/newrelic/infrastructure/nrdot/nginx/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/nginx/debian.yml
@@ -32,6 +32,8 @@ processMatch:
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'nginx.%' SINCE 10 minutes ago"
 
 preInstall:
+  discoveryMode:
+    - targeted
   info: |2
       To capture data from the NGINX integration, you'll first need to configure
       the HTTP stub status module in your nginx config before running this install.

--- a/recipes/newrelic/infrastructure/nrdot/nginx/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/nginx/rhel.yml
@@ -48,6 +48,8 @@ processMatch:
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'nginx.%' SINCE 10 minutes ago"
 
 preInstall:
+  discoveryMode:
+    - targeted
   info: |2
       To capture data from the NGINX integration, you'll first need to configure
       the HTTP stub status module in your nginx config before running this install.


### PR DESCRIPTION
## What this fixes

Without \`discoveryMode: [targeted]\` in the \`preInstall\` block, running \`newrelic install -n nrdot-collector-nginx\` via guided install would trigger auto-discovery and install the Infrastructure agent and log forwarder alongside the NRDOT collector — even when the user only requested NGINX monitoring.

Adding \`discoveryMode: [targeted]\` suppresses this auto-discovery, ensuring only the explicitly requested recipe is installed.

## Changes

- \`recipes/newrelic/infrastructure/nrdot/nginx/debian.yml\` — added \`preInstall.discoveryMode: [targeted]\`
- \`recipes/newrelic/infrastructure/nrdot/nginx/rhel.yml\` — added \`preInstall.discoveryMode: [targeted]\`

## Testing

Tested manually on an Ubuntu 22.04 (amd64) EC2 instance:

1. Installed nginx and configured stub_status at \`http://127.0.0.1:8080/nginx_status\`
2. Ran the install command **without** \`NEW_RELIC_CLI_SKIP_CORE=1\` to simulate a real guided install:

\`\`\`bash
sudo NEW_RELIC_API_KEY=key \
     NEW_RELIC_ACCOUNT_ID=id\
     NEW_RELIC_REGION=staging \
     NR_CLI_NGINX_STATUS_URL="http://127.0.0.1:8080/nginx_status" \
     NR_CLI_NGINX_DEPLOYMENT_NAME="test-discoverymode" \
     /usr/local/bin/newrelic install -n nrdot-collector-nginx --recipePath /tmp/nrdot-nginx-debian.yml -y
\`\`\`

3. Verified post-install:

Only the NRDOT collector was installed — no infrastructure agent or log forwarder.