### PR TITLE
feat: Add Ubuntu 26.04 LTS (Resolute Raccoon) support

### DIFF
--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -22,6 +22,7 @@ keywords:
   - Bionic
   - Focal
   - Jammy
+  - Resolute
   - Noble
 
 processMatch: []

--- a/test/definitions/infra-agent/ubuntu26-infra.json
+++ b/test/definitions/infra-agent/ubuntu26-infra.json
@@ -1,0 +1,35 @@
+{
+    "global_tags": {
+      "owning_team": "virtuoso",
+      "Environment": "development",
+      "Department": "product",
+      "Product": "virtuoso"
+    },
+
+    "resources": [
+      {
+        "id": "host1",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "ami_name": "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-????????",
+        "user_name": "ubuntu"
+      }
+    ],
+
+    "instrumentations": {
+      "resources": [
+        {
+          "id": "nr_infra_ubuntu26",
+          "resource_ids": ["host1"],
+          "provider": "newrelic",
+          "source_repository": "https://github.com/newrelic/open-install-library",
+          "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
+          "params": {
+            "validate_output": "Infrastructure Agent\\s+\\(installed\\)",
+            "local_recipes": true
+          }
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
- Adds Ubuntu 26.04 LTS "Resolute Raccoon" support to the infrastructure agent recipe and automated test infrastructure.                                                                                                                                                     
                                                                                                                                                                                                                                                                           
Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
  
Recipe                                                                                                                                                                                                                                                                     
  - Add Resolute to the keywords list in recipes/newrelic/infrastructure/ubuntu.yml to enable guided install support for Ubuntu 26.04                                                                                                                                        
                                                                                                                                                                                                                                                                            Test definitions                                                                                                                                                                                                                                                           
  - Add test/definitions/infra-agent/ubuntu26-infra.json to run automated infra agent validation tests against Ubuntu 26.04 EC2 instances                                                                                                                                    
                                                                                                                                                                                                                                                                             Out of scope                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
- Log forwarder (fluent-bit) support for Ubuntu 26.04 is not included — blocked on the logging team confirming fluent-bit support for this platform.