### PR TITLE
[ebpf] Release 1.4.1 changes

### DIFF
--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -286,8 +286,6 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
-          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
-          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint

--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -286,6 +286,8 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
+          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
+          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint

--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -293,8 +293,8 @@ install:
           otlpProxy:
             # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
             host: "${NEW_RELIC_PROXY_HOST:-}"
-            # -- Proxy port (default: 8080)
-            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy port (e.g., 8080). Required when host is set.
+            port: ${NEW_RELIC_PROXY_PORT:-}
             # -- Proxy URL scheme: http or https (default: http)
             scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
             # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.

--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -118,20 +118,20 @@ install:
             exit 15
           fi
         - |
-          # Check kernel version - eBPF agent requires kernel 5.4 or higher
+          # Check kernel version - eBPF agent requires kernel 5.8 or higher
           KERNEL_VERSION=$(uname -r | cut -d'-' -f1)
           KERNEL_MAJOR=$(echo $KERNEL_VERSION | cut -d'.' -f1)
           KERNEL_MINOR=$(echo $KERNEL_VERSION | cut -d'.' -f2)
 
-          # Convert to comparable format (e.g., 5.4 becomes 504, 4.19 becomes 419)
+          # Convert to comparable format (e.g., 5.8 becomes 508, 4.19 becomes 419)
           KERNEL_NUM=$((KERNEL_MAJOR * 100 + KERNEL_MINOR))
-          REQUIRED_KERNEL_NUM=504  # 5.4
+          REQUIRED_KERNEL_NUM=508  # 5.8
 
           if [ $KERNEL_NUM -lt $REQUIRED_KERNEL_NUM ]; then
             echo ""
-            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.4 or higher." >&2
+            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.8 or higher." >&2
             echo -e "Current kernel version: $KERNEL_VERSION" >&2
-            echo -e "Please upgrade your kernel to version 5.4 or higher and re-run the installation." >&2
+            echo -e "Please upgrade your kernel to version 5.8 or higher and re-run the installation." >&2
             echo ""
             exit 17
           fi

--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -290,6 +290,22 @@ install:
           customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
+          # -- HTTP/HTTPS proxy configuration for OTLP endpoint
+          # Allows routing telemetry data through corporate proxies
+          otlpProxy:
+            # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
+            host: "${NEW_RELIC_PROXY_HOST:-}"
+            # -- Proxy port (default: 8080)
+            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy URL scheme: http or https (default: http)
+            scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
+            # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.
+            user: "${NEW_RELIC_PROXY_USER:-}"
+            # -- Password for proxy Basic Authentication (optional). Only used with user.
+            password: "${NEW_RELIC_PROXY_PASS:-}"
+            # -- Alternative: Complete proxy URL (overrides individual settings above)
+            # Format: http://[user:pass@]host:port
+            url: "${NEW_RELIC_PROXY_URL:-}"
           # -- To configure the log level in increasing order of verboseness.
           # -- OFF, FATAL, ERROR, WARNING, INFO, DEBUG
           logLevel: "INFO"

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -275,6 +275,8 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
+          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
+          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -279,6 +279,22 @@ install:
           customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
+          # -- HTTP/HTTPS proxy configuration for OTLP endpoint
+          # Allows routing telemetry data through corporate proxies
+          otlpProxy:
+            # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
+            host: "${NEW_RELIC_PROXY_HOST:-}"
+            # -- Proxy port (default: 8080)
+            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy URL scheme: http or https (default: http)
+            scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
+            # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.
+            user: "${NEW_RELIC_PROXY_USER:-}"
+            # -- Password for proxy Basic Authentication (optional). Only used with user.
+            password: "${NEW_RELIC_PROXY_PASS:-}"
+            # -- Alternative: Complete proxy URL (overrides individual settings above)
+            # Format: http://[user:pass@]host:port
+            url: "${NEW_RELIC_PROXY_URL:-}"
           # -- To configure the log level in increasing order of verboseness.
           # -- OFF, FATAL, ERROR, WARNING, INFO, DEBUG
           logLevel: "INFO"

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -107,20 +107,20 @@ install:
             exit 15
           fi
         - |
-          # Check kernel version - eBPF agent requires kernel 5.4 or higher
+          # Check kernel version - eBPF agent requires kernel 5.8 or higher
           KERNEL_VERSION=$(uname -r | cut -d'-' -f1)
           KERNEL_MAJOR=$(echo $KERNEL_VERSION | cut -d'.' -f1)
           KERNEL_MINOR=$(echo $KERNEL_VERSION | cut -d'.' -f2)
           
-          # Convert to comparable format (e.g., 5.4 becomes 504, 4.19 becomes 419)
+          # Convert to comparable format (e.g., 5.8 becomes 508, 4.19 becomes 419)
           KERNEL_NUM=$((KERNEL_MAJOR * 100 + KERNEL_MINOR))
-          REQUIRED_KERNEL_NUM=504  # 5.4
+          REQUIRED_KERNEL_NUM=508  # 5.8
           
           if [ $KERNEL_NUM -lt $REQUIRED_KERNEL_NUM ]; then
             echo ""
-            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.4 or higher." >&2
+            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.8 or higher." >&2
             echo -e "Current kernel version: $KERNEL_VERSION" >&2
-            echo -e "Please upgrade your kernel to version 5.4 or higher and re-run the installation." >&2
+            echo -e "Please upgrade your kernel to version 5.8 or higher and re-run the installation." >&2
             echo ""
             exit 17
           fi

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -282,8 +282,8 @@ install:
           otlpProxy:
             # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
             host: "${NEW_RELIC_PROXY_HOST:-}"
-            # -- Proxy port (default: 8080)
-            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy port (e.g., 8080). Required when host is set.
+            port: ${NEW_RELIC_PROXY_PORT:-}
             # -- Proxy URL scheme: http or https (default: http)
             scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
             # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -275,8 +275,6 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
-          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
-          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -275,6 +275,8 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
+          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
+          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -279,6 +279,22 @@ install:
           customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
+          # -- HTTP/HTTPS proxy configuration for OTLP endpoint
+          # Allows routing telemetry data through corporate proxies
+          otlpProxy:
+            # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
+            host: "${NEW_RELIC_PROXY_HOST:-}"
+            # -- Proxy port (default: 8080)
+            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy URL scheme: http or https (default: http)
+            scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
+            # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.
+            user: "${NEW_RELIC_PROXY_USER:-}"
+            # -- Password for proxy Basic Authentication (optional). Only used with user.
+            password: "${NEW_RELIC_PROXY_PASS:-}"
+            # -- Alternative: Complete proxy URL (overrides individual settings above)
+            # Format: http://[user:pass@]host:port
+            url: "${NEW_RELIC_PROXY_URL:-}"
           # -- To configure the log level in increasing order of verboseness.
           # -- OFF, FATAL, ERROR, WARNING, INFO, DEBUG
           logLevel: "INFO"

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -107,20 +107,20 @@ install:
             exit 15
           fi
         - |
-          # Check kernel version - eBPF agent requires kernel 5.4 or higher
+          # Check kernel version - eBPF agent requires kernel 5.8 or higher
           KERNEL_VERSION=$(uname -r | cut -d'-' -f1)
           KERNEL_MAJOR=$(echo $KERNEL_VERSION | cut -d'.' -f1)
           KERNEL_MINOR=$(echo $KERNEL_VERSION | cut -d'.' -f2)
           
-          # Convert to comparable format (e.g., 5.4 becomes 504, 4.19 becomes 419)
+          # Convert to comparable format (e.g., 5.8 becomes 508, 4.19 becomes 419)
           KERNEL_NUM=$((KERNEL_MAJOR * 100 + KERNEL_MINOR))
-          REQUIRED_KERNEL_NUM=504  # 5.4
+          REQUIRED_KERNEL_NUM=508  # 5.8
           
           if [ $KERNEL_NUM -lt $REQUIRED_KERNEL_NUM ]; then
             echo ""
-            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.4 or higher." >&2
+            echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.8 or higher." >&2
             echo -e "Current kernel version: $KERNEL_VERSION" >&2
-            echo -e "Please upgrade your kernel to version 5.4 or higher and re-run the installation." >&2
+            echo -e "Please upgrade your kernel to version 5.8 or higher and re-run the installation." >&2
             echo ""
             exit 17
           fi

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -282,8 +282,8 @@ install:
           otlpProxy:
             # -- Proxy hostname (e.g., proxy.example.com). If empty, no proxy is used.
             host: "${NEW_RELIC_PROXY_HOST:-}"
-            # -- Proxy port (default: 8080)
-            port: ${NEW_RELIC_PROXY_PORT:-8080}
+            # -- Proxy port (e.g., 8080). Required when host is set.
+            port: ${NEW_RELIC_PROXY_PORT:-}
             # -- Proxy URL scheme: http or https (default: http)
             scheme: "${NEW_RELIC_PROXY_SCHEME:-http}"
             # -- Username for proxy Basic Authentication (optional). If empty, no authentication is used.

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -275,8 +275,6 @@ install:
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
-          # Only overridden when both customOtlpEndpoint and this field are explicitly set.
-          customOtlpEndpointTlsEnabled: true
           # -- Path to custom certificates for OTLP endpoint TLS.
           customOtlpEndpointTlsCertPath: ""
           # -- HTTP/HTTPS proxy configuration for OTLP endpoint


### PR DESCRIPTION
This PR updates the eBPF agent recipes for the `1.4.1` release across all supported Linux distributions (AWS Linux, CentOS, Ubuntu) with two changes:

- Bump minimum kernel requirement from `5.4` to `5.8` — The eBPF agent now requires Linux kernel `5.8` or higher. All kernel version checks and error messages have been updated to reflect this new minimum.
- Add proxy support for the OTLP endpoint — A new `otlpProxy` configuration block is injected into the generated YAML config, allowing telemetry data to be routed through corporate HTTP/HTTPS proxies. Configuration is driven by environment variables:

  - `NEW_RELIC_PROXY_HOST` — proxy hostname
  - `NEW_RELIC_PROXY_PORT` — proxy port
  - `NEW_RELIC_PROXY_SCHEME` — http or https (default: http)
  - `NEW_RELIC_PROXY_USER` / `NEW_RELIC_PROXY_PASS` — optional Basic Auth credentials
  - `NEW_RELIC_PROXY_URL` — alternative complete proxy URL (overrides individual fields)