### PR TITLE
fix: add support for ubuntu26 and some fixes

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -14,7 +14,7 @@ installTargets:
   - type: host
     os: linux
     platform: ubuntu
-    platformVersion: "(16|18|20|22|24)\\.04"
+    platformVersion: "(16|18|20|22|24|26)\\.04"
 
 keywords:
   - AgentControl
@@ -173,7 +173,7 @@ install:
         DEBIAN_CODENAME:
           sh: awk -F= '/VERSION_CODENAME/ {print $2}' /etc/os-release
         DEBIAN_VERSION_CODENAME:
-          sh: cat /etc/os-release | grep "VERSION=\"[0-9] " | awk -F " " '{print $2}' | sed 's/[()"]//g'
+          sh: cat /etc/os-release | grep "VERSION=\"[0-9]" | awk -F " " '{print $2}' | sed 's/[()"]//g'
 
     log_ssl_ciphers:
       cmds:
@@ -216,7 +216,8 @@ install:
     add_gpg_key:
       cmds:
         - |
-          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | gpg --dearmor --batch --yes -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
+          mkdir -p /etc/apt/keyrings
+          curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | gpg --dearmor --batch --yes -o /etc/apt/keyrings/newrelic-infra.gpg
       silent: true
 
     add_nr_source:
@@ -229,17 +230,17 @@ install:
           fi
 
           if [ -n "{{.DEBIAN_CODENAME}}" ]; then
-            printf "deb [arch="$ARCH"] {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
-            printf "\ndeb [arch="$ARCH"] {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/apt {{.DEBIAN_CODENAME}} main" | tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch="$ARCH" signed-by=/etc/apt/keyrings/newrelic-infra.gpg] {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/apt {{.DEBIAN_CODENAME}} main" | tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "\ndeb [arch="$ARCH" signed-by=/etc/apt/keyrings/newrelic-infra.gpg] {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/apt {{.DEBIAN_CODENAME}} main" | tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           else
-            printf "deb [arch="$ARCH"] {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
-            printf "\ndeb [arch="$ARCH"] {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "deb [arch="$ARCH" signed-by=/etc/apt/keyrings/newrelic-infra.gpg] {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | tee /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
+            printf "\ndeb [arch="$ARCH" signed-by=/etc/apt/keyrings/newrelic-infra.gpg] {{.NEW_RELIC_DOWNLOAD_URL}}preview/linux/apt {{.DEBIAN_VERSION_CODENAME}} main" | tee -a /etc/apt/sources.list.d/newrelic-infra.list > /dev/null
           fi
       vars:
         DEBIAN_CODENAME:
           sh: awk -F= '/VERSION_CODENAME/ {print $2}' /etc/os-release
         DEBIAN_VERSION_CODENAME:
-          sh: cat /etc/os-release | grep "VERSION=\"[0-9] " | awk -F " " '{print $2}' | sed 's/[()"]//g'
+          sh: cat /etc/os-release | grep "VERSION=\"[0-9]" | awk -F " " '{print $2}' | sed 's/[()"]//g'
       silent: true
 
     update_apt_nr_source:

--- a/test/definitions/agent-control/debians/ubuntu26-agent-control.json
+++ b/test/definitions/agent-control/debians/ubuntu26-agent-control.json
@@ -1,0 +1,39 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-resolute-26.??-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_agent_control",
+        "resource_ids": ["host1"],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/agent-control/debian.yml",
+          "validate_output": "Agent Control\\s+\\(installed\\)",
+          "recipe_targeted": "agent-control",
+          "use_organization_id": true,
+          "nr_host_fleet_id": "[credential:secrets:nrHostFleetId]",
+          "use_system_identity_auth": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
  ### Changes

  - Added 26 to platformVersion regex for Ubuntu 26.04 LTS support
  - Modernized APT GPG key handling: moved keys to `/etc/apt/keyrings/` with `signed-by=` parameter (follows modern APT best practices, eliminates deprecation warnings, improves security)
  - Fixed DEBIAN_VERSION_CODENAME parser regex to correctly extract codenames from Debian