### PR TITLE
chore: exclude nrdot tests from daily scheduled non-regression jobs

### DIFF
--- a/.github/deprecated-tests.json
+++ b/.github/deprecated-tests.json
@@ -1,4 +1,7 @@
 {
+  "_notes": {
+    "nrdot": "TEMPORARY: NRDOT tests (test/definitions/nrdot/**) are excluded from the daily scheduled non-regression jobs (US + EU) because real-time customer installs of NRDOT recipes are currently very minimal. PR checks (validation.yml) still run the relevant nrdot tests whenever a nrdot recipe or test definition is modified, so coverage is preserved on changes. Revisit and re-enable in the daily schedule once real-time install volume increases."
+  },
   "exclude": [
     "test/definitions-eu/apm/dotNet/linux/debian10-nginx-aspnetcore.json",
     "test/definitions-eu/apm/dotNet/linux/ubuntu20-apache-aspnetcore.json",
@@ -51,6 +54,28 @@
     "test/definitions/ohi/linux/mysql-ubuntu24.json",
     "test/definitions/ohi/linux/postgres-debian-targeted-failure.json",
     "test/definitions/ohi/linux/postgres-debian.json",
-    "test/definitions/ohi/linux/postgres-rhel.json"
+    "test/definitions/ohi/linux/postgres-rhel.json",
+
+    "test/definitions/nrdot/elasticsearch/al2-amd64.json",
+    "test/definitions/nrdot/elasticsearch/al2023-amd64.json",
+    "test/definitions/nrdot/elasticsearch/ubuntu22-amd64.json",
+    "test/definitions/nrdot/elasticsearch/ubuntu24-amd64.json",
+    "test/definitions/nrdot/kafka/al2023-amd64.json",
+    "test/definitions/nrdot/kafka/al2023-arm64.json",
+    "test/definitions/nrdot/kafka/debian-amd64.json",
+    "test/definitions/nrdot/kafka/debian-arm64.json",
+    "test/definitions/nrdot/kafka/rhel9-amd64.json",
+    "test/definitions/nrdot/kafka/ubuntu22-amd64.json",
+    "test/definitions/nrdot/kafka/ubuntu22-arm64.json",
+    "test/definitions/nrdot/nginx/al2-amd64.json",
+    "test/definitions/nrdot/nginx/al2023-amd64.json",
+    "test/definitions/nrdot/nginx/al2023-arm64.json",
+    "test/definitions/nrdot/nginx/rhel9-amd64.json",
+    "test/definitions/nrdot/nginx/ubuntu22-amd64.json",
+    "test/definitions/nrdot/nginx/ubuntu24-amd64.json",
+    "test/definitions/nrdot/rabbitmq/al2023-amd64.json",
+    "test/definitions/nrdot/rabbitmq/rhel9-amd64.json",
+    "test/definitions/nrdot/rabbitmq/ubuntu22-amd64.json",
+    "test/definitions/nrdot/rabbitmq/ubuntu24-amd64.json"
   ]
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
   
  Excludes all 21 NRDOT test definitions from the daily scheduled non-regression workflows (US and EU) by adding them to `.github/deprecated-tests.json`. 

This exclusion is **temporary** — to be revisited once real-time install volume for NRDOT recipes picks back up. A `_notes.nrdot` field in the exclusion file documents the rationale.                             
