### PR TITLE
fix(install): remove only NR key from legacy APT keyring instead of deleting entire file

### DIFF
--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -228,9 +228,23 @@ install:
     add_gpg_key:
       cmds:
         - |
-          # Remove the key from the legacy keyring if it exists
+          # Remove our per-repo key file before re-adding (safe - only removes our own key)
           sudo rm -f /etc/apt/trusted.gpg.d/newrelic-infra.gpg 2>/dev/null
-          sudo rm -f /etc/apt/trusted.gpg 2>/dev/null
+
+          # Remove ONLY the New Relic key from the legacy keyring if present
+          # This avoids the APT deprecation warning without deleting other third-party keys
+          if [ -f /etc/apt/trusted.gpg ]; then
+            NR_KEY_ID=$(gpg --no-default-keyring --keyring /etc/apt/trusted.gpg \
+              --list-keys --with-colons 2>/dev/null \
+              | grep -B1 "infrastructure-eng@newrelic.com" \
+              | grep "^pub" | cut -d: -f5)
+            if [ -n "$NR_KEY_ID" ]; then
+              sudo gpg --no-default-keyring --batch --yes \
+                --keyring gnupg-ring:/etc/apt/trusted.gpg \
+                --delete-keys "$NR_KEY_ID" 2>/dev/null || true
+            fi
+          fi
+
           # Add the key to the correct directory
           # Use SHA256 key for Debian 13 (trixie) to avoid SHA1 deprecation issues
           CODENAME=""

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -210,9 +210,23 @@ install:
     add_gpg_key:
       cmds:
         - |
-          # Remove the key from the legacy keyring if it exists
+          # Remove our per-repo key file before re-adding (safe - only removes our own key)
           sudo rm -f /etc/apt/trusted.gpg.d/newrelic-infra.gpg 2>/dev/null
-          sudo rm -f /etc/apt/trusted.gpg 2>/dev/null
+
+          # Remove ONLY the New Relic key from the legacy keyring if present
+          # This avoids the APT deprecation warning without deleting other third-party keys
+          if [ -f /etc/apt/trusted.gpg ]; then
+            NR_KEY_ID=$(gpg --no-default-keyring --keyring /etc/apt/trusted.gpg \
+              --list-keys --with-colons 2>/dev/null \
+              | grep -B1 "infrastructure-eng@newrelic.com" \
+              | grep "^pub" | cut -d: -f5)
+            if [ -n "$NR_KEY_ID" ]; then
+              sudo gpg --no-default-keyring --batch --yes \
+                --keyring gnupg-ring:/etc/apt/trusted.gpg \
+                --delete-keys "$NR_KEY_ID" 2>/dev/null || true
+            fi
+          fi
+
           # Add the key to the correct directory
           curl -s {{.NEW_RELIC_DOWNLOAD_URL}}infrastructure_agent/keys/newrelic_apt_key_current.gpg | sudo gpg --dearmor --batch --yes -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
       silent: true


### PR DESCRIPTION
## Summary

- The `add_gpg_key` task in `debian.yml` and `ubuntu.yml` previously ran `sudo rm -f /etc/apt/trusted.gpg` which deletes the **entire system-wide legacy APT keyring**, breaking `apt` for any third-party repo (Docker, NodeSource, Chrome, etc.) whose key was stored there.
- Replaced with a targeted removal that only deletes the New Relic key (`infrastructure-eng@newrelic.com`) from the legacy keyring, leaving other keys intact.
- The APT deprecation warning is still resolved because the NR key is removed from the legacy location and freshly added to `/etc/apt/trusted.gpg.d/newrelic-infra.gpg`.

## Problem

PR #1197 introduced `sudo rm -f /etc/apt/trusted.gpg` to fix APT deprecation warnings about the NR key being in the legacy keyring. However, this deletes ALL keys from ALL repos — not just the NR key. On systems with other third-party repos configured via the old `apt-key add` method, this causes:

- `apt-get update` fails with `NO_PUBKEY` errors for those repos
- `apt-get install` breaks for packages from those repos
- The NR install itself succeeds, so there's no obvious error at install time

Reported via customer feedback: [NR-511322](https://new-relic.atlassian.net/browse/NR-511322)

## Fix

Instead of deleting `/etc/apt/trusted.gpg` entirely, the script now:
1. Checks if the legacy keyring file exists
2. Looks up only the NR key by UID (`infrastructure-eng@newrelic.com`)
3. Removes only that specific key using `gpg --delete-keys`
4. Fails silently if the key isn't found

## Files Changed

- `recipes/newrelic/infrastructure/debian.yml`
- `recipes/newrelic/infrastructure/ubuntu.yml`

## Test plan

- [ ] Spin up Debian 12 (Bookworm) with third-party key in `/etc/apt/trusted.gpg` + NR key in legacy keyring → verify only NR key is removed, other keys intact
- [ ] Spin up Ubuntu 24.04 with same setup → same verification
- [ ] Verify no APT deprecation warning for NR after install
- [ ] Verify `apt-get update` works for all configured repos post-install
- [ ] Run existing deployer test definitions (`ubuntu24-infra.json`)


[NR-511322]: https://new-relic.atlassian.net/browse/NR-511322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ