### PR TITLE
chore(renovate): fix renovate rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,8 +19,7 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "newrelic-agent-control",
-      "packageNameTemplate": "newrelic/newrelic-agent-control",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "packageNameTemplate": "newrelic/newrelic-agent-control"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Fix the renovate rule to update the Agent Control version.

Why the rule isn't necessary here (AI explanation):

The newrelic/newrelic-agent-control releases are tagged 1.15.0, 1.14.1, 1.14.0, … — already valid semver, no decoration. When extractVersionTemplate is omitted, Renovate uses each tag as-is, applies its configured versioning (defaults to semver for github-releases), sorts, and finds the latest. That's exactly what we want.

When extractVersionTemplate is present, it's not a fallback — it's an assertion. Any tag that doesn't match the regex is silently dropped from the candidate set. So `^v(?<version>.*)$` against a tag like `1.15.0` doesn't gracefully fall through; it removes 1.15.0 from consideration entirely. With every tag bare, every tag gets dropped, and Renovate concludes "no newer version exists" — which is the symptom you saw.