### PR TITLE
fix(infra-windows): quiet noisy install output for cleaner UX

### DIFF
--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -257,12 +257,9 @@ install:
               Add-Content -Path $Path -Value "proxy: $env:HTTPS_PROXY" -Encoding utf8
             }
             Add-Content -Path $Path -Value $CustomAttrs -Encoding utf8
-            Write-Host "Configuration written successfully"
           }
 
           if ($existingService) {
-            Write-Host "Existing service detected, performing upgrade..."
-
             # Write fresh config before calling installer.ps1 — in upgrade mode
             # installer.ps1 preserves the existing config, so this ensures the service
             # starts with valid settings (including license_key) on the first start.
@@ -285,7 +282,6 @@ install:
               Write-Host -ForegroundColor Red "installer.ps1 not found in extracted MSI"
               exit 1
             }
-            Write-Host "Found installer.ps1 at: $($installerScript.FullName)"
 
             $scriptDir = $installerScript.DirectoryName
             Push-Location $scriptDir
@@ -303,7 +299,6 @@ install:
               Pop-Location
             }
           } else {
-            Write-Host "No existing service detected, performing fresh install..."
             $process = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i `"$MSI_PATH`" GENERATE_CONFIG=true LICENSE_KEY=`"$LICENSE_KEY`" /L*v `"$env:TEMP\\msi_install.log`"" -Wait -NoNewWindow -PassThru
             if ($process.ExitCode -ne 0) {
               Write-Host -ForegroundColor Red "MSI installation failed with exit code: $($process.ExitCode)"
@@ -317,7 +312,7 @@ install:
             # MSI starts the service with a yamlgen-generated config (license_key only).
             # Rewrite config fresh and restart so all required settings take effect.
             Write-FreshConfig -Path $InfraConfig -LicenseKey $LICENSE_KEY -Region $NEW_RELIC_REGION -CustomAttrs $customAttributes
-            Restart-Service -Name "newrelic-infra" -Force -ErrorAction SilentlyContinue
+            Restart-Service -Name "newrelic-infra" -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
           }
           '
 
@@ -333,14 +328,13 @@ install:
           if ($service.Status -ne "Running") {
               try {
                   Start-Service -Name $serviceName
-                  Write-Host "New Relic infrastructure agent for Windows installed and started"  -ForegroundColor Green
               }
               catch {
                   Write-Host "Error starting service: $_" -ForegroundColor Red
               }
           }
-          else {
-              Write-Host "$serviceName is already running" -ForegroundColor Green
+          if ((Get-Service $serviceName -ErrorAction SilentlyContinue).Status -eq "Running") {
+              Write-Host "New Relic Infrastructure Agent is running" -ForegroundColor Green
           }
           '
 

--- a/test/definitions-eu/apm/dotNet/windows/iis-blank.json
+++ b/test/definitions-eu/apm/dotNet/windows/iis-blank.json
@@ -12,7 +12,7 @@
       "type": "ec2",
       "size": "t3.small",
       "is_windows": true,
-      "ami_name": "Windows_Server-2019-English-Full-HyperV-*",
+      "ami_name": "Windows_Server-2019-English-Full-Base-*",
       "user_name": "Administrator"
   }],
 


### PR DESCRIPTION
### What
Trims the Windows infra-agent recipe install output so it reads cleanly. Output-only change — no install/upgrade behavior is affected.

### Why
Customers running the recipe install saw output that looked confusing or worrying:
- Repeated `WARNING: Waiting for service 'newrelic-infra' to stop...` — just PowerShell's `Restart-Service` chatter, not a real issue.
- Internal debug lines (`No existing service detected...`, `Configuration written successfully`, etc.) meant only for developers.
- `newrelic-infra is already running` on a **fresh** install — confusing, since `install_infra` now starts the service itself, so `start_infra` always hit the "already running" branch.

### Changes
- Suppress `Restart-Service` warning chatter (`-WarningAction SilentlyContinue`).
- Remove debug-only `Write-Host` narration.
- Unify `start_infra` into one clear confirmation: `New Relic Infrastructure Agent is running`.
- Kept all error messages and useful confirmations (status check, infra key).

### Result (fresh install)
```
==> Installing Infrastructure Agent
Installing latest version of New Relic Infrastructure Agent
New Relic Infrastructure Agent is running
Agent status check ok.
Infra key: i-0734fdea54a400372

```
