### PR TITLE
NR-568690: Adding ubuntu 26 (resolute) support for logs recipe

### DIFF
--- a/recipes/newrelic/infrastructure/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/linux-logs.yml
@@ -33,7 +33,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "(((16|18|20|21|22|24)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
+    platformVersion: "(((16|18|20|21|22|24|26)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
   - type: host
     os: linux
     platform: "redhat"

--- a/test/definitions/logging/ubuntu26-logs.json
+++ b/test/definitions/logging/ubuntu26-logs.json
@@ -1,0 +1,36 @@
+{
+    "global_tags": {
+      "owning_team": "virtuoso",
+      "Environment": "development",
+      "Department": "product",
+      "Product": "virtuoso"
+    },
+
+    "resources": [
+      {
+        "id": "host1",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "ami_name": "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.??-amd64-server-????????",
+        "user_name": "ubuntu"
+      }
+    ],
+
+    "instrumentations": {
+      "resources": [
+        {
+          "id": "nr_logging_ubuntu26",
+          "resource_ids": ["host1"],
+          "provider": "newrelic",
+          "source_repository": "https://github.com/newrelic/open-install-library",
+          "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
+          "params": {
+            "newrelic_cli_option": "-n logs-integration",
+            "validate_output": "Logs Integration\\s+\\(installed\\)",
+            "local_recipes": true
+          }
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
## Summary
Adds **Ubuntu 26.04 (resolute)** support to the `logs-integration` recipe, modeled on the Ubuntu 24.04 commit (8cdc4e2).

- `recipes/newrelic/infrastructure/logs/linux-logs.yml` — added `26` to the Ubuntu `installTargets` `platformVersion` regex so `newrelic install -n logs-integration` matches Ubuntu 26.04.
- `test/definitions/logging/ubuntu26-logs.json` — new validation definition (amd64), mirroring `ubuntu24-logs.json` with the resolute AMI pattern.

## ⚠️ Draft — validation will fail until infrastructure-agent ships for resolute
This recipe depends on `infrastructure-agent-installer`, which runs `apt-get install newrelic-infra`. The `newrelic-infra` package is **not yet published for the `resolute` codename** (checked staging + prod: only on-host integrations and fluent-bit are present, 0 agent entries). So the `ubuntu26-logs` validation will fail until the agent is released.

**Plan:** keep this as a draft; once `newrelic-infra` is published for resolute (staging + prod), re-trigger the workflows and mark ready for review.

Related: Fluent Bit support for Ubuntu 26.04 in `newrelic/fluent-bit-package` (prerelease e2e green; awaiting the same infra-agent dependency).