### PR TITLE
NR-568690: Adding ubuntu 26 (resolute) support for logs recipe

### DIFF
--- a/recipes/newrelic/infrastructure/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/linux-logs.yml
@@ -33,7 +33,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "(((16|18|20|21|22|24)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
+    platformVersion: "(((16|18|20|21|22|24|26)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
   - type: host
     os: linux
     platform: "redhat"

--- a/recipes/newrelic/infrastructure/logs/linux-logs.yml
+++ b/recipes/newrelic/infrastructure/logs/linux-logs.yml
@@ -33,7 +33,7 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "(((16|18|20|21|22|24|26)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy
+    platformVersion: "(((16|18|20|21|22|24|26)\\.04)|(20.10))" # Xenial, Bionic, Focal, Hirsute, Jammy, Groovy, Resolute
   - type: host
     os: linux
     platform: "redhat"

--- a/test/definitions/logging/ubuntu26-logs.json
+++ b/test/definitions/logging/ubuntu26-logs.json
@@ -1,0 +1,36 @@
+{
+    "global_tags": {
+      "owning_team": "virtuoso",
+      "Environment": "development",
+      "Department": "product",
+      "Product": "virtuoso"
+    },
+
+    "resources": [
+      {
+        "id": "host1",
+        "provider": "aws",
+        "type": "ec2",
+        "size": "t3.micro",
+        "ami_name": "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.??-amd64-server-????????",
+        "user_name": "ubuntu"
+      }
+    ],
+
+    "instrumentations": {
+      "resources": [
+        {
+          "id": "nr_logging_ubuntu26",
+          "resource_ids": ["host1"],
+          "provider": "newrelic",
+          "source_repository": "https://github.com/newrelic/open-install-library",
+          "deploy_script_path": "test/deploy/linux/newrelic-cli/install/roles",
+          "params": {
+            "newrelic_cli_option": "-n logs-integration",
+            "validate_output": "Logs Integration\\s+\\(installed\\)",
+            "local_recipes": true
+          }
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
# Summary
Adds Ubuntu 26.04 (resolute) support to the logs-integration recipe.

### Changes
linux-logs.yml — added 26 to the Ubuntu platformVersion regex (amd64)
ubuntu26-logs.json — new amd64 validation test for resolute

### How Tested
Verified the recipe on a real Ubuntu 26.04 EC2 instance using local recipes:

`newrelic install -n logs-integration -y --debug --localRecipes ./recipes
`

Recipe matched Ubuntu 26.04 (install proceeded, not skipped as unsupported) Infra agent + Fluent Bit installed and running Logs confirmed in NRDB.

### Related
Fluent Bit 26.04 support in newrelic/fluent-bit-package (blocked on the same infra-agent dependency)