### PR TITLE
Add nrdot-ibm-mq install recipe for IBM MQ via OpenTelemetry

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml
@@ -1,0 +1,280 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+
+name: nrdot-ibm-mq
+displayName: NRDOT IBM MQ
+description: New Relic install recipe for IBM MQ monitoring via NRDOT Collector on Debian/Ubuntu.
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platformFamily: debian
+  - type: host
+    os: linux
+    platform: ubuntu
+
+keywords:
+  - IBM MQ
+  - IBMMQ
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Messaging
+  - Queue
+  - Linux
+  - Debian
+  - Ubuntu
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+
+inputVars:
+  - name: NR_CLI_IBMMQ_EXPORTER_ENDPOINT
+    prompt: "IBM MQ Prometheus exporter address (mq-metric-samples, e.g. localhost:9157): "
+    default: "localhost:9157"
+  - name: NR_CLI_IBMMQ_CLUSTER_NAME
+    prompt: "IBM MQ cluster name (optional, press Enter to skip): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'ibmmq_%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+    NRDOT_ARCH:
+      sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi
+    NRDOT_VERSION:
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.18.0"
+    COLLECTOR_DISTRO: "nrdot-collector"
+    CONFIG_DIR: "/etc/nrdot-collector"
+
+  tasks:
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: install_nrdot
+        - task: create_collector_config
+        - task: configure_service
+        - task: restart_nrdot
+        - task: assert_nrdot_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 3
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+        - |
+          # Config-only recipe: verify the existing mq_prometheus exporter is serving ibmmq_*.
+          ENDPOINT="{{.NR_CLI_IBMMQ_EXPORTER_ENDPOINT}}"
+          if ! curl -sf "http://${ENDPOINT}/metrics" 2>/dev/null | grep -q "^ibmmq_"; then
+            echo "" >&2
+            echo "Could not read IBM MQ metrics from the exporter at http://${ENDPOINT}/metrics" >&2
+            echo "Make sure the mq-metric-samples (mq_prometheus) exporter is running and serving" >&2
+            echo "ibmmq_* metrics, then re-run. Setup: https://github.com/ibm-messaging/mq-metric-samples" >&2
+            exit 132
+          fi
+
+    install_nrdot:
+      cmds:
+        - |
+          # Idempotent: skip the download if the latest version is already installed.
+          if dpkg -l | grep -q "^ii.*{{.COLLECTOR_DISTRO}} "; then
+            INSTALLED_VERSION=$(dpkg -l {{.COLLECTOR_DISTRO}} | awk '/^ii/{print $3}' | sed 's/^[0-9]*://')
+            if [ "$INSTALLED_VERSION" = "{{.NRDOT_VERSION}}" ]; then
+              echo "{{.COLLECTOR_DISTRO}} {{.NRDOT_VERSION}} is already installed. Skipping download."
+              exit 0
+            fi
+          fi
+          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
+          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb"
+          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb" \
+            --location --output "$NRDOT_DEB" 2>/dev/null
+          DEBIAN_FRONTEND=noninteractive dpkg -i "$NRDOT_DEB" > /dev/null
+          if [ $? -ne 0 ]; then
+            apt-get -o DPkg::Lock::Timeout=60 install -f -y > /dev/null
+            if [ $? -ne 0 ]; then
+              echo "Failed to install NRDOT Collector package." >&2
+              exit 1
+            fi
+          fi
+          rm -f "$NRDOT_DEB"
+
+    create_collector_config:
+      cmds:
+        - |
+          COLLECTOR_CONFIG="{{.CONFIG_DIR}}/ibmmq-collector-config.yaml"
+          ENV_FILE="{{.CONFIG_DIR}}/ibmmq-env.conf"
+          mkdir -p "{{.CONFIG_DIR}}"
+
+          # Config uses ${env:...} expansion; values come from the env file below
+          # (no in-place edits). target.name is derived from the detected host.id.
+          cat > "$COLLECTOR_CONFIG" << 'EOF'
+          extensions:
+            health_check:
+              endpoint: 0.0.0.0:13133
+          receivers:
+            prometheus/ibmmq:
+              config:
+                scrape_configs:
+                  - job_name: 'ibmmq'
+                    scrape_interval: 60s
+                    scrape_timeout: 15s
+                    static_configs:
+                      - targets: ['${env:IBMMQ_EXPORTER_ENDPOINT}']
+          processors:
+            resourcedetection:
+              detectors: [env, ec2, gcp, azure, system]
+              system:
+                resource_attributes:
+                  host.id:
+                    enabled: true
+                  host.name:
+                    enabled: true
+            filter/ibmmq-overhead:
+              metrics:
+                exclude:
+                  match_type: regexp
+                  metric_names:
+                    - "^go_.*"
+                    - "^process_.*"
+                    - "^promhttp_.*"
+                    - "^scrape_.*"
+            filter/ibmmq-queues:
+              metrics:
+                datapoint:
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.](ADMIN[.]|MQSC[.]|DEFAULT[.]|AUTH[.]|CHANNEL[.]|CHLAUTH[.]|CICS[.]|SYNCPOINT[.]|INTERNAL[.]|PENDING[.]|PROTECTION[.]|BROKER[.]|AMQP[.]|DOTNET[.]|REST[.]|RETAINED[.]|SELECTION[.]|DURABLE[.]|HIERARCHY[.]|DDELAY[.])")'
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.]CLUSTER[.](COMMAND|HISTORY)[.]QUEUE$")'
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^AMQ[.]")'
+            transform/ibmmq-cleanup:
+              metric_statements:
+                - context: resource
+                  statements:
+                    - set(attributes["target.name"], attributes["host.id"]) where attributes["host.id"] != nil
+                    - set(attributes["cluster.name"], "${env:IBMMQ_CLUSTER_NAME}") where "${env:IBMMQ_CLUSTER_NAME}" != ""
+                    - delete_key(attributes, "service.name")
+                    - delete_key(attributes, "service.instance.id")
+                    - delete_key(attributes, "server.address")
+                    - delete_key(attributes, "server.port")
+                    - delete_key(attributes, "url.scheme")
+                - context: datapoint
+                  statements:
+                    - delete_key(attributes, "instance")
+                    - delete_key(attributes, "job")
+            memory_limiter/ibmmq:
+              check_interval: 1s
+              limit_mib: 512
+              spike_limit_mib: 256
+            cumulativetodelta/ibmmq: {}
+            batch/ibmmq:
+              send_batch_size: 1000
+              timeout: 200ms
+          exporters:
+            otlphttp/ibmmq:
+              endpoint: ${env:NEW_RELIC_OTLP_ENDPOINT}
+              headers:
+                api-key: ${env:NEW_RELIC_LICENSE_KEY}
+              compression: gzip
+          service:
+            extensions: [health_check]
+            pipelines:
+              metrics/ibmmq:
+                receivers: [prometheus/ibmmq]
+                processors: [memory_limiter/ibmmq, resourcedetection, filter/ibmmq-overhead, filter/ibmmq-queues, transform/ibmmq-cleanup, cumulativetodelta/ibmmq, batch/ibmmq]
+                exporters: [otlphttp/ibmmq]
+          EOF
+
+          if [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            OTLP_ENDPOINT="https://otlp.eu01.nr-data.net"
+          elif [ "{{.NEW_RELIC_REGION}}" = "staging" ]; then
+            OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318"
+          elif [ "{{.NEW_RELIC_REGION}}" = "JP" ]; then
+            OTLP_ENDPOINT="https://otlp.jp.nr-data.net"
+          else
+            OTLP_ENDPOINT="https://otlp.nr-data.net"
+          fi
+
+          printf "IBMMQ_EXPORTER_ENDPOINT=%s\n" "{{.NR_CLI_IBMMQ_EXPORTER_ENDPOINT}}" > "$ENV_FILE"
+          printf "IBMMQ_CLUSTER_NAME=%s\n" "{{.NR_CLI_IBMMQ_CLUSTER_NAME}}" >> "$ENV_FILE"
+          printf "NEW_RELIC_OTLP_ENDPOINT=%s\n" "$OTLP_ENDPOINT" >> "$ENV_FILE"
+          printf "NEW_RELIC_LICENSE_KEY=%s\n" "{{.NEW_RELIC_LICENSE_KEY}}" >> "$ENV_FILE"
+          chmod 600 "$ENV_FILE"
+          echo "Collector config written to $COLLECTOR_CONFIG"
+
+    configure_service:
+      cmds:
+        - |
+          DROPIN_DIR="/etc/systemd/system/{{.COLLECTOR_DISTRO}}.service.d"
+          mkdir -p "$DROPIN_DIR"
+          NRDOT_BIN=$(command -v {{.COLLECTOR_DISTRO}} 2>/dev/null || echo "/usr/bin/{{.COLLECTOR_DISTRO}}")
+          {
+            printf '[Service]\n'
+            printf 'EnvironmentFile={{.CONFIG_DIR}}/ibmmq-env.conf\n'
+            printf 'ExecStart=\n'
+            printf 'ExecStart=%s --config {{.CONFIG_DIR}}/ibmmq-collector-config.yaml\n' "$NRDOT_BIN"
+          } > "$DROPIN_DIR/ibmmq-config.conf"
+          echo "Systemd drop-in configured."
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl daemon-reload
+          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+
+    assert_nrdot_status_ok:
+      cmds:
+        - |
+          MAX_RETRIES=30
+          TRIES=0
+          echo "Waiting for NRDOT Collector to start..."
+          while [ $TRIES -lt $MAX_RETRIES ]; do
+            TRIES=$((TRIES + 1))
+            if systemctl is-active --quiet {{.COLLECTOR_DISTRO}}.service && curl -sf http://localhost:13133 > /dev/null 2>&1; then
+              echo "NRDOT Collector is running and healthy."
+              echo ""
+              echo "Configuration: {{.CONFIG_DIR}}/ibmmq-collector-config.yaml"
+              echo "Environment:   {{.CONFIG_DIR}}/ibmmq-env.conf"
+              echo ""
+              echo "Useful commands:"
+              echo "  Check status:  sudo systemctl status nrdot-collector"
+              echo "  View logs:     sudo journalctl -u nrdot-collector -f"
+              echo "  Restart:       sudo systemctl restart nrdot-collector"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "NRDOT Collector did not start in time." >&2
+          journalctl -u {{.COLLECTOR_DISTRO}}.service --no-pager -n 50 >&2
+          exit 31
+
+postInstall:
+  info: |2
+      IBM MQ OTel Collector config: /etc/nrdot-collector/ibmmq-collector-config.yaml
+      Environment file:             /etc/nrdot-collector/ibmmq-env.conf
+      Service status: systemctl status nrdot-collector
+      View logs:      journalctl -u nrdot-collector -f

--- a/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml
@@ -1,0 +1,287 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+
+name: nrdot-ibm-mq
+displayName: NRDOT IBM MQ
+description: New Relic install recipe for IBM MQ monitoring via NRDOT Collector on RHEL/CentOS/Amazon Linux.
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platform: amazon
+  - type: host
+    os: linux
+    platform: centos
+  - type: host
+    os: linux
+    platform: oracle
+  - type: host
+    os: linux
+    platform: redhat
+
+keywords:
+  - IBM MQ
+  - IBMMQ
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Messaging
+  - Queue
+  - Linux
+  - RHEL
+  - CentOS
+  - Amazon Linux
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+
+inputVars:
+  - name: NR_CLI_IBMMQ_EXPORTER_ENDPOINT
+    prompt: "IBM MQ Prometheus exporter address (mq-metric-samples, e.g. localhost:9157): "
+    default: "localhost:9157"
+  - name: NR_CLI_IBMMQ_CLUSTER_NAME
+    prompt: "IBM MQ cluster name (optional, press Enter to skip): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'ibmmq_%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+    # RPM packages use x86_64 for AMD64 (not amd64 as used by .deb)
+    NRDOT_ARCH:
+      sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi
+    NRDOT_VERSION:
+      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.18.0"
+    COLLECTOR_DISTRO: "nrdot-collector"
+    CONFIG_DIR: "/etc/nrdot-collector"
+
+  tasks:
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: install_nrdot
+        - task: create_collector_config
+        - task: configure_service
+        - task: restart_nrdot
+        - task: assert_nrdot_status_ok
+
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 3
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+        - |
+          # Config-only recipe: verify the existing mq_prometheus exporter is serving ibmmq_*.
+          ENDPOINT="{{.NR_CLI_IBMMQ_EXPORTER_ENDPOINT}}"
+          if ! curl -sf "http://${ENDPOINT}/metrics" 2>/dev/null | grep -q "^ibmmq_"; then
+            echo "" >&2
+            echo "Could not read IBM MQ metrics from the exporter at http://${ENDPOINT}/metrics" >&2
+            echo "Make sure the mq-metric-samples (mq_prometheus) exporter is running and serving" >&2
+            echo "ibmmq_* metrics, then re-run. Setup: https://github.com/ibm-messaging/mq-metric-samples" >&2
+            exit 132
+          fi
+
+    install_nrdot:
+      cmds:
+        - |
+          # Idempotent: skip the download if the latest version is already installed.
+          if rpm -q {{.COLLECTOR_DISTRO}} >/dev/null 2>&1; then
+            INSTALLED_VERSION=$(rpm -q --qf '%{VERSION}' {{.COLLECTOR_DISTRO}})
+            if [ "$INSTALLED_VERSION" = "{{.NRDOT_VERSION}}" ]; then
+              echo "{{.COLLECTOR_DISTRO}} {{.NRDOT_VERSION}} is already installed. Skipping download."
+              exit 0
+            fi
+          fi
+          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
+          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm"
+          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm" \
+            --location --output "$NRDOT_RPM" 2>/dev/null
+          rpm -i "$NRDOT_RPM" > /dev/null 2>&1 || \
+            (command -v dnf >/dev/null 2>&1 && dnf install -y "$NRDOT_RPM" > /dev/null) || \
+            yum install -y "$NRDOT_RPM" > /dev/null
+          if [ $? -ne 0 ]; then
+            echo "Failed to install NRDOT Collector package." >&2
+            exit 1
+          fi
+          rm -f "$NRDOT_RPM"
+
+    create_collector_config:
+      cmds:
+        - |
+          COLLECTOR_CONFIG="{{.CONFIG_DIR}}/ibmmq-collector-config.yaml"
+          ENV_FILE="{{.CONFIG_DIR}}/ibmmq-env.conf"
+          mkdir -p "{{.CONFIG_DIR}}"
+
+          # Config uses ${env:...} expansion; values come from the env file below
+          # (no in-place edits). target.name is derived from the detected host.id.
+          cat > "$COLLECTOR_CONFIG" << 'EOF'
+          extensions:
+            health_check:
+              endpoint: 0.0.0.0:13133
+          receivers:
+            prometheus/ibmmq:
+              config:
+                scrape_configs:
+                  - job_name: 'ibmmq'
+                    scrape_interval: 60s
+                    scrape_timeout: 15s
+                    static_configs:
+                      - targets: ['${env:IBMMQ_EXPORTER_ENDPOINT}']
+          processors:
+            resourcedetection:
+              detectors: [env, ec2, gcp, azure, system]
+              system:
+                resource_attributes:
+                  host.id:
+                    enabled: true
+                  host.name:
+                    enabled: true
+            filter/ibmmq-overhead:
+              metrics:
+                exclude:
+                  match_type: regexp
+                  metric_names:
+                    - "^go_.*"
+                    - "^process_.*"
+                    - "^promhttp_.*"
+                    - "^scrape_.*"
+            filter/ibmmq-queues:
+              metrics:
+                datapoint:
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.](ADMIN[.]|MQSC[.]|DEFAULT[.]|AUTH[.]|CHANNEL[.]|CHLAUTH[.]|CICS[.]|SYNCPOINT[.]|INTERNAL[.]|PENDING[.]|PROTECTION[.]|BROKER[.]|AMQP[.]|DOTNET[.]|REST[.]|RETAINED[.]|SELECTION[.]|DURABLE[.]|HIERARCHY[.]|DDELAY[.])")'
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.]CLUSTER[.](COMMAND|HISTORY)[.]QUEUE$")'
+                  - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^AMQ[.]")'
+            transform/ibmmq-cleanup:
+              metric_statements:
+                - context: resource
+                  statements:
+                    - set(attributes["target.name"], attributes["host.id"]) where attributes["host.id"] != nil
+                    - set(attributes["cluster.name"], "${env:IBMMQ_CLUSTER_NAME}") where "${env:IBMMQ_CLUSTER_NAME}" != ""
+                    - delete_key(attributes, "service.name")
+                    - delete_key(attributes, "service.instance.id")
+                    - delete_key(attributes, "server.address")
+                    - delete_key(attributes, "server.port")
+                    - delete_key(attributes, "url.scheme")
+                - context: datapoint
+                  statements:
+                    - delete_key(attributes, "instance")
+                    - delete_key(attributes, "job")
+            memory_limiter/ibmmq:
+              check_interval: 1s
+              limit_mib: 512
+              spike_limit_mib: 256
+            cumulativetodelta/ibmmq: {}
+            batch/ibmmq:
+              send_batch_size: 1000
+              timeout: 200ms
+          exporters:
+            otlphttp/ibmmq:
+              endpoint: ${env:NEW_RELIC_OTLP_ENDPOINT}
+              headers:
+                api-key: ${env:NEW_RELIC_LICENSE_KEY}
+              compression: gzip
+          service:
+            extensions: [health_check]
+            pipelines:
+              metrics/ibmmq:
+                receivers: [prometheus/ibmmq]
+                processors: [memory_limiter/ibmmq, resourcedetection, filter/ibmmq-overhead, filter/ibmmq-queues, transform/ibmmq-cleanup, cumulativetodelta/ibmmq, batch/ibmmq]
+                exporters: [otlphttp/ibmmq]
+          EOF
+
+          if [ "{{.NEW_RELIC_REGION}}" = "EU" ]; then
+            OTLP_ENDPOINT="https://otlp.eu01.nr-data.net"
+          elif [ "{{.NEW_RELIC_REGION}}" = "staging" ]; then
+            OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318"
+          elif [ "{{.NEW_RELIC_REGION}}" = "JP" ]; then
+            OTLP_ENDPOINT="https://otlp.jp.nr-data.net"
+          else
+            OTLP_ENDPOINT="https://otlp.nr-data.net"
+          fi
+
+          printf "IBMMQ_EXPORTER_ENDPOINT=%s\n" "{{.NR_CLI_IBMMQ_EXPORTER_ENDPOINT}}" > "$ENV_FILE"
+          printf "IBMMQ_CLUSTER_NAME=%s\n" "{{.NR_CLI_IBMMQ_CLUSTER_NAME}}" >> "$ENV_FILE"
+          printf "NEW_RELIC_OTLP_ENDPOINT=%s\n" "$OTLP_ENDPOINT" >> "$ENV_FILE"
+          printf "NEW_RELIC_LICENSE_KEY=%s\n" "{{.NEW_RELIC_LICENSE_KEY}}" >> "$ENV_FILE"
+          chmod 600 "$ENV_FILE"
+          echo "Collector config written to $COLLECTOR_CONFIG"
+
+    configure_service:
+      cmds:
+        - |
+          DROPIN_DIR="/etc/systemd/system/{{.COLLECTOR_DISTRO}}.service.d"
+          mkdir -p "$DROPIN_DIR"
+          NRDOT_BIN=$(command -v {{.COLLECTOR_DISTRO}} 2>/dev/null || echo "/usr/bin/{{.COLLECTOR_DISTRO}}")
+          {
+            printf '[Service]\n'
+            printf 'EnvironmentFile={{.CONFIG_DIR}}/ibmmq-env.conf\n'
+            printf 'ExecStart=\n'
+            printf 'ExecStart=%s --config {{.CONFIG_DIR}}/ibmmq-collector-config.yaml\n' "$NRDOT_BIN"
+          } > "$DROPIN_DIR/ibmmq-config.conf"
+          echo "Systemd drop-in configured."
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl daemon-reload
+          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+
+    assert_nrdot_status_ok:
+      cmds:
+        - |
+          MAX_RETRIES=30
+          TRIES=0
+          echo "Waiting for NRDOT Collector to start..."
+          while [ $TRIES -lt $MAX_RETRIES ]; do
+            TRIES=$((TRIES + 1))
+            if systemctl is-active --quiet {{.COLLECTOR_DISTRO}}.service && curl -sf http://localhost:13133 > /dev/null 2>&1; then
+              echo "NRDOT Collector is running and healthy."
+              echo ""
+              echo "Configuration: {{.CONFIG_DIR}}/ibmmq-collector-config.yaml"
+              echo "Environment:   {{.CONFIG_DIR}}/ibmmq-env.conf"
+              echo ""
+              echo "Useful commands:"
+              echo "  Check status:  sudo systemctl status nrdot-collector"
+              echo "  View logs:     sudo journalctl -u nrdot-collector -f"
+              echo "  Restart:       sudo systemctl restart nrdot-collector"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "NRDOT Collector did not start in time." >&2
+          journalctl -u {{.COLLECTOR_DISTRO}}.service --no-pager -n 50 >&2
+          exit 31
+
+postInstall:
+  info: |2
+      IBM MQ OTel Collector config: /etc/nrdot-collector/ibmmq-collector-config.yaml
+      Environment file:             /etc/nrdot-collector/ibmmq-env.conf
+      Service status: systemctl status nrdot-collector
+      View logs:      journalctl -u nrdot-collector -f

--- a/test/definitions/nrdot/ibm-mq/al2023-amd64.json
+++ b/test/definitions/nrdot/ibm-mq/al2023-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "al2023-ami-2023.*-x86_64",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "ibmmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-ibm-mq/install/rhel/roles",
+      "port": 9157
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_ibmmq_al2023_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml",
+          "recipe_targeted": "nrdot-ibm-mq",
+          "validate_output": "NRDOT IBM MQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_IBMMQ_EXPORTER_ENDPOINT=localhost:9157 NR_CLI_IBMMQ_CLUSTER_NAME=ibmmq-al2023-amd64-cluster"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/ibm-mq/debian-amd64.json
+++ b/test/definitions/nrdot/ibm-mq/debian-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "debian-12-amd64-daily-202?????-*",
+      "user_name": "admin"
+    }
+  ],
+  "services": [
+    {
+      "id": "ibmmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-ibm-mq/install/debian/roles",
+      "port": 9157
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_ibmmq_debian_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml",
+          "recipe_targeted": "nrdot-ibm-mq",
+          "validate_output": "NRDOT IBM MQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_IBMMQ_EXPORTER_ENDPOINT=localhost:9157 NR_CLI_IBMMQ_CLUSTER_NAME=ibmmq-debian-amd64-cluster"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/ibm-mq/rhel9-amd64.json
+++ b/test/definitions/nrdot/ibm-mq/rhel9-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "RHEL-9.0.0_HVM-2024????-x86_64-39-Hourly2-GP3",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "ibmmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-ibm-mq/install/rhel/roles",
+      "port": 9157
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_ibmmq_rhel9_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml",
+          "recipe_targeted": "nrdot-ibm-mq",
+          "validate_output": "NRDOT IBM MQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_IBMMQ_EXPORTER_ENDPOINT=localhost:9157 NR_CLI_IBMMQ_CLUSTER_NAME=ibmmq-rhel9-amd64-cluster"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/ibm-mq/ubuntu22-amd64.json
+++ b/test/definitions/nrdot/ibm-mq/ubuntu22-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "OHAI",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "OHAI"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*",
+      "user_name": "ubuntu"
+    }
+  ],
+  "services": [
+    {
+      "id": "ibmmq1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-ibm-mq/install/debian/roles",
+      "port": 9157
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_ibmmq_ubuntu22_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml",
+          "recipe_targeted": "nrdot-ibm-mq",
+          "validate_output": "NRDOT IBM MQ\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_IBMMQ_EXPORTER_ENDPOINT=localhost:9157 NR_CLI_IBMMQ_CLUSTER_NAME=ibmmq-ubuntu22-amd64-cluster"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/deploy/linux/nrdot-ibm-mq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-ibm-mq/install/debian/roles/configure/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# Stands up IBM MQ + the ibm-messaging/mq-metric-samples Prometheus exporter via
+# Docker so the nrdot-ibm-mq recipe has a live exporter at localhost:9157 to
+# scrape (the recipe is configuration-only — it does not install MQ/exporter).
+- name: install Docker prerequisites
+  package:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    update_cache: yes
+    state: present
+  become: yes
+
+- name: add Docker GPG key
+  apt_key:
+    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+    state: present
+  become: yes
+
+- name: add Docker apt repository
+  apt_repository:
+    repo: "deb [arch={{ ansible_architecture | replace('x86_64','amd64') | replace('aarch64','arm64') }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: install Docker CE
+  package:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+    state: present
+  become: yes
+
+- name: start and enable Docker
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
+  become: yes
+
+- name: run IBM MQ queue manager (QM1) with its built-in Prometheus metrics on :9157
+  # The IBM MQ container bundles the mq-metric-samples exporter; MQ_ENABLE_METRICS=true
+  # serves ibmmq_* on :9157 — no separate exporter container needed for the smoke test.
+  shell: >
+    docker run -d --name ibmmq
+    -p 1414:1414 -p 9443:9443 -p 9157:9157
+    -e LICENSE=accept -e MQ_QMGR_NAME=QM1 -e MQ_ENABLE_METRICS=true
+    -e MQ_ADMIN_PASSWORD=passw0rd -e MQ_APP_PASSWORD=passw0rd
+    icr.io/ibm-messaging/mq:latest
+  become: yes
+
+- name: wait for QM1 to be running
+  shell: docker exec ibmmq dspmq | grep -q 'Running'
+  register: mq_status
+  retries: 40
+  delay: 10
+  until: mq_status.rc == 0
+  become: yes
+
+- name: wait for the built-in exporter to serve ibmmq_* metrics on :9157
+  shell: curl -sf http://localhost:9157/metrics | grep -q '^ibmmq_qmgr'
+  register: exporter_status
+  retries: 30
+  delay: 10
+  until: exporter_status.rc == 0
+  become: yes

--- a/test/deploy/linux/nrdot-ibm-mq/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-ibm-mq/install/rhel/roles/configure/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+# Stands up IBM MQ + the ibm-messaging/mq-metric-samples Prometheus exporter via
+# Docker so the nrdot-ibm-mq recipe has a live exporter at localhost:9157 to
+# scrape (the recipe is configuration-only — it does not install MQ/exporter).
+
+########################################
+# Docker install — RHEL / CentOS / Oracle
+########################################
+- block:
+  - name: add Docker CE repo
+    shell: dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+    args:
+      creates: /etc/yum.repos.d/docker-ce.repo
+
+  - name: install Docker CE
+    dnf:
+      name:
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+      state: present
+
+  - name: start and enable Docker
+    systemd:
+      name: docker
+      state: started
+      enabled: yes
+
+  when: ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux']
+  become: yes
+
+########################################
+# Docker install — Amazon Linux (2 and 2023)
+########################################
+- block:
+  - name: amazon - install docker
+    package:
+      name: docker
+      state: present
+
+  - name: amazon - start and enable docker
+    systemd:
+      name: docker
+      state: started
+      enabled: yes
+
+  when: ansible_distribution == 'Amazon'
+  become: yes
+
+- name: run IBM MQ queue manager (QM1) with its built-in Prometheus metrics on :9157
+  # The IBM MQ container bundles the mq-metric-samples exporter; MQ_ENABLE_METRICS=true
+  # serves ibmmq_* on :9157 — no separate exporter container needed for the smoke test.
+  shell: >
+    docker run -d --name ibmmq
+    -p 1414:1414 -p 9443:9443 -p 9157:9157
+    -e LICENSE=accept -e MQ_QMGR_NAME=QM1 -e MQ_ENABLE_METRICS=true
+    -e MQ_ADMIN_PASSWORD=passw0rd -e MQ_APP_PASSWORD=passw0rd
+    icr.io/ibm-messaging/mq:latest
+  become: yes
+
+- name: wait for QM1 to be running
+  shell: docker exec ibmmq dspmq | grep -q 'Running'
+  register: mq_status
+  retries: 40
+  delay: 10
+  until: mq_status.rc == 0
+  become: yes
+
+- name: wait for the built-in exporter to serve ibmmq_* metrics on :9157
+  shell: curl -sf http://localhost:9157/metrics | grep -q '^ibmmq_qmgr'
+  register: exporter_status
+  retries: 30
+  delay: 10
+  until: exporter_status.rc == 0
+  become: yes


### PR DESCRIPTION
## Summary

Adds a `nrdot-ibm-mq` install recipe that configures the NRDOT Collector to monitor IBM MQ via OpenTelemetry.

- `recipes/newrelic/infrastructure/nrdot/ibm-mq/{debian,rhel}.yml` — config-only recipe: installs the NRDOT Collector and points it at an existing IBM MQ `mq-metric-samples` (`mq_prometheus`) exporter, exporting `ibmmq_*` metrics to New Relic via OTLP. Resource detection (`env, ec2, gcp, azure, system`) maps `host.id` to the IBM MQ entity identity; metric/label shape (`qmgr`/`queue`) is preserved for entity synthesis.
- `test/definitions/nrdot/ibm-mq/*.json` — amd64 test definitions (debian, ubuntu22, rhel9, al2023).
- `test/deploy/linux/nrdot-ibm-mq/...` — Ansible roles that stand up IBM MQ + the exporter via Docker for the test harness.

## Testing

Validated end-to-end on a Debian 13 EC2 host against a New Relic staging account: `newrelic install -n nrdot-ibm-mq` installs, validates, and `ibmmq_*` metrics arrive with correct `host.id`/`qmgr` attributes.

## Note

Mirrors the existing `nrdot/kafka` recipe structure. arm64 test definitions are omitted for now (the IBM MQ container image's arm64 support is unreliable).