### PR TITLE
fix(nrdot): harden NRDOT version resolution in kafka/rabbitmq recipes 

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/ibm-mq/debian.yml
@@ -101,10 +101,7 @@ install:
     install_nrdot:
       cmds:
         - |
-          # Resolve the latest release into a variable and fail fast if it is empty.
-          # (A pipeline's trailing `|| fallback` only guards the last command, so an
-          # empty API response would otherwise yield an empty version and a broken
-          # download URL that fails much later at dpkg with a misleading error.)
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
           NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
           if [ -z "$NRDOT_VERSION" ]; then
             echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2

--- a/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/ibm-mq/rhel.yml
@@ -109,10 +109,7 @@ install:
     install_nrdot:
       cmds:
         - |
-          # Resolve the latest release into a variable and fail fast if it is empty.
-          # (A pipeline's trailing `|| fallback` only guards the last command, so an
-          # empty API response would otherwise yield an empty version and a broken
-          # download URL that fails much later at rpm with a misleading error.)
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
           NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
           if [ -z "$NRDOT_VERSION" ]; then
             echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2
@@ -137,7 +134,6 @@ install:
           # rpm -U handles both fresh install and upgrade in a single command.
           rpm -U "$NRDOT_RPM" > /dev/null
           if [ $? -ne 0 ]; then
-            echo "rpm install failed, attempting yum install..." >&2
             yum install -y "$NRDOT_RPM" > /dev/null
             if [ $? -ne 0 ]; then
               echo "Failed to install NRDOT Collector package." >&2

--- a/recipes/newrelic/infrastructure/nrdot/kafka/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/kafka/debian.yml
@@ -47,8 +47,6 @@ install:
       sh: command -v systemctl | wc -l
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi
-    NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
     COLLECTOR_CONFIG_URL: "https://raw.githubusercontent.com/newrelic/newrelic-opentelemetry-examples/main/other-examples/collector/kafka/self-host-kafka/otel-collector-config.yaml"
@@ -90,10 +88,20 @@ install:
     install_nrdot:
       cmds:
         - |
-          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
-          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb"
-          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb" \
-            --location --output "$NRDOT_DEB" 2>/dev/null
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
+          NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
+          if [ -z "$NRDOT_VERSION" ]; then
+            echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2
+            exit 1
+          fi
+          echo "Installing NRDOT Collector v$NRDOT_VERSION..."
+          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.deb"
+          curl -fL --output "$NRDOT_DEB" \
+            "https://github.com/newrelic/nrdot-collector-releases/releases/download/${NRDOT_VERSION}/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.deb"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the NRDOT Collector package (version ${NRDOT_VERSION}, arch {{.NRDOT_ARCH}})." >&2
+            exit 1
+          fi
           dpkg -i "$NRDOT_DEB" > /dev/null
           if [ $? -ne 0 ]; then
             dpkg --configure -a > /dev/null
@@ -166,7 +174,8 @@ install:
       cmds:
         - |
           systemctl daemon-reload
-          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+          systemctl enable {{.COLLECTOR_DISTRO}}.service
+          systemctl restart {{.COLLECTOR_DISTRO}}.service
 
     assert_nrdot_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/nrdot/kafka/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/kafka/rhel.yml
@@ -55,8 +55,6 @@ install:
     # RPM packages use x86_64 for AMD64 (not amd64 as used by .deb)
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi
-    NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.11.1"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
     COLLECTOR_CONFIG_URL: "https://raw.githubusercontent.com/newrelic/newrelic-opentelemetry-examples/main/other-examples/collector/kafka/self-host-kafka/otel-collector-config.yaml"
@@ -98,16 +96,28 @@ install:
     install_nrdot:
       cmds:
         - |
-          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
-          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm"
-          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm" \
-            --location --output "$NRDOT_RPM" 2>/dev/null
-          rpm -i "$NRDOT_RPM" > /dev/null 2>&1 || \
-            (which dnf >/dev/null 2>&1 && dnf install -y "$NRDOT_RPM" > /dev/null) || \
-            yum install -y "$NRDOT_RPM" > /dev/null
-          if [ $? -ne 0 ]; then
-            echo "Failed to install NRDOT Collector package." >&2
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
+          NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
+          if [ -z "$NRDOT_VERSION" ]; then
+            echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2
             exit 1
+          fi
+          echo "Installing NRDOT Collector v$NRDOT_VERSION..."
+          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.rpm"
+          curl -fL --output "$NRDOT_RPM" \
+            "https://github.com/newrelic/nrdot-collector-releases/releases/download/${NRDOT_VERSION}/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.rpm"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the NRDOT Collector package (version ${NRDOT_VERSION}, arch {{.NRDOT_ARCH}})." >&2
+            exit 1
+          fi
+          # rpm -U handles both fresh install and upgrade in a single command.
+          rpm -U "$NRDOT_RPM" > /dev/null
+          if [ $? -ne 0 ]; then
+            yum install -y "$NRDOT_RPM" > /dev/null
+            if [ $? -ne 0 ]; then
+              echo "Failed to install NRDOT Collector package." >&2
+              exit 1
+            fi
           fi
           rm -f "$NRDOT_RPM"
 
@@ -172,7 +182,8 @@ install:
       cmds:
         - |
           systemctl daemon-reload
-          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+          systemctl enable {{.COLLECTOR_DISTRO}}.service
+          systemctl restart {{.COLLECTOR_DISTRO}}.service
 
     assert_nrdot_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/debian.yml
@@ -56,8 +56,6 @@ install:
       sh: command -v systemctl | wc -l
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi
-    NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.13.0"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
 
@@ -98,10 +96,20 @@ install:
     install_nrdot:
       cmds:
         - |
-          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
-          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb"
-          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.deb" \
-            --location --output "$NRDOT_DEB" 2>/dev/null
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
+          NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
+          if [ -z "$NRDOT_VERSION" ]; then
+            echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2
+            exit 1
+          fi
+          echo "Installing NRDOT Collector v$NRDOT_VERSION..."
+          NRDOT_DEB="/tmp/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.deb"
+          curl -fL --output "$NRDOT_DEB" \
+            "https://github.com/newrelic/nrdot-collector-releases/releases/download/${NRDOT_VERSION}/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.deb"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the NRDOT Collector package (version ${NRDOT_VERSION}, arch {{.NRDOT_ARCH}})." >&2
+            exit 1
+          fi
           dpkg -i "$NRDOT_DEB" > /dev/null
           if [ $? -ne 0 ]; then
             dpkg --configure -a > /dev/null
@@ -261,7 +269,8 @@ install:
       cmds:
         - |
           systemctl daemon-reload
-          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+          systemctl enable {{.COLLECTOR_DISTRO}}.service
+          systemctl restart {{.COLLECTOR_DISTRO}}.service
 
     assert_nrdot_status_ok:
       cmds:

--- a/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/rabbitmq/rhel.yml
@@ -63,8 +63,6 @@ install:
       sh: command -v systemctl | wc -l
     NRDOT_ARCH:
       sh: if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi
-    NRDOT_VERSION:
-      sh: curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "1.13.0"
     COLLECTOR_DISTRO: "nrdot-collector"
     CONFIG_DIR: "/etc/nrdot-collector"
 
@@ -105,16 +103,28 @@ install:
     install_nrdot:
       cmds:
         - |
-          echo "Installing NRDOT Collector v{{.NRDOT_VERSION}}..."
-          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm"
-          curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/{{.NRDOT_VERSION}}/{{.COLLECTOR_DISTRO}}_{{.NRDOT_VERSION}}_linux_{{.NRDOT_ARCH}}.rpm" \
-            --location --output "$NRDOT_RPM" 2>/dev/null
-          rpm -i "$NRDOT_RPM" > /dev/null 2>&1 || \
-            (which dnf >/dev/null 2>&1 && dnf install -y "$NRDOT_RPM" > /dev/null) || \
-            yum install -y "$NRDOT_RPM" > /dev/null
-          if [ $? -ne 0 ]; then
-            echo "Failed to install NRDOT Collector package." >&2
+          # Resolve the latest release version and fail fast if empty (a blank version yields a broken download URL).
+          NRDOT_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name"' | head -1 | cut -d '"' -f 4 | sed 's/^v//')
+          if [ -z "$NRDOT_VERSION" ]; then
+            echo "Could not determine the latest nrdot-collector release from GitHub (network issue or API rate limit). Please re-run the installation." >&2
             exit 1
+          fi
+          echo "Installing NRDOT Collector v$NRDOT_VERSION..."
+          NRDOT_RPM="/tmp/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.rpm"
+          curl -fL --output "$NRDOT_RPM" \
+            "https://github.com/newrelic/nrdot-collector-releases/releases/download/${NRDOT_VERSION}/{{.COLLECTOR_DISTRO}}_${NRDOT_VERSION}_linux_{{.NRDOT_ARCH}}.rpm"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the NRDOT Collector package (version ${NRDOT_VERSION}, arch {{.NRDOT_ARCH}})." >&2
+            exit 1
+          fi
+          # rpm -U handles both fresh install and upgrade in a single command.
+          rpm -U "$NRDOT_RPM" > /dev/null
+          if [ $? -ne 0 ]; then
+            yum install -y "$NRDOT_RPM" > /dev/null
+            if [ $? -ne 0 ]; then
+              echo "Failed to install NRDOT Collector package." >&2
+              exit 1
+            fi
           fi
           rm -f "$NRDOT_RPM"
           mkdir -p {{.CONFIG_DIR}}
@@ -266,7 +276,8 @@ install:
       cmds:
         - |
           systemctl daemon-reload
-          systemctl reload-or-restart {{.COLLECTOR_DISTRO}}.service
+          systemctl enable {{.COLLECTOR_DISTRO}}.service
+          systemctl restart {{.COLLECTOR_DISTRO}}.service
 
     assert_nrdot_status_ok:
       cmds:

--- a/test/definitions/nrdot/kafka/rhel9-amd64.json
+++ b/test/definitions/nrdot/kafka/rhel9-amd64.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.medium",
-      "ami_name": "RHEL-9.0.0_HVM-2024????-x86_64-39-Hourly2-GP3",
+      "ami_name": "RHEL-9.*_HVM-????????-x86_64-*-Hourly2-GP3",
       "user_name": "ec2-user"
     }
   ],

--- a/test/definitions/nrdot/rabbitmq/rhel9-amd64.json
+++ b/test/definitions/nrdot/rabbitmq/rhel9-amd64.json
@@ -11,7 +11,7 @@
       "provider": "aws",
       "type": "ec2",
       "size": "t3.small",
-      "ami_name": "RHEL-9.0.0_HVM-2024????-x86_64-39-Hourly2-GP3",
+      "ami_name": "RHEL-9.*_HVM-????????-x86_64-*-Hourly2-GP3",
       "user_name": "ec2-user"
     }
   ],

--- a/test/deploy/linux/nrdot-ibm-mq/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-ibm-mq/install/debian/roles/configure/tasks/main.yml
@@ -43,8 +43,7 @@
   become: yes
 
 - name: run IBM MQ queue manager (QM1) with its built-in Prometheus metrics on :9157
-  # The IBM MQ container bundles the mq-metric-samples exporter; MQ_ENABLE_METRICS=true
-  # serves ibmmq_* on :9157 — no separate exporter container needed for the smoke test.
+  # Smoke test: container's built-in qmgr-level metrics; per-queue metrics need the standalone exporter.
   # Publish 9157 on loopback only (collector + healthcheck scrape localhost), so it is
   # unreachable off-box. The MQ listener (1414) and web console (9443) are not published.
   shell: >

--- a/test/deploy/linux/nrdot-ibm-mq/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-ibm-mq/install/rhel/roles/configure/tasks/main.yml
@@ -48,8 +48,7 @@
   become: yes
 
 - name: run IBM MQ queue manager (QM1) with its built-in Prometheus metrics on :9157
-  # The IBM MQ container bundles the mq-metric-samples exporter; MQ_ENABLE_METRICS=true
-  # serves ibmmq_* on :9157 — no separate exporter container needed for the smoke test.
+  # Smoke test: container's built-in qmgr-level metrics; per-queue metrics need the standalone exporter.
   # Publish 9157 on loopback only (collector + healthcheck scrape localhost), so it is
   # unreachable off-box. The MQ listener (1414) and web console (9443) are not published.
   shell: >


### PR DESCRIPTION
## What

Applies the NRDOT collector **version-resolution fix** (and two related install-hardening alignments) to the `nrdot-collector-kafka` and `nrdot-collector-rabbitmq` recipes, mirroring what already landed for `nrdot-collector-ibm-mq` in #1386. Also includes two minor follow-up trims to the ibm-mq recipe for consistency.

This is the follow-up sweep flagged in the #1386 review ("same pattern is in kafka/rabbitmq recipes").

## Why

All three of kafka/rabbitmq resolved the collector version in a recipe var:

```yaml
NRDOT_VERSION:
  sh: curl -sf ".../releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/^v//' || echo "<pinned>"
```

A pipeline's trailing `|| fallback` only guards the **last** command (`sed`), which exits `0` on empty input. So when the API call fails or is rate-limited, `NRDOT_VERSION` becomes **empty** (not the fallback), producing a broken download URL that fails much later at `dpkg`/`rpm` with a misleading error. The pinned fallback was also stale.

## Changes (per recipe)

| Change | kafka | rabbitmq | ibm-mq (this PR) |
|---|:---:|:---:|:---:|
| Resolve version in `install_nrdot` body, fail fast if empty, no hardcoded fallback | ✅ | ✅ | already in #1386 |
| Download with `curl -fL` + explicit failure check (was `--location ... 2>/dev/null`) | ✅ | ✅ | already in #1386 |
| **rhel:** `rpm -U` + `yum` fallback (was `rpm -i` + `which dnf` dance) | ✅ | ✅ | already in #1386 |
| **both:** `systemctl enable` + `restart` (was `reload-or-restart`, no enable) | ✅ | ✅ | already in #1386 |
| Trim 4-line version comment → 1 line; drop intermediate "attempting yum" echo | — | — | ✅ |

The new pattern matches the most recent reference recipes (`nrdot-collector-nginx`, `-haproxy`, `-ibm-mq`).

### Notes
- `rpm -i` errors when a different version is already installed (breaks upgrades); `rpm -U` installs **or** upgrades in one command.
- `reload-or-restart` could SIGHUP-reload instead of restarting — the collector has no live config reload, so a config change wouldn't take effect on re-run. nginx documents this same reasoning in its recipe.
- The `sed 's/^v//'` is retained: `nrdot-collector-releases` tags without a `v` prefix (latest is `1.19.0`), so it's a harmless no-op today and defensive if that ever changes. Verified the resulting `.deb`/`.rpm` URLs return HTTP 200.

## Testing
- All 6 changed recipes parse as valid YAML; no leftover `{{.NRDOT_VERSION}}` references or `reload-or-restart`.
- The ibm-mq recipe (same pattern) was validated end-to-end on Debian/Ubuntu/RHEL9/AL2023 hosts with data confirmed in staging in #1386.

Assisted-by: Claude Opus 4.8