### PR TITLE
fix(mssql): self-hosted pre-install check now supports SQL Auth credentials and fixes TCP timeout

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
+++ b/recipes/newrelic/infrastructure/ohi/sql/ms-sql.yml
@@ -106,14 +106,21 @@ preInstall:
 
         $NEW_RELIC_MSSQL_DB_HOSTNAME = if ($env:NEW_RELIC_MSSQL_DB_HOSTNAME) { $env:NEW_RELIC_MSSQL_DB_HOSTNAME } else { $env:NR_CLI_DB_HOSTNAME };
         if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_HOSTNAME)) {$NEW_RELIC_MSSQL_DB_HOSTNAME = hostname}
-        
+
         $NEW_RELIC_MSSQL_DB_PORT = if ($env:NEW_RELIC_MSSQL_DB_PORT) { $env:NEW_RELIC_MSSQL_DB_PORT } else { $env:NR_CLI_DB_PORT };
         if ([string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_DB_PORT)) {$NEW_RELIC_MSSQL_DB_PORT = "1433"}
+
+        $sqlUsername = if ($env:NEW_RELIC_MSSQL_SQL_USERNAME) { $env:NEW_RELIC_MSSQL_SQL_USERNAME } else { $env:NR_CLI_SQL_USERNAME }
+        $sqlPassword = if ($env:NEW_RELIC_MSSQL_SQL_PASSWORD) { $env:NEW_RELIC_MSSQL_SQL_PASSWORD } else { $env:NR_CLI_SQL_PASSWORD }
+        $sqlCredArgs = @()
+        if (-not [string]::IsNullOrWhiteSpace($sqlUsername)) {
+            $sqlCredArgs = @("-U", $sqlUsername, "-P", $sqlPassword)
+        }
 
         # Loop on each instance names to see if we can connect
         foreach ($instance in $instances) {
           $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance},${NEW_RELIC_MSSQL_DB_PORT}"
-          $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+          $name=(sqlcmd -S $connection @sqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
           If ($name.Length -ge 3) {
             $actualName = $name[2].ToString().Trim();
             If ($actualName -eq $instance) {
@@ -126,7 +133,7 @@ preInstall:
           }
 
           $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance}"
-          $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+          $name=(sqlcmd -S $connection @sqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
           If ($name.Length -ge 3) {
             $actualName = $name[2].ToString().Trim();
             If ($actualName -eq $instance) {
@@ -139,7 +146,7 @@ preInstall:
           }
 
           $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME},${NEW_RELIC_MSSQL_DB_PORT}"
-          $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+          $name=(sqlcmd -S $connection @sqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
           If ($name.Length -ge 3) {
             $actualName = $name[2].ToString().Trim();
             If ($actualName -eq $instance) {
@@ -152,7 +159,7 @@ preInstall:
           }
 
         }
-        exit 3 
+        exit 3
       }
       '
   info: |
@@ -655,10 +662,15 @@ install:
             $instances = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server").InstalledInstances
             $loginModes = (Get-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\*\*" -name "LoginMode" -ErrorAction SilentlyContinue | Where-Object -Property loginMode -eq -Value "2")
 
+            $installSqlCredArgs = @()
+            if (-not [string]::IsNullOrWhiteSpace($NEW_RELIC_MSSQL_SQL_USERNAME)) {
+                $installSqlCredArgs = @("-U", $NEW_RELIC_MSSQL_SQL_USERNAME, "-P", $NEW_RELIC_MSSQL_SQL_PASSWORD)
+            }
+
             foreach ($instance in $instances) {
 
               $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance},${NEW_RELIC_MSSQL_DB_PORT}"
-              $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+              $name=(sqlcmd -S $connection @installSqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
               If ($name.Length -ge 3) {
                 $actualName = $name[2].ToString().Trim();
                 If ($actualName -eq $instance) {
@@ -671,7 +683,7 @@ install:
                       $isQueryStoreEnabled = Enable-QueryStore -connection $connection -InstanceName $instance -Port $NEW_RELIC_MSSQL_DB_PORT
                       if($isQueryStoreEnabled -ne $true) {
                         Write-Error "Failed to enable QueryStore for Azure SQL Managed Instance: ${NEW_RELIC_MSSQL_DB_HOSTNAME}. Check SQL connectivity and admin credentials."
-                        Exit 139 
+                        Exit 139
                       }
                     }
 
@@ -685,7 +697,7 @@ install:
               }
 
               $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME}\${instance}"
-              $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+              $name=(sqlcmd -S $connection @installSqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
               If ($name.Length -ge 3) {
                 $actualName = $name[2].ToString().Trim();
                 If ($actualName -eq $instance) {
@@ -698,7 +710,7 @@ install:
                       $isQueryStoreEnabled = Enable-QueryStore -connection $connection -InstanceName $instance
                       if($isQueryStoreEnabled -ne $true) {
                         Write-Error "Failed to enable QueryStore for Azure SQL Managed Instance: ${NEW_RELIC_MSSQL_DB_HOSTNAME}. Check SQL connectivity and admin credentials."
-                        Exit 135 
+                        Exit 135
                       }
                     }
 
@@ -712,7 +724,7 @@ install:
               }
 
               $connection = "${NEW_RELIC_MSSQL_DB_HOSTNAME},${NEW_RELIC_MSSQL_DB_PORT}"
-              $name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)
+              $name=(sqlcmd -S $connection @installSqlCredArgs -Q "SELECT @@SERVICENAME" -l 30 2>&1)
               If ($name.Length -ge 3) {
                 $actualName = $name[2].ToString().Trim();
                 If ($actualName -eq $instance) {


### PR DESCRIPTION
**Problem**

The self-hosted MSSQL `requireAtDiscovery` pre-install check and install task connection checks used Windows Authentication exclusively, ignoring `NEW_RELIC_MSSQL_SQL_USERNAME and NEW_RELIC_MSSQL_SQL_PASSWORD` environment variables that users may provide.

This caused the installer to fail with exit status 3 ("unsupported") for any user whose Windows identity has no SQL Server login — even when valid SQL credentials were supplied. The Azure SQL path already supported explicit SQL credentials via `NEW_RELIC_MSSQL_SQL_USERNAME`, but the self-hosted path did not.

A second issue was discovered during investigation: all self-hosted sqlcmd connection checks used -l 1 (1-second login timeout), which is too short for TCP connections and causes reliable timeouts when a port number is appended to the connection string.

**Root Cause**

In the else branch (self-hosted MSSQL) of both requireAtDiscovery and the install task, sqlcmd was called without -U/-P flags:

 Before — always Windows Auth, always times out on TCP
`$name=(sqlcmd -S $connection -Q "SELECT @@SERVICENAME" -l 1 2>&1)`

The Azure SQL branch already read `$env:NEW_RELIC_MSSQL_SQL_USERNAME and passed -U/-P to sqlcmd`. The self-hosted branch lacked this same modularity.

**Fix**

1. preInstall.requireAtDiscovery (self-hosted branch):
- Added `$sqlUsername / $sqlPassword reading from NEW_RELIC_MSSQL_SQL_USERNAME / NEW_RELIC_MSSQL_SQL_PASSWORD env vars (with NR_CLI_SQL_USERNAME / NR_CLI_SQL_PASSWORD as fallbacks)`
- Added `$sqlCredArgs` array splatting — injects -`U/-P` when credentials are set, empty array (Windows Auth) when not
- Changed -l 1 → -l 30 on all 3 connection attempts

2. Install task (self-hosted branch connection checks):
- Added `$installSqlCredArgs using $NEW_RELIC_MSSQL_SQL_USERNAME` (already read earlier in the task)
- Changed -l 1 → -l 30 on all 3 connection attempts

**Test screenshots:**

**Before fix:**
The integration is failing with the username and password.
<img width="1711" height="952" alt="mssql-selfhosted-error" src="https://github.com/user-attachments/assets/5f6a8b03-fff5-4c6a-bfee-cb9edf1f8675" />

**After fix:**
After fix using the username and password, it's integrated successfully.
<img width="786" height="685" alt="mssql-self-hosted-fix" src="https://github.com/user-attachments/assets/7bf8485f-561c-4323-b314-e18aca440d42" />
