### PR TITLE
ci(release): record every release as an empty commit on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-22.04
+    outputs:
+      release_url: ${{ steps.create_release.outputs.html_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -106,3 +108,56 @@ jobs:
         run: |
           rm -rf /home/runner/.aws/credentials
           rm -rf /home/runner/.aws/config
+
+  commit-release-notes:
+    name: Record release on main
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit release marker to main
+        env:
+          RELEASE_URL: ${{ needs.build.outputs.release_url }}
+        run: |
+          set -euo pipefail
+
+          # Strip refs/tags/ → e.g. v0.82.0
+          TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_DATE=$(date -u +'%-d %B %Y')
+
+          # Previous release tag = second-newest v* tag by semver sort.
+          # `git tag --sort=-v:refname` puts the newest first; filter out the just-released tag.
+          PREV=$(git tag --list 'v*' --sort=-v:refname | grep -v "^${TAG}$" | head -1 || true)
+
+          {
+            printf 'chore(release): Open Install Library Release %s, %s\n\n' "$TAG" "$RELEASE_DATE"
+            if [ -n "$PREV" ]; then
+              printf 'Changes since %s:\n\n' "$PREV"
+              git log --no-merges --pretty=format:'- %s (%h)' "${PREV}..${TAG}"
+              printf '\n\n'
+            fi
+            printf 'Release: %s\n' "${RELEASE_URL}"
+          } > /tmp/commit-msg.txt
+
+          echo "----- Commit message preview -----"
+          cat /tmp/commit-msg.txt
+          echo "----------------------------------"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --allow-empty -F /tmp/commit-msg.txt
+
+          # Retry once on race (someone else pushed to main between checkout and push).
+          if ! git push origin main; then
+            echo "push rejected; refetching and rebasing before retry"
+            git pull --rebase origin main
+            git push origin main
+          fi


### PR DESCRIPTION
## Summary

Extend the tag-triggered release workflow (\`release.yml\`) so that every published release also lands as a marker commit on \`main\`.

- New job \`commit-release-notes\` runs after \`build\` (which creates the GitHub Release), so we can consume the release's canonical URL.
- Subject: \`chore(release): Open Install Library Release vX.Y.Z, D Month YYYY\`
- Body: the per-commit change list (\`git log <prev-v-tag>..<new-v-tag>\` in \`- subject (short-sha)\` form) plus a \`Release: <html_url>\` deep-link to the GitHub release page.
- Empty commit — no changelog file is added (repo has none); \`git log main\` becomes the release history.
- Uses \`github-actions[bot]\` via \`\${{ secrets.GITHUB_TOKEN }}\`, matching existing automation identity.
- One rebase-retry to survive a concurrent push to main.

## Test plan

- [ ] Push a throwaway pre-release tag (e.g. \`v0.83.0-rc1\`) after this merges and verify the new job runs, the \`Commit message preview\` step prints the expected format, and the empty commit appears on main.
- [ ] If branch protection blocks the push, add \`github-actions[bot]\` to the "Allow specified actors to bypass required pull requests" list on the main branch protection rule (or swap \`GITHUB_TOKEN\` for a PAT stored as a repo secret).