### PR TITLE
ci(release): use RELEASE_TOKEN for the post-release push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN (PAT) is required because main is protected — rules
+          # forbid direct pushes and require FOSSA to pass. The default
+          # GITHUB_TOKEN cannot bypass those rules. RELEASE_TOKEN is the same
+          # PAT the CLI's OIL→CLI workflow already uses to push tags into OIL.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Commit release marker to main
         env:


### PR DESCRIPTION
## Summary

Follow-up to #1394. The first release-notes marker job (release v0.85.0, [run 29247023786](https://github.com/newrelic/open-install-library/actions/runs/29247023786)) failed at `git push origin main` — the default `GITHUB_TOKEN` cannot bypass main's protection rules (PR-only, required FOSSA check).

`RELEASE_TOKEN` is the PAT that the CLI's OIL→CLI workflow already uses to push tags into this repo, so it has the necessary write permissions. Wiring it through `actions/checkout`'s `token:` param persists it in `.git/config` for the subsequent `git push`.

Everything else in the job already works correctly — the commit assembly ran perfectly, the local commit was created (`[main 267a7752] chore(release): Open Install Library Release v0.85.0, 13 July 2026`), the format matches spec, only the push was rejected.

## Test plan

- [ ] Merge this.
- [ ] Push `v0.86.0` at the fixed main and verify the `Record release on main` job succeeds and the marker commit appears on main.