### PR TITLE
security(release): declare least-privilege permissions on the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,19 @@ on:
 
 name: Create Release
 
+# Least-privilege default for the whole workflow — jobs that need more
+# override at the job level. Matches the convention used by
+# cleanup-jp.yml / nonregression-jp.yml.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Create Release
     runs-on: ubuntu-22.04
+    # actions/create-release@v1 needs contents: write to publish a Release.
+    permissions:
+      contents: write
     outputs:
       release_url: ${{ steps.create_release.outputs.html_url }}
     steps:
@@ -35,6 +44,9 @@ jobs:
   zip-recipes:
     runs-on: ubuntu-22.04
     needs: build
+    # actions/upload-release-asset needs contents: write to attach recipes.zip.
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -113,8 +125,9 @@ jobs:
     name: Record release on main
     runs-on: ubuntu-22.04
     needs: build
-    permissions:
-      contents: write
+    # No override needed — the push uses secrets.RELEASE_TOKEN (a PAT), not
+    # the default GITHUB_TOKEN, so this job only needs the workflow-level
+    # `contents: read` (for actions/checkout).
     steps:
       - name: Checkout main
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts [#61](https://github.com/newrelic/open-install-library/security/code-scanning/61) and [#43](https://github.com/newrelic/open-install-library/security/code-scanning/43) — both are `actions/missing-workflow-permissions` (medium severity) against `.github/workflows/release.yml`.

Adopts the workflow-level default already used by `cleanup-jp.yml` and `nonregression-jp.yml`:

```yaml
permissions:
  contents: read
```

…and overrides individually where a job legitimately needs more:

| Job | Perm | Why |
|---|---|---|
| `build` | `contents: write` | `actions/create-release@v1` publishes the Release |
| `zip-recipes` | `contents: write` | `actions/upload-release-asset` attaches `recipes.zip` |
| `commit-release-notes` | *(inherits `contents: read`)* | Push uses `secrets.RELEASE_TOKEN` (PAT), not `GITHUB_TOKEN` — this also tightens a leftover `contents: write` from before #1395 landed |

## Test plan

- [ ] Merge this.
- [ ] Verify CodeQL alerts #61 and #43 auto-close on the next scan.
- [ ] Verify next release tag still lands (`Create Release` still creates release, `zip-recipes` still uploads, `commit-release-notes` still pushes to main).