### PR TITLE
ci(release): compact marker subject, skip CI on marker, filter prior markers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,14 +154,32 @@ jobs:
           # `git tag --sort=-v:refname` puts the newest first; filter out the just-released tag.
           PREV=$(git tag --list 'v*' --sort=-v:refname | grep -v "^${TAG}$" | head -1 || true)
 
+          # Compact subject: `chore(release): OIL <tag>, <date>`.
+          #
+          # Change list excludes prior release-marker commits so a release
+          # doesn't list its predecessors. --extended-regexp matches both the
+          # current shorter format ("OIL v...") and the legacy longer one
+          # ("Open Install Library Release v...") so older markers on main
+          # stay filtered too.
+          #
+          # `[skip ci]` at the end tells GitHub Actions not to run
+          # push-triggered workflows on the marker commit itself — the
+          # release just built the artifacts, there's nothing to re-verify.
           {
-            printf 'chore(release): Open Install Library Release %s, %s\n\n' "$TAG" "$RELEASE_DATE"
+            printf 'chore(release): OIL %s, %s\n\n' "$TAG" "$RELEASE_DATE"
             if [ -n "$PREV" ]; then
               printf 'Changes since %s:\n\n' "$PREV"
-              git log --no-merges --pretty=format:'- %s (%h)' "${PREV}..${TAG}"
+              git log \
+                --no-merges \
+                --invert-grep \
+                --extended-regexp \
+                --grep='^chore\(release\): (OIL|Open Install Library Release) v[0-9]' \
+                --pretty=format:'- %s (%h)' \
+                "${PREV}..${TAG}"
               printf '\n\n'
             fi
-            printf 'Release: %s\n' "${RELEASE_URL}"
+            printf 'Release: %s\n\n' "${RELEASE_URL}"
+            printf '[skip ci]\n'
           } > /tmp/commit-msg.txt
 
           echo "----- Commit message preview -----"


### PR DESCRIPTION
## Summary

Three small refinements to the release-marker workflow (`.github/workflows/release.yml`), all in the `commit-release-notes` job:

### 1. Compact subject

| Before | After |
|---|---|
| `chore(release): Open Install Library Release v0.86.2, 13 July 2026` | `chore(release): OIL v0.86.2, 13 July 2026` |

### 2. Marker commit no longer triggers CI

Appends `[skip ci]` to the commit body. GitHub Actions natively honors that marker (and its variants — `[ci skip]`, `[skip actions]`, `***NO_CI***`, `skip-checks: true` trailer) and skips push-triggered workflows on that specific commit. Since the release workflow already built and verified everything a moment ago, there's nothing for the full check matrix to re-verify on the marker itself.

### 3. Prior release markers excluded from the change list

The `git log` now uses `--invert-grep --extended-regexp` with a pattern that matches both the new short form (`OIL v...`) and the legacy long form (`Open Install Library Release v...`), so the two older markers on main stay filtered too:

```
--grep='^chore\(release\): (OIL|Open Install Library Release) v[0-9]'
```

Each release's change list now reflects only real work, not the trail of previous marker commits.

## Expected diff for the next release (v0.86.3, purely illustrative)

Before this PR:
```
chore(release): Open Install Library Release v0.86.3, 13 July 2026

Changes since v0.86.2:

- <some real commit> (abc12345)
- chore(release): Open Install Library Release v0.86.2, 13 July 2026 (f184b05a)

Release: https://github.com/newrelic/open-install-library/releases/tag/v0.86.3
```

After this PR:
```
chore(release): OIL v0.86.3, 13 July 2026

Changes since v0.86.2:

- <some real commit> (abc12345)

Release: https://github.com/newrelic/open-install-library/releases/tag/v0.86.3

[skip ci]
```

## Test plan

- [ ] Merge this.
- [ ] Cut a patch tag (e.g. `v0.86.3`) and verify:
  - marker subject uses the compact form
  - `[skip ci]` is present in the body
  - **no CI workflows kick off** for the marker commit push to main
  - the change list does not include prior `chore(release):` markers