### PR TITLE
feat(infrastructure): write fedramp: true to infra config when region is GOV or FEDRAMP

### DIFF
--- a/recipes/newrelic/infrastructure/awslinux.yml
+++ b/recipes/newrelic/infrastructure/awslinux.yml
@@ -162,18 +162,22 @@ install:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
             sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sed -i "/^fedramp/d" /etc/newrelic-infra.yml
             sed -i "/^enable_process_metrics/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                        
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
         - |
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> /etc/newrelic-infra.yml
+          fi
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> /etc/newrelic-infra.yml
           fi
           echo 'enable_process_metrics: true' >> /etc/newrelic-infra.yml
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml

--- a/recipes/newrelic/infrastructure/centos_rhel.yml
+++ b/recipes/newrelic/infrastructure/centos_rhel.yml
@@ -137,18 +137,22 @@ install:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
             sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sed -i "/^fedramp/d" /etc/newrelic-infra.yml
             sed -i "/^enable_process_metrics/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                        
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
         - |
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> /etc/newrelic-infra.yml
+          fi
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> /etc/newrelic-infra.yml
           fi
           echo 'enable_process_metrics: true' >> /etc/newrelic-infra.yml
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml

--- a/recipes/newrelic/infrastructure/darwin.yml
+++ b/recipes/newrelic/infrastructure/darwin.yml
@@ -130,6 +130,7 @@ install:
         - |
           if [ -f "{{.V2_CONFIG_FILE}}" ]; then
             sed -i.bak "/^staging/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
+            sed -i.bak "/^fedramp/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^enable_process_metrics/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^status_server_enabled/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
             sed -i.bak "/^status_server_port/d" "{{.V2_CONFIG_FILE}}" && rm "{{.V2_CONFIG_FILE}}".bak
@@ -142,6 +143,9 @@ install:
         - |
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> "{{.V2_CONFIG_FILE}}"
+          fi
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> "{{.V2_CONFIG_FILE}}"
           fi
           echo 'enable_process_metrics: true' >> "{{.V2_CONFIG_FILE}}"
           echo 'status_server_enabled: true' >> "{{.V2_CONFIG_FILE}}"

--- a/recipes/newrelic/infrastructure/debian.yml
+++ b/recipes/newrelic/infrastructure/debian.yml
@@ -157,12 +157,13 @@ install:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
             sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sed -i "/^fedramp/d" /etc/newrelic-infra.yml
             sed -i "/^enable_process_metrics/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml            
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
 
           else
             touch /etc/newrelic-infra.yml
@@ -170,6 +171,9 @@ install:
         - |
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> /etc/newrelic-infra.yml
+          fi
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> /etc/newrelic-infra.yml
           fi
           echo 'enable_process_metrics: true' >> /etc/newrelic-infra.yml
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml

--- a/recipes/newrelic/infrastructure/suse.yml
+++ b/recipes/newrelic/infrastructure/suse.yml
@@ -138,12 +138,13 @@ install:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
             sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sed -i "/^fedramp/d" /etc/newrelic-infra.yml
             sed -i "/^enable_process_metrics/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
             sed -i "/^license_key/d" /etc/newrelic-infra.yml
             sed -i '/^custom_attributes:/,/^\S/{ /^\S/!d }' /etc/newrelic-infra.yml
-            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml                      
+            sed -i '/^custom_attributes:/d' /etc/newrelic-infra.yml
           else
             touch /etc/newrelic-infra.yml
           fi
@@ -151,7 +152,9 @@ install:
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> /etc/newrelic-infra.yml
           fi
-
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> /etc/newrelic-infra.yml
+          fi
           echo 'enable_process_metrics: true' >> /etc/newrelic-infra.yml
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml
           echo 'status_server_port: 18003' >> /etc/newrelic-infra.yml

--- a/recipes/newrelic/infrastructure/ubuntu.yml
+++ b/recipes/newrelic/infrastructure/ubuntu.yml
@@ -144,6 +144,7 @@ install:
         - |
           if [ -f /etc/newrelic-infra.yml ]; then
             sed -i "/^staging/d" /etc/newrelic-infra.yml
+            sed -i "/^fedramp/d" /etc/newrelic-infra.yml
             sed -i "/^enable_process_metrics/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_enabled/d" /etc/newrelic-infra.yml
             sed -i "/^status_server_port/d" /etc/newrelic-infra.yml
@@ -156,6 +157,9 @@ install:
         - |
           if [ $(echo {{.NEW_RELIC_REGION}} | grep -i staging | wc -l) -gt 0 ]; then
             echo 'staging: true' >> /etc/newrelic-infra.yml
+          fi
+          if echo {{.NEW_RELIC_REGION}} | grep -iqE '^(gov|fedramp)$'; then
+            echo 'fedramp: true' >> /etc/newrelic-infra.yml
           fi
           echo 'enable_process_metrics: true' >> /etc/newrelic-infra.yml
           echo 'status_server_enabled: true' >> /etc/newrelic-infra.yml

--- a/recipes/newrelic/infrastructure/windows.yml
+++ b/recipes/newrelic/infrastructure/windows.yml
@@ -249,6 +249,9 @@ install:
             if ($Region -ilike "staging") {
               Add-Content -Path $Path -Value "staging: true" -Encoding utf8
             }
+            if ($Region -ilike "gov" -or $Region -ilike "fedramp") {
+              Add-Content -Path $Path -Value "fedramp: true" -Encoding utf8
+            }
             Add-Content -Path $Path -Value "license_key: $LicenseKey" -Encoding utf8
             Add-Content -Path $Path -Value "enable_process_metrics: true" -Encoding utf8
             Add-Content -Path $Path -Value "status_server_enabled: true" -Encoding utf8


### PR DESCRIPTION
## Summary

When `NEW_RELIC_REGION` is `GOV` or `FEDRAMP`, the infrastructure agent requires `fedramp: true` in `newrelic-infra.yml` to route all ingest to the FedRAMP-compliant `gov-*` endpoints. Without this flag the agent silently 401s against the US ingest cell — confirmed by end-to-end testing on Ubuntu 22.04.

## Why `fedramp: true` is the correct and only attribute needed

Verified directly from [`pkg/config/config.go`](https://github.com/newrelic/infrastructure-agent/blob/master/pkg/config/config.go) and [`pkg/config/defaults.go`](https://github.com/newrelic/infrastructure-agent/blob/master/pkg/config/defaults.go) in `newrelic/infrastructure-agent`:

```go
Fedramp bool `yaml:"fedramp" envconfig:"fedramp" public:"true"`
```

When `fedramp: true`, the agent routes to:
| Endpoint | URL |
|---|---|
| Collector (ingest) | `gov-infra-api.newrelic.com` |
| Identity | `gov-identity-api.newrelic.com` |
| Command channel | `gov-infrastructure-command-api.newrelic.com` |
| Metrics | `gov-metric-api.newrelic.com` |

No other config attributes are required. `fedramp` is checked before `staging` in the agent's URL calculation, so the two flags don't conflict (though they'd never be set together in practice).

`FIPS` mode (`NEW_RELIC_FIPS_ENABLED`) is a separate concern — it installs the FIPS-crypto binary variant. This PR does not touch FIPS handling.

## Changes

All 7 platform recipes are updated with the same two-part change:

**Linux / macOS** (`ubuntu.yml`, `debian.yml`, `centos_rhel.yml`, `awslinux.yml`, `suse.yml`, `darwin.yml`):
1. Add `sed -i "/^fedramp/d"` to the cleanup block so reinstalling with a non-GOV region removes any leftover `fedramp: true`
2. Write `fedramp: true` when `NEW_RELIC_REGION` matches `^(gov|fedramp)$` (case-insensitive, exact match — not a substring)

**Windows** (`windows.yml`):
1. Add `fedramp: true` branch in `Write-FreshConfig` (which always writes a fresh file, so no cleanup step needed)

## Non-regression guarantee

- The `grep -iqE '^(gov|fedramp)$'` pattern is an **exact** case-insensitive match — it will not match `staging`, `us`, `eu`, `jp`, or any other value
- US/EU/JP/Staging installs are completely unaffected
- The `sed -i "/^fedramp/d"` cleanup is a no-op when the key is not present

## Test evidence

End-to-end test on Ubuntu 22.04 EC2, kernel 6.8 (us-west-2):
- Without `fedramp: true`: infra agent 401s on every push to `infra-api.newrelic.com`
- With `fedramp: true` manually added: infra agent routes to `gov-infra-api.newrelic.com`, 19 `SystemSample` events confirmed in GOV account (account 4012030) via NRQL within 60 seconds

## Related

- `newrelic/newrelic-client-go` [PR #1434](https://github.com/newrelic/newrelic-client-go/pull/1434) (merged, released as v2.91.0) — defines the GOV region with FedRAMP-compliant endpoints
- `newrelic/newrelic-cli` [PR #1866](https://github.com/newrelic/newrelic-cli/pull/1866) — accepts `GOV` and `FEDRAMP` as valid `NEW_RELIC_REGION` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)