### PR TITLE
[ebpf] Release 1.5.0 changes

### DIFF
--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -344,7 +344,7 @@ install:
             # 'auto' (send only when neither APM nor OTel agent is attached)
             enabled: ${AI_MONITORING_ENABLED:-false}
             # samplingLatency represents the sampling latency threshold for the spans to export.
-            # Options: p1, p10, p50, p90, p99.
+            # Options: any percentile from p0 to p99 (e.g., p0, p1, p5, p10, p50, p90, p99).
             samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
             # -- samplingErrorRate represents the error rate threshold
             # for an HTTP route where surpassing it would mean the
@@ -388,8 +388,6 @@ install:
           # Configure filters to drop all types of data (Network Metrics and APM data) based on config provided
           allDataFilters:
             # -- Define a regex to match k8s service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
-            # RENAMED from 'dropServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
             dropServiceNameRegex: ""
@@ -397,8 +395,6 @@ install:
             # Service names that match this regex will not have their data dropped by the dropServiceNameRegex.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
-            # RENAMED from 'allowServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             keepServiceNameRegex: ""
             # -- Drop all data for applications/entities that have NewRelic/OTEL APM agents running
             dropApmAgentEnabledEntity: false

--- a/recipes/newrelic/ebpf/awslinux.yml
+++ b/recipes/newrelic/ebpf/awslinux.yml
@@ -206,13 +206,13 @@ install:
           echo "License key validated."
 
           # Validate DEPLOYMENT_NAME (required unless Agent Control mode)
-          if [[ -z "${DEPLOYMENT_NAME:-}" && "${NEW_RELIC_AGENT_CONTROL:-}" != "true" ]]; then
-            echo ""
-            echo -e "\e[31mERROR:\e[0m DEPLOYMENT_NAME is required but not set. Aborting installation."
-            echo ""
-            exit 1
-          fi
-          echo "Deployment name validated."
+          # if [[ -z "${DEPLOYMENT_NAME:-}" && "${NEW_RELIC_AGENT_CONTROL:-}" != "true" ]]; then
+          #   echo ""
+          #   echo -e "\e[31mERROR:\e[0m DEPLOYMENT_NAME is required but not set. Aborting installation."
+          #   echo ""
+          #   exit 1
+          # fi
+          # echo "Deployment name validated."
 
           # Set default log file path if not provided
           if [[ -z "${NEW_RELIC_LOG_FILE_PATH:-}" ]]; then
@@ -338,12 +338,39 @@ install:
           # Accepted values: 'true' (always send), 'false' (never send)
           # and 'auto' (send only when APM is not attached)
           reportLogs: "${REPORT_LOGS:-false}"
-          # -- Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.
-          # Accepted values: 'true' (always send), 'false' (never send) and 'auto'
-          reportAiMetrics: "false"
-          # -- Enable GenAI capture message content. When enabled, the agent captures
-          # message content for GenAI interactions. Use with caution.
-          genAICaptureMessageContent: false
+          ai_monitoring:
+            # -- Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.
+            # Accepted values: 'true' (always send), 'false' (never send) and
+            # 'auto' (send only when neither APM nor OTel agent is attached)
+            enabled: ${AI_MONITORING_ENABLED:-false}
+            # samplingLatency represents the sampling latency threshold for the spans to export.
+            # Options: p1, p10, p50, p90, p99.
+            samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
+            # -- samplingErrorRate represents the error rate threshold
+            # for an HTTP route where surpassing it would mean the
+            # corresponding spans of the route are exported.
+            # Options: 1-100
+            samplingErrorRate: "${AI_MONITORING_SAMPLING_ERROR_RATE:-}"
+            # -- Enable GenAI capture message content. When enabled, the agent captures
+            # message content for GenAI interactions. Use with caution.
+            genAICaptureMessageContent: ${AI_MONITORING_GENAI_CAPTURE_MESSAGE_CONTENT:-false}
+
+          # -- HTTP path normalization patterns. Each pattern must contain at least one * wildcard.
+          # Use '!' prefix for exclusion patterns to preserve paths as-is (skip auto-clustering).
+          # Patterns are applied before auto-clustering and take precedence over it.
+          # Example:
+          # httpPathNormalizationPatterns:
+          #   - "/api/users/*"
+          #   - "/api/orders/*"
+          #   - "!/health/*"
+          httpPathNormalizationPatterns: []
+
+          # -- Maximum number of bytes captured from an HTTP request/response body.
+          # Default: 1048576 (1MB) when ai_monitoring.enabled is 'true' or 'auto', otherwise 1024 (1KB).
+          # Increase this value if AI monitoring payloads are being truncated.
+          # Example: 2097152 for 2MB
+          httpBodyLimitBytes: ""
+
           # Capability to include/exclude port from entity name, default: true. ex: python:frosty_merkle:[80]
           # Set it to false, to exclude ports from entity name, ex: python:frosty_merkle
           includePortInServerEntityIdentification: true

--- a/recipes/newrelic/ebpf/centos.yml
+++ b/recipes/newrelic/ebpf/centos.yml
@@ -337,7 +337,7 @@ install:
             # 'auto' (send only when neither APM nor OTel agent is attached)
             enabled: ${AI_MONITORING_ENABLED:-false}
             # samplingLatency represents the sampling latency threshold for the spans to export.
-            # Options: p1, p10, p50, p90, p99.
+            # Options: any percentile from p0 to p99 (e.g., p0, p1, p5, p10, p50, p90, p99).
             samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
             # -- samplingErrorRate represents the error rate threshold
             # for an HTTP route where surpassing it would mean the
@@ -381,8 +381,6 @@ install:
           # Configure filters to drop all types of data (Network Metrics and APM data) based on config provided
           allDataFilters:
             # -- Define a regex to match k8s service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
-            # RENAMED from 'dropServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
             dropServiceNameRegex: ""
@@ -390,8 +388,6 @@ install:
             # Service names that match this regex will not have their data dropped by the dropServiceNameRegex.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
-            # RENAMED from 'allowServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             keepServiceNameRegex: ""
             # -- Drop all data for applications/entities that have NewRelic/OTEL APM agents running
             dropApmAgentEnabledEntity: false

--- a/recipes/newrelic/ebpf/suse.yml
+++ b/recipes/newrelic/ebpf/suse.yml
@@ -7,35 +7,19 @@ description: New Relic install recipe for the eBPF agent
 repository: https://github.com/newrelic/newrelic-ebpf-agent
 
 installTargets:
+  # - type: host
+  #   os: linux
+  #   platform: suse
   - type: host
     os: linux
-    platform: "redhat"
-    platformFamily: rhel
-    platformVersion: "((8|9|10)\\.?.*)"
-  - type: host
-    os: linux
-    platform: "centos"
-    platformFamily: rhel
-    platformVersion: "((9|10)\\.?.*)"
-  - type: host
-    os: linux
-    platform: "almalinux"
-    platformFamily: rhel
-    platformVersion: "((9|10)\\.?.*)"
-  - type: host
-    os: linux
-    platform: "oracle"
-    platformVersion: "(8|9|10)\\.*"
-
+    platformFamily: suse
 
 keywords:
   - eBPF
   - Agent
   - Linux
-  - CentOS 10
-  - CentOS 9
-  - RHEL 8
-  - RHEL 9
+  - Suse
+  - SLES
 
 processMatch: []
 
@@ -115,11 +99,11 @@ install:
           KERNEL_VERSION=$(uname -r | cut -d'-' -f1)
           KERNEL_MAJOR=$(echo $KERNEL_VERSION | cut -d'.' -f1)
           KERNEL_MINOR=$(echo $KERNEL_VERSION | cut -d'.' -f2)
-          
+
           # Convert to comparable format (e.g., 5.8 becomes 508, 4.19 becomes 419)
           KERNEL_NUM=$((KERNEL_MAJOR * 100 + KERNEL_MINOR))
           REQUIRED_KERNEL_NUM=508  # 5.8
-          
+
           if [ $KERNEL_NUM -lt $REQUIRED_KERNEL_NUM ]; then
             echo ""
             echo -e "\e[31mERROR:\e[0m eBPF agent requires Linux kernel version 5.8 or higher." >&2
@@ -175,7 +159,7 @@ install:
                   echo "Please remove the existing setup and do a fresh installation."
                   echo ""
                   echo "To remove the existing installation, run:"
-                  echo "  sudo yum remove newrelic-ebpf-agent"
+                  echo "  sudo zypper remove newrelic-ebpf-agent"
                   echo ""
                   exit 25
                 fi
@@ -275,7 +259,7 @@ install:
           # -- Unique name for the deployment to identify data posting via eBPF Agent
           deploymentName: "${DEPLOYMENT_NAME:-}"
           # -- If using a customSecretLicenseKey, you must supply your
-          # region "US"/"EU"/"JP". Otherwise, leave this value as an empty string.
+          # region "US"/"EU". Otherwise, leave this value as an empty string.
           region: "${NEW_RELIC_REGION}"
           # -- Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.
           customOtlpEndpoint: ""
@@ -529,23 +513,34 @@ install:
           EOS
 
           echo "YAML configuration file created successfully at $CONFIG_FILE"
-    
+
     install_linux_headers:
       cmds:
         - |
           KERNEL_VERSION=$(uname -r)
           echo "Installing kernel headers for kernel version: $KERNEL_VERSION"
-          if echo "$KERNEL_VERSION" | grep -q "uek"; then
-            # Oracle Linux UEK: kernel-uek-devel contains all headers needed; no separate kernel-uek-headers package exists
-            if yum install -y "kernel-uek-devel-$KERNEL_VERSION"; then
+          # Detect kernel flavor from uname (e.g., default, azure, rt)
+          KERNEL_FLAVOR=$(echo "$KERNEL_VERSION" | grep -oP '[^-]+$')
+          # Get exact package version from the RPM that owns the running kernel
+          # Try vmlinuz (x86_64) first, then Image (aarch64)
+          KERNEL_PKG_VERSION=""
+          if [[ -f "/boot/vmlinuz-${KERNEL_VERSION}" ]]; then
+            KERNEL_PKG_VERSION=$(rpm -qf "/boot/vmlinuz-${KERNEL_VERSION}" --queryformat '%{VERSION}-%{RELEASE}\n' 2>/dev/null | head -1)
+          elif [[ -f "/boot/Image-${KERNEL_VERSION}" ]]; then
+            KERNEL_PKG_VERSION=$(rpm -qf "/boot/Image-${KERNEL_VERSION}" --queryformat '%{VERSION}-%{RELEASE}\n' 2>/dev/null | head -1)
+          fi
+          if [[ -n "$KERNEL_PKG_VERSION" ]]; then
+            echo "Found matching kernel package version: $KERNEL_PKG_VERSION"
+            if zypper --non-interactive install "kernel-${KERNEL_FLAVOR}-devel=${KERNEL_PKG_VERSION}"; then
               echo "Kernel headers installed successfully for kernel $KERNEL_VERSION."
             else
               echo ""
-              echo -e "\e[31mERROR:\e[0m Failed to install UEK kernel headers for kernel $KERNEL_VERSION. Ensure the Oracle Linux UEK repo is enabled (e.g. ol8_UEKR7) and try again."
+              echo -e "\e[31mERROR:\e[0m Failed to install kernel headers for kernel $KERNEL_VERSION. Please ensure the correct headers are available and try again."
               echo ""
             fi
           else
-            if yum install -y "kernel-devel-$KERNEL_VERSION" "kernel-headers-$KERNEL_VERSION"; then
+            echo "Could not determine exact kernel package version, installing latest kernel-${KERNEL_FLAVOR}-devel"
+            if zypper --non-interactive install "kernel-${KERNEL_FLAVOR}-devel"; then
               echo "Kernel headers installed successfully for kernel $KERNEL_VERSION."
             else
               echo ""
@@ -559,21 +554,25 @@ install:
       cmds:
         - |
           ARCH=$(uname -m)
-          REPO_URL=$(echo -n "https://download.newrelic.com/preview/linux/yum/el/{{.DISTRO_VERSION}}/$ARCH/newrelic-infra.repo")
+          REPO_URL=$(echo -n "https://download.newrelic.com/preview/linux/zypp/sles/{{.SLES_VERSION}}/$ARCH/newrelic-infra.repo")
           IS_NEWRELIC_AVAILABLE=$(curl -Ls $REPO_URL | grep "\[newrelic-infra\]" | wc -l)
           if [ $IS_NEWRELIC_AVAILABLE -eq 0 ] ; then
             echo "newrelic infrastructure agent is not available for this architecture "$ARCH". See our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic" >&2
             exit 131
           fi
 
-          curl -s $REPO_URL -o /etc/yum.repos.d/newrelic-infra.repo
-          yum -y -q makecache --disablerepo='*' --enablerepo='newrelic-infra'
-          yum -y -q install newrelic-ebpf-agent || {
+          curl -s $REPO_URL -o /etc/zypp/repos.d/newrelic-infra.repo
+          curl -s -L https://download.newrelic.com/infrastructure_agent/keys/newrelic_rpm_key_current.gpg > newrelic_rpm_key_current.gpg
+          rpm --import newrelic_rpm_key_current.gpg
+          zypper -n --quiet ref -r newrelic-infra
+
+          zypper -n --quiet install newrelic-ebpf-agent || {
             echo ""
             echo -e "\e[31mERROR:\e[0m newrelic-ebpf-agent installation failed. Aborting installation."
             echo ""
             exit 1
           }
+          rm -f newrelic_rpm_key_current.gpg
 
           # Verify package was actually installed
           if ! rpm -q newrelic-ebpf-agent &>/dev/null; then
@@ -585,11 +584,10 @@ install:
 
           echo "eBPF agent package installed successfully."
       vars:
-        DISTRO_VERSION:
-          sh: |
-            rpm -E %{rhel}
+        SLES_VERSION:
+          sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release
       silent: true
-    
+
     # When the eBPF agent is installed alongside Agent Control, the default services are disabled
     # and the binary execution is orchestrated by Agent Control
     disable_service_for_agent_control:

--- a/recipes/newrelic/ebpf/suse.yml
+++ b/recipes/newrelic/ebpf/suse.yml
@@ -321,7 +321,7 @@ install:
             # 'auto' (send only when neither APM nor OTel agent is attached)
             enabled: ${AI_MONITORING_ENABLED:-false}
             # samplingLatency represents the sampling latency threshold for the spans to export.
-            # Options: p1, p10, p50, p90, p99.
+            # Options: any percentile from p0 to p99 (e.g., p0, p1, p5, p10, p50, p90, p99).
             samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
             # -- samplingErrorRate represents the error rate threshold
             # for an HTTP route where surpassing it would mean the
@@ -365,8 +365,6 @@ install:
           # Configure filters to drop all types of data (Network Metrics and APM data) based on config provided
           allDataFilters:
             # -- Define a regex to match k8s service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
-            # RENAMED from 'dropServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
             dropServiceNameRegex: ""
@@ -374,8 +372,6 @@ install:
             # Service names that match this regex will not have their data dropped by the dropServiceNameRegex.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
-            # RENAMED from 'allowServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             keepServiceNameRegex: ""
             # -- Drop all data for applications/entities that have NewRelic/OTEL APM agents running
             dropApmAgentEnabledEntity: false

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -10,11 +10,11 @@ installTargets:
   - type: host
     os: linux
     platform: "ubuntu"
-    platformVersion: "((20|22|24)\\.04)"
+    platformVersion: "((20|22|24|26)\\.04)"
   - type: host
     os: linux
     platform: "debian"
-    platformVersion: "((11|12)\\.?.*)"
+    platformVersion: "((11|12|13)\\.?.*)"
 
 keywords:
   - eBPF
@@ -195,13 +195,13 @@ install:
           echo "License key validated."
 
           # Validate DEPLOYMENT_NAME (required unless Agent Control mode)
-          if [[ -z "${DEPLOYMENT_NAME:-}" && "${NEW_RELIC_AGENT_CONTROL:-}" != "true" ]]; then
-            echo ""
-            echo -e "\e[31mERROR:\e[0m DEPLOYMENT_NAME is required but not set. Aborting installation."
-            echo ""
-            exit 1
-          fi
-          echo "Deployment name validated."
+          # if [[ -z "${DEPLOYMENT_NAME:-}" && "${NEW_RELIC_AGENT_CONTROL:-}" != "true" ]]; then
+          #   echo ""
+          #   echo -e "\e[31mERROR:\e[0m DEPLOYMENT_NAME is required but not set. Aborting installation."
+          #   echo ""
+          #   exit 1
+          # fi
+          # echo "Deployment name validated."
 
           # Set default log file path if not provided
           if [[ -z "${NEW_RELIC_LOG_FILE_PATH:-}" ]]; then
@@ -327,12 +327,39 @@ install:
           # Accepted values: 'true' (always send), 'false' (never send)
           # and 'auto' (send only when APM is not attached)
           reportLogs: "${REPORT_LOGS:-false}"
-          # -- Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.
-          # Accepted values: 'true' (always send), 'false' (never send) and 'auto'
-          reportAiMetrics: "false"
-          # -- Enable GenAI capture message content. When enabled, the agent captures
-          # message content for GenAI interactions. Use with caution.
-          genAICaptureMessageContent: false
+          ai_monitoring:
+            # -- Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.
+            # Accepted values: 'true' (always send), 'false' (never send) and
+            # 'auto' (send only when neither APM nor OTel agent is attached)
+            enabled: ${AI_MONITORING_ENABLED:-false}
+            # samplingLatency represents the sampling latency threshold for the spans to export.
+            # Options: p1, p10, p50, p90, p99.
+            samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
+            # -- samplingErrorRate represents the error rate threshold
+            # for an HTTP route where surpassing it would mean the
+            # corresponding spans of the route are exported.
+            # Options: 1-100
+            samplingErrorRate: "${AI_MONITORING_SAMPLING_ERROR_RATE:-}"
+            # -- Enable GenAI capture message content. When enabled, the agent captures
+            # message content for GenAI interactions. Use with caution.
+            genAICaptureMessageContent: ${AI_MONITORING_GENAI_CAPTURE_MESSAGE_CONTENT:-false}
+
+          # -- HTTP path normalization patterns. Each pattern must contain at least one * wildcard.
+          # Use '!' prefix for exclusion patterns to preserve paths as-is (skip auto-clustering).
+          # Patterns are applied before auto-clustering and take precedence over it.
+          # Example:
+          # httpPathNormalizationPatterns:
+          #   - "/api/users/*"
+          #   - "/api/orders/*"
+          #   - "!/health/*"
+          httpPathNormalizationPatterns: []
+
+          # -- Maximum number of bytes captured from an HTTP request/response body.
+          # Default: 1048576 (1MB) when ai_monitoring.enabled is 'true' or 'auto', otherwise 1024 (1KB).
+          # Increase this value if AI monitoring payloads are being truncated.
+          # Example: 2097152 for 2MB
+          httpBodyLimitBytes: ""
+
           # Capability to include/exclude port from entity name, default: true. ex: python:frosty_merkle:[80]
           # Set it to false, to exclude ports from entity name, ex: python:frosty_merkle
           includePortInServerEntityIdentification: true
@@ -569,28 +596,21 @@ install:
 
           # Install the eBPF agent package
           apt-get $OPTIONS install -yq --no-install-recommends newrelic-ebpf-agent || {
-            echo "Error: newrelic-ebpf-agent installation failed"
-            echo "Attempting to configure the packages again"
-            dpkg --configure -a
-            # Check if there was an error
-            if [ $? -ne 0 ]; then
-              echo "Error found while reconfiguring dpkg database"
-              # Force-Install the Software
-              echo "Attempting to install any missing dependencies or fixes broken packages."
-              apt-get $OPTIONS install -f
-              if [ $? -ne 0 ]; then
+            # apt returned non-zero - check if eBPF agent was actually installed despite the error.
+            # dpkg exits non-zero when any package fails to configure, even ones unrelated to the
+            # eBPF agent (e.g. a broken nginx whose post-install script fails to bind its port).
+            if ! dpkg -l | grep -q "^ii.*newrelic-ebpf-agent"; then
+              echo "Attempting to configure the packages again"
+              dpkg --configure -a 2>/dev/null || true
+              apt-get $OPTIONS install -f -yq 2>/dev/null || true
+              if ! dpkg -l | grep -q "^ii.*newrelic-ebpf-agent"; then
+                echo ""
+                echo -e "\e[31mERROR:\e[0m newrelic-ebpf-agent installation failed. Aborting installation."
+                echo ""
                 exit 1
               fi
             fi
           }
-
-          # Verify package was actually installed
-          if ! dpkg -l | grep -q "^ii.*newrelic-ebpf-agent"; then
-            echo ""
-            echo -e "\e[31mERROR:\e[0m newrelic-ebpf-agent installation failed. Aborting installation."
-            echo ""
-            exit 1
-          fi
 
           echo "eBPF agent package installed successfully."
 

--- a/recipes/newrelic/ebpf/ubuntu.yml
+++ b/recipes/newrelic/ebpf/ubuntu.yml
@@ -333,7 +333,7 @@ install:
             # 'auto' (send only when neither APM nor OTel agent is attached)
             enabled: ${AI_MONITORING_ENABLED:-false}
             # samplingLatency represents the sampling latency threshold for the spans to export.
-            # Options: p1, p10, p50, p90, p99.
+            # Options: any percentile from p0 to p99 (e.g., p0, p1, p5, p10, p50, p90, p99).
             samplingLatency: "${AI_MONITORING_SAMPLING_LATENCY:-p50}"
             # -- samplingErrorRate represents the error rate threshold
             # for an HTTP route where surpassing it would mean the
@@ -377,8 +377,6 @@ install:
           # Configure filters to drop all types of data (Network Metrics and APM data) based on config provided
           allDataFilters:
             # -- Define a regex to match k8s service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
-            # RENAMED from 'dropServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
             dropServiceNameRegex: ""
@@ -386,8 +384,6 @@ install:
             # Service names that match this regex will not have their data dropped by the dropServiceNameRegex.
             # Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both.
             # If both are provided, keepServiceNameRegex takes precedence.
-            # RENAMED from 'allowServiceNameRegex' for clarity. The old name
-            # is deprecated but still supported for backward compatibility.
             keepServiceNameRegex: ""
             # -- Drop all data for applications/entities that have NewRelic/OTEL APM agents running
             dropApmAgentEnabledEntity: false

--- a/recipes/newrelic/infrastructure/kubernetes.yml
+++ b/recipes/newrelic/infrastructure/kubernetes.yml
@@ -89,9 +89,9 @@ install:
 
           # Current EBPF integration
           NR_CLI_EBPF_AGENT="{{.NR_CLI_EBPF_AGENT}}"
-          NR_CLI_EBPF_AGENT_APM_DATA_REPORTING="{{.NR_CLI_EBPF_AGENT_APM_DATA_REPORTING}}"
-          NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING="{{.NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING}}"
-          NR_CLI_EBPF_AGENT_LOG_REPORTING="{{.NR_CLI_EBPF_AGENT_LOG_REPORTING}}"
+          NR_CLI_EBPF_AGENT_REPORT_APM_DATA="{{.NR_CLI_EBPF_AGENT_REPORT_APM_DATA}}"
+          NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS="{{.NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS}}"
+          NR_CLI_EBPF_AGENT_REPORT_LOGS="{{.NR_CLI_EBPF_AGENT_REPORT_LOGS}}"
           NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED="{{.NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED}}"
 
           # Prometheus integrations
@@ -309,10 +309,10 @@ install:
 
           # Current EBPF integration
           NR_CLI_EBPF_AGENT=${NR_CLI_EBPF_AGENT:-false}
-          NR_CLI_EBPF_AGENT_APM_DATA_REPORTING=${NR_CLI_EBPF_AGENT_APM_DATA_REPORTING:-true}
-          NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING=${NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING:-true}
-          NR_CLI_EBPF_AGENT_LOG_REPORTING=${NR_CLI_EBPF_AGENT_LOG_REPORTING:-false}
-          NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED=${NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED:-false}
+          NR_CLI_EBPF_AGENT_REPORT_APM_DATA=${NR_CLI_EBPF_AGENT_REPORT_APM_DATA:-auto}
+          NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS=${NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS:-auto}
+          NR_CLI_EBPF_AGENT_REPORT_LOGS=${NR_CLI_EBPF_AGENT_REPORT_LOGS:-false}
+          NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED=${NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED:-true}
 
           # Prometheus integrations
 
@@ -645,9 +645,9 @@ install:
 
             # Current EBPF integration
             ARGS="${ARGS} --set nr-ebpf-agent.enabled=${NR_CLI_EBPF_AGENT}"
-            ARGS="${ARGS} --set nr-ebpf-agent.apmDataReporting=${NR_CLI_EBPF_AGENT_APM_DATA_REPORTING}"
-            ARGS="${ARGS} --set nr-ebpf-agent.networkMetricsReporting=${NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING}"
-            ARGS="${ARGS} --set nr-ebpf-agent.logReporting=${NR_CLI_EBPF_AGENT_LOG_REPORTING}"
+            ARGS="${ARGS} --set nr-ebpf-agent.reportApmData=${NR_CLI_EBPF_AGENT_REPORT_APM_DATA}"
+            ARGS="${ARGS} --set nr-ebpf-agent.reportNetworkMetrics=${NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS}"
+            ARGS="${ARGS} --set nr-ebpf-agent.reportLogs=${NR_CLI_EBPF_AGENT_REPORT_LOGS}"
             ARGS="${ARGS} --set nr-ebpf-agent.logDataFilters.applicationLogReporting.enabled=${NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED}"
 
             # Prometheus integrations
@@ -776,9 +776,9 @@ install:
 
             # Current EBPF integration
             BODY="${BODY},\"nr-ebpf-agent.enabled\":\"${NR_CLI_EBPF_AGENT}\""
-            BODY="${BODY},\"nr-ebpf-agent.apmDataReporting\":\"${NR_CLI_EBPF_AGENT_APM_DATA_REPORTING}\""
-            BODY="${BODY},\"nr-ebpf-agent.networkMetricsReporting\":\"${NR_CLI_EBPF_AGENT_NETWORK_METRICS_REPORTING}\""
-            BODY="${BODY},\"nr-ebpf-agent.logReporting\":\"${NR_CLI_EBPF_AGENT_LOG_REPORTING}\""
+            BODY="${BODY},\"nr-ebpf-agent.reportApmData\":\"${NR_CLI_EBPF_AGENT_REPORT_APM_DATA}\""
+            BODY="${BODY},\"nr-ebpf-agent.reportNetworkMetrics\":\"${NR_CLI_EBPF_AGENT_REPORT_NETWORK_METRICS}\""
+            BODY="${BODY},\"nr-ebpf-agent.reportLogs\":\"${NR_CLI_EBPF_AGENT_REPORT_LOGS}\""
             BODY="${BODY},\"nr-ebpf-agent.logDataFilters.applicationLogReporting.enabled\":\"${NR_CLI_EBPF_AGENT_APPLICATION_LOG_REPORTING_ENABLED}\""
 
             # Prometheus integrations


### PR DESCRIPTION
- New SUSE/SLES recipe added for the eBPF agent
- Extended OS/platform support: RHEL 10, Oracle Linux (incl. UEK kernel headers), Ubuntu 26.04, Debian 13
- Replaced reportAiMetrics/genAICaptureMessageContent with a nested ai_monitoring config block
- Added httpPathNormalizationPatterns and httpBodyLimitBytes config options
- Relaxed Ubuntu install failure check — only fails if the eBPF agent package itself didn't install
- Renamed and re-defaulted eBPF agent reporting variables in the Kubernetes recipe
- Commented out hard requirement for `DEPLOYMENT_NAME` during installation