### PR TITLE
chore: bump ac version to 1.19.0

### DIFF
--- a/recipes/newrelic/infrastructure/agent-control/debian.yml
+++ b/recipes/newrelic/infrastructure/agent-control/debian.yml
@@ -270,7 +270,7 @@ install:
           fi
       vars:
         # Allows to set a specific version from the cli
-        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.18.0" }}'
+        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.19.0" }}'
       silent: true
 
     config_agent_control:

--- a/recipes/newrelic/infrastructure/agent-control/rhel.yml
+++ b/recipes/newrelic/infrastructure/agent-control/rhel.yml
@@ -200,7 +200,7 @@ install:
           sh: |
             rpm -E %{rhel}
         # Allows to set a specific version from the cli
-        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.18.0" }}'
+        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.19.0" }}'
       silent: true
 
     config_agent_control:

--- a/recipes/newrelic/infrastructure/agent-control/suse.yml
+++ b/recipes/newrelic/infrastructure/agent-control/suse.yml
@@ -153,7 +153,7 @@ install:
         SLES_VERSION:
           sh: awk -F= '/VERSION_ID/ {print $2}' /etc/os-release
         # Allows to set a specific version from the cli
-        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.18.0" }}'
+        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.19.0" }}'
       silent: true
 
     config_agent_control:

--- a/recipes/newrelic/infrastructure/agent-control/windows.yml
+++ b/recipes/newrelic/infrastructure/agent-control/windows.yml
@@ -117,7 +117,7 @@ install:
               }
           '    
       vars:
-        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.18.0" }}'
+        NEW_RELIC_AGENT_VERSION: '{{ .NEW_RELIC_AGENT_VERSION | default "1.19.0" }}'
 
     run_install_ps1:
       cmds:


### PR DESCRIPTION
bump ac version to 1.19.0