### PR TITLE
feat(nrdot-mysql): add MySQL NRDOT recipes (Linux self-hosted + RDS)

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -396,11 +396,8 @@ install:
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
-                insecure_skip_verify: false
-                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
-                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
-                # ca_file: /path/to/global-bundle.pem
+                insecure: true
+                insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
               # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
@@ -652,9 +649,8 @@ install:
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
-                insecure_skip_verify: false
-                # ca_file: /path/to/global-bundle.pem
+                insecure: true
+                insecure_skip_verify: true
               explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -38,10 +38,15 @@ preInstall:
     (the 'root' account or equivalent) on the account running this installation.
 
     Note: this installer connects to MySQL over TCP using a password, so the
-    'root' account must use password-based authentication. On a default
-    Debian/Ubuntu install, 'root'@'localhost' uses the auth_socket plugin
-    (no password, local-socket-only) and will not work here. Switch it first:
-      ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';
+    'root' account must use password-based authentication. On some
+    Debian/Ubuntu installs, 'root'@'localhost' defaults to the auth_socket
+    plugin (no password, local-socket-only) or another state with no known
+    password, and will not work here. Switch it first, run locally as root:
+      mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
+    If that itself fails with "Access denied", the mysql-server package also
+    creates a debian-sys-maint account with known admin credentials in
+    /etc/mysql/debian.cnf for its own maintenance scripts - use it instead:
+      mysql --defaults-file=/etc/mysql/debian.cnf -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
 
 inputVars:
   - name: NR_CLI_MYSQL_CONFIG_PRESET
@@ -59,9 +64,15 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
-    default: ""
+
+# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
+# newrelic-cli's non-interactive mode requires every declared inputVar to
+# either have a non-empty default or be explicitly provided, even when the
+# field is meant to be optional (default: "" is not sufficient - see
+# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
+# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
+# string when unset, which is exactly the "monitor all databases" behavior
+# documented for this field - while still letting users set it via env var.
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -251,7 +251,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           cat > "$SQL_FILE" << EOF
           CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
@@ -307,7 +307,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
           if [ $? -ne 0 ]; then
@@ -316,24 +316,16 @@ install:
             exit 1
           fi
 
-          if [ "$PRESET" = "2" ]; then
-            COLLECTION_INTERVAL="30s"
-            LIMIT_MIB=500
-          else
-            COLLECTION_INTERVAL="15s"
-            LIMIT_MIB=200
-          fi
-
           DATABASE_LINE=""
           if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: ${DATABASE}"
+            DATABASE_LINE="    database: \"${DATABASE}\""
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4317" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4317" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4317" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -367,6 +359,10 @@ install:
                       enabled: false
                     system.paging.faults:
                       enabled: false
+                filesystem:
+                  metrics:
+                    system.filesystem.utilization:
+                      enabled: true
                 disk:
                   metrics:
                     system.disk.merged:
@@ -379,40 +375,48 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
-                processes:
-                process:
-                  mute_process_name_error: true
-                  mute_process_exe_error: true
-                  mute_process_user_error: true
-                  mute_process_io_error: true
-                  metrics:
-                    process.cpu.utilization:
-                      enabled: true
-                    process.memory.utilization:
-                      enabled: true
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                # process:
+                #  metrics:
+                #    process.cpu.utilization:
+                #      enabled: true
+                #    process.cpu.time:
+                #      enabled: false
 
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
-
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
+                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
+                # ca_file: /path/to/global-bundle.pem
+              # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
+              # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
+              # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
+              # Requires one-time setup per schema -- see Prerequisites -> DML query plan collection.
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                # APM-DB correlation: surfaces the nr_service_guid SQL comment tag (e.g. injected by
+                # transaction_tracer.sql_metadata_comments in the Java agent) as db.query.comment_tags /
+                # db.query.comment_tags.nr_service_guid. Empty list by default -- nothing is extracted
+                # unless the key is explicitly allow-listed here.
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -420,109 +424,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-                mysql.connection.count:
-                  enabled: true
-                mysql.connection.errors:
-                  enabled: true
-                mysql.max_used_connections:
-                  enabled: true
-                mysql.client.network.io:
-                  enabled: true
-                mysql.mysqlx_worker_threads:
-                  enabled: true
-                mysql.commands:
-                  enabled: true
-                mysql.query.count:
-                  enabled: true
-                mysql.query.client.count:
-                  enabled: true
-                mysql.query.slow.count:
-                  enabled: true
-                mysql.joins:
-                  enabled: true
-                mysql.statement_event.count:
-                  enabled: true
-                mysql.statement_event.wait.time:
-                  enabled: true
-                mysql.table.average_row_length:
-                  enabled: true
-                mysql.table.rows:
-                  enabled: true
-                mysql.table.size:
-                  enabled: true
-                mysql.table_open_cache:
-                  enabled: true
-                mysql.table.lock_wait.read.count:
-                  enabled: true
-                mysql.table.lock_wait.read.time:
-                  enabled: true
-                mysql.table.lock_wait.write.count:
-                  enabled: true
-                mysql.table.lock_wait.write.time:
-                  enabled: true
-                mysql.replica.sql_delay:
-                  enabled: true
-                mysql.replica.time_behind_source:
-                  enabled: true
-                mysql.page_size:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -607,7 +509,14 @@ install:
                 - key: type
                   action: delete
 
-            cumulativetodelta:
+            cumulative_to_delta:
+
+            transform:
+              trace_statements:
+                - context: span
+                  statements:
+                    - truncate_all(span.attributes, 4095)
+                    - truncate_all(resource.attributes, 4095)
 
             transform/host:
               metric_statements:
@@ -618,17 +527,21 @@ install:
 
           EOF
             cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+            # Static server.address/server.port, reusing the same ${SERVER}/${PORT}
+            # values already set on the receiver's own \`endpoint\` field above -- nrmysqlreceiver
+            # itself emits no server.address/server.port, only its own mysql.instance.endpoint
+            # (a combined "host:port" string). Applies uniformly to both metrics and logs
+            # pipelines since neither depends on how that string is derived.
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
             batch:
-
-            batch/logs:
-              send_batch_size: 15
-              send_batch_max_size: 15
-              timeout: 5s
 
             resource_detection:
               detectors: ["system"]
@@ -637,23 +550,28 @@ install:
                 resource_attributes:
                   host.id:
                     enabled: true
+
             resource_detection/cloud:
               detectors: ["gcp", "ec2", "azure"]
               timeout: 2s
               override: true
+
             resource_detection/env:
               detectors: ["env"]
               timeout: 2s
               override: true
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
             telemetry:
@@ -664,7 +582,7 @@ install:
 
             pipelines:
               metrics/host:
-                receivers: [host_metrics, nrmysql]
+                receivers: [host_metrics]
                 processors:
                   - metrics_transform
                   - filter/exclude_cpu_utilization
@@ -680,60 +598,71 @@ install:
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - cumulativetodelta
-                  - memory_limiter
+                  - cumulative_to_delta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
-              logs/host:
+              metrics/mysql:
                 receivers: [nrmysql]
                 processors:
+                  - resource/mysql
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - batch/logs
-                exporters: [otlphttp]
+                  - batch
+                exporters: [otlp/newrelic]
+
+              logs/mysql:
+                receivers: [nrmysql]
+                processors:
+                  - resource/mysql
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch
+                exporters: [otlp/newrelic]
 
               traces:
                 receivers: [otlp]
-                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                processors: [transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlp/newrelic]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
           receivers:
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
-
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+                # ca_file: /path/to/global-bundle.pem
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -741,63 +670,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -805,39 +678,38 @@ install:
                   enabled: true
 
           processors:
-          EOF
-            cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
-
             batch:
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
-            telemetry:
-              metrics:
-                level: none
-
             pipelines:
               metrics:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
-
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
               logs:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
           EOF
           fi
 
@@ -887,8 +759,9 @@ postInstall:
       View logs:           journalctl -u nrdot-collector -f
       Restart service:     sudo systemctl restart nrdot-collector
 
-      Note: query plans for write statements are not collected by default
-      (explain_mode is left at its "inline" default). Enabling "procedure"
-      mode requires creating an explain_statement stored procedure and
-      granting EXECUTE on it to the monitoring user - see:
+      Note: explain_mode is set to "procedure" to collect query plans for
+      write statements without granting DML privileges to the monitoring
+      user. This falls back to "inline" automatically for any schema where
+      the one-time explain_statement stored procedure hasn't been created -
+      see:
       https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -1,0 +1,883 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+# WORK IN PROGRESS - not for use.
+
+name: nrdot-collector-mysql
+displayName: NRDOT MySQL (Debian/Ubuntu)
+description: New Relic install recipe for MySQL monitoring via NRDOT Collector on Debian/Ubuntu self-hosted environments
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platformFamily: debian
+  - type: host
+    os: linux
+    platform: ubuntu
+
+keywords:
+  - MySQL
+  - MariaDB
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Database
+  - Linux
+  - Debian
+  - Ubuntu
+
+processMatch:
+  - mysqld
+
+preInstall:
+  discoveryMode:
+    - targeted
+  info: |
+    To capture data from MySQL, we need to create/authorize a monitoring identity
+    (a MySQL user). This requires administrative access to your MySQL server
+    (the 'root' account or equivalent) on the account running this installation.
+
+    Note: this installer connects to MySQL over TCP using a password, so the
+    'root' account must use password-based authentication. On a default
+    Debian/Ubuntu install, 'root'@'localhost' uses the auth_socket plugin
+    (no password, local-socket-only) and will not work here. Switch it first:
+      ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';
+
+inputVars:
+  - name: NR_CLI_MYSQL_CONFIG_PRESET
+    prompt: "NRDOT configuration - 1) Standard  2) Full-feature: "
+    default: "1"
+  - name: NR_CLI_MYSQL_SERVER
+    prompt: "MySQL host (e.g. localhost): "
+    default: "localhost"
+  - name: NR_CLI_MYSQL_PORT
+    prompt: "MySQL port: "
+    default: "3306"
+  - name: NR_CLI_MYSQL_ROOT_PASSWORD
+    prompt: "MySQL 'root' password (used once to create the monitoring user): "
+    secret: true
+  - name: NR_CLI_MYSQL_LOGIN_NAME
+    prompt: "Monitoring username: "
+    default: "newrelic"
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+successLinkConfig:
+  type: EXPLORER
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+
+  tasks:
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 131
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if ! command -v mysql > /dev/null 2>&1; then
+            echo "The mysql client is required to configure MySQL monitoring. Please install the mysql-client package and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    assert_mysql_version:
+      cmds:
+        - |
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to connect to MySQL to check its version:" >&2
+            echo "$RESULT" >&2
+            if echo "$RESULT" | grep -qi "Access denied"; then
+              echo "" >&2
+              echo "If this is a default Debian/Ubuntu MySQL install, 'root'@'localhost' likely" >&2
+              echo "uses the auth_socket plugin (no TCP/password access). Switch it first:" >&2
+              echo "  ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';" >&2
+            fi
+            exit 1
+          fi
+
+          MAJOR=$(echo "$RESULT" | grep -oE '^[0-9]+' | head -1)
+          MINOR=$(echo "$RESULT" | grep -oE '^[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+
+          if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 5 ] || { [ "$MAJOR" -eq 5 ] && [ "${MINOR:-0}" -lt 7 ]; }; then
+            echo "MySQL version ${RESULT:-unknown} is not supported. MySQL 5.7 or later is required." >&2
+            exit 1
+          fi
+
+          echo "MySQL version ${RESULT} detected - supported."
+
+          PS_STATUS=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SHOW VARIABLES LIKE 'performance_schema';" 2>&1 | awk '{print $2}')
+          if [ "$PS_STATUS" != "ON" ]; then
+            echo "performance_schema is disabled on this MySQL server." >&2
+            echo "Enable it (performance_schema=ON in my.cnf) and restart MySQL, then re-run this installation." >&2
+            exit 1
+          fi
+
+          echo "performance_schema is enabled."
+
+    install_nrdot:
+      cmds:
+        - |
+          COLLECTOR_DISTRO="nrdot-collector"
+
+          if dpkg -l | grep -q "^ii.*${COLLECTOR_DISTRO} "; then
+            echo "NRDOT Collector is already installed."
+            echo ""
+            echo "Please follow the steps below to complete the setup:"
+            echo ""
+            echo "  1. Create mysql-config.yaml"
+            echo "     if not present. Refer to:"
+            echo "     https://docs.newrelic.com/docs/opentelemetry/database/mysql/hosted/"
+            echo ""
+            echo "  2. Make sure the monitoring user is created"
+            echo "     and has the required permissions granted."
+            echo ""
+            echo "  3. After making the above changes, restart the NRDOT Collector:"
+            echo "     sudo systemctl restart nrdot-collector"
+            echo ""
+            exit 131
+          fi
+
+          COLLECTOR_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name":' | awk -F'"' '{print $4}')
+          if [ -z "$COLLECTOR_VERSION" ]; then
+            echo "Failed to fetch the latest release version from GitHub. Please check your internet connection." >&2
+            exit 1
+          fi
+
+          if [ "$(uname -m)" = "aarch64" ]; then
+            ARCH="arm64"
+          else
+            ARCH="amd64"
+          fi
+
+          DOWNLOAD_URL="https://github.com/newrelic/nrdot-collector-releases/releases/download/${COLLECTOR_VERSION}/${COLLECTOR_DISTRO}_${COLLECTOR_VERSION}_linux_${ARCH}.deb"
+          echo "Installing ${COLLECTOR_DISTRO} version: ${COLLECTOR_VERSION}"
+          echo "Downloading from: ${DOWNLOAD_URL}"
+
+          curl -L --output /tmp/nrdot-collector.deb "$DOWNLOAD_URL"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          dpkg -i /tmp/nrdot-collector.deb
+          if [ $? -ne 0 ]; then
+            echo "Failed to install the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rm -f /tmp/nrdot-collector.deb
+          echo "${COLLECTOR_DISTRO} installed successfully."
+
+    configure_database_user:
+      cmds:
+        - |
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
+          chmod 600 "$CNF_FILE" "$SQL_FILE"
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          cat > "$SQL_FILE" << EOF
+          CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          GRANT SELECT ON performance_schema.* TO '${LOGIN_NAME}'@'%';
+          GRANT UPDATE ON performance_schema.setup_consumers TO '${LOGIN_NAME}'@'%';
+          FLUSH PRIVILEGES;
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" < "$SQL_FILE" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "SQL script failed:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+          echo "$RESULT"
+
+          echo "MySQL monitoring identity configured successfully."
+
+    create_collector_config:
+      cmds:
+        - |
+          PRESET="{{.NR_CLI_MYSQL_CONFIG_PRESET}}"
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+          REGION="{{.NEW_RELIC_REGION}}"
+          LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
+          CONFIG_DIR="/etc/nrdot-collector"
+          CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
+          ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+
+          mkdir -p "$CONFIG_DIR"
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to set the monitoring user's password:" >&2
+            echo "$ALTER_RESULT" >&2
+            exit 1
+          fi
+
+          if [ "$PRESET" = "2" ]; then
+            COLLECTION_INTERVAL="30s"
+            LIMIT_MIB=500
+          else
+            COLLECTION_INTERVAL="15s"
+            LIMIT_MIB=200
+          fi
+
+          DATABASE_LINE=""
+          if [ -n "$DATABASE" ]; then
+            DATABASE_LINE="    database: ${DATABASE}"
+          fi
+
+          case "$REGION" in
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+          esac
+
+          if [ "$PRESET" = "2" ]; then
+            cat > "$CONFIG_PATH" << EOF
+          extensions:
+            health_check:
+
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                http:
+
+            host_metrics:
+              collection_interval: 30s
+              scrapers:
+                cpu:
+                  metrics:
+                    system.cpu.time:
+                      enabled: false
+                    system.cpu.utilization:
+                      enabled: true
+                load:
+                memory:
+                  metrics:
+                    system.memory.utilization:
+                      enabled: true
+                paging:
+                  metrics:
+                    system.paging.utilization:
+                      enabled: false
+                    system.paging.faults:
+                      enabled: false
+                disk:
+                  metrics:
+                    system.disk.merged:
+                      enabled: false
+                    system.disk.pending_operations:
+                      enabled: false
+                    system.disk.weighted_io_time:
+                      enabled: false
+                network:
+                  metrics:
+                    system.network.connections:
+                      enabled: false
+                processes:
+                process:
+                  mute_process_name_error: true
+                  mute_process_exe_error: true
+                  mute_process_user_error: true
+                  mute_process_io_error: true
+                  metrics:
+                    process.cpu.utilization:
+                      enabled: true
+                    process.memory.utilization:
+                      enabled: true
+
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+                mysql.connection.count:
+                  enabled: true
+                mysql.connection.errors:
+                  enabled: true
+                mysql.max_used_connections:
+                  enabled: true
+                mysql.client.network.io:
+                  enabled: true
+                mysql.mysqlx_worker_threads:
+                  enabled: true
+                mysql.commands:
+                  enabled: true
+                mysql.query.count:
+                  enabled: true
+                mysql.query.client.count:
+                  enabled: true
+                mysql.query.slow.count:
+                  enabled: true
+                mysql.joins:
+                  enabled: true
+                mysql.statement_event.count:
+                  enabled: true
+                mysql.statement_event.wait.time:
+                  enabled: true
+                mysql.table.average_row_length:
+                  enabled: true
+                mysql.table.rows:
+                  enabled: true
+                mysql.table.size:
+                  enabled: true
+                mysql.table_open_cache:
+                  enabled: true
+                mysql.table.lock_wait.read.count:
+                  enabled: true
+                mysql.table.lock_wait.read.time:
+                  enabled: true
+                mysql.table.lock_wait.write.count:
+                  enabled: true
+                mysql.table.lock_wait.write.time:
+                  enabled: true
+                mysql.replica.sql_delay:
+                  enabled: true
+                mysql.replica.time_behind_source:
+                  enabled: true
+                mysql.page_size:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+            metrics_transform:
+              transforms:
+                - include: system.cpu.utilization
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [state]
+                      aggregation_type: mean
+                - include: system.paging.operations
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [direction]
+                      aggregation_type: sum
+
+            filter/exclude_cpu_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+            filter/exclude_memory_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+            filter/exclude_memory_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+            filter/exclude_filesystem_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+            filter/exclude_filesystem_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_filesystem_inodes_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_system_disk:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+            filter/exclude_network:
+              metrics:
+                datapoint:
+                  - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+            attributes/exclude_system_paging:
+              include:
+                match_type: strict
+                metric_names:
+                  - system.paging.operations
+              actions:
+                - key: type
+                  action: delete
+
+            cumulativetodelta:
+
+            transform/host:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(metric.description, "")
+                    - set(metric.unit, "")
+
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+            batch/logs:
+              send_batch_size: 15
+              send_batch_max_size: 15
+              timeout: 5s
+
+            resource_detection:
+              detectors: ["system"]
+              system:
+                hostname_sources: ["os"]
+                resource_attributes:
+                  host.id:
+                    enabled: true
+            resource_detection/cloud:
+              detectors: ["gcp", "ec2", "azure"]
+              timeout: 2s
+              override: true
+            resource_detection/env:
+              detectors: ["env"]
+              timeout: 2s
+              override: true
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            extensions: [health_check]
+
+            pipelines:
+              metrics/host:
+                receivers: [host_metrics, nrmysql]
+                processors:
+                  - metrics_transform
+                  - filter/exclude_cpu_utilization
+                  - filter/exclude_memory_utilization
+                  - filter/exclude_memory_usage
+                  - filter/exclude_filesystem_utilization
+                  - filter/exclude_filesystem_usage
+                  - filter/exclude_filesystem_inodes_usage
+                  - filter/exclude_system_disk
+                  - filter/exclude_network
+                  - attributes/exclude_system_paging
+                  - transform/host
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - cumulativetodelta
+                  - memory_limiter
+                  - batch
+                exporters: [otlphttp]
+
+              logs/host:
+                receivers: [nrmysql]
+                processors:
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch/logs
+                exporters: [otlphttp]
+
+              traces:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              metrics:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+          EOF
+          else
+            cat > "$CONFIG_PATH" << EOF
+          receivers:
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            pipelines:
+              metrics:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+          EOF
+          fi
+
+          cat > "$ENV_FILE" << EOF
+          OTELCOL_OPTIONS="--config=${CONFIG_PATH}"
+          EOF
+
+          chown nrdot-collector:nrdot-collector "$CONFIG_PATH"
+          chmod 600 "$CONFIG_PATH"
+
+          echo "MySQL OTel config written to ${CONFIG_PATH}"
+          echo "Env file written to ${ENV_FILE}"
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl restart nrdot-collector
+
+          echo "Waiting for NRDOT Collector to start..."
+          for i in $(seq 1 30); do
+            if systemctl is-active --quiet nrdot-collector; then
+              echo "NRDOT Collector is running."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "NRDOT Collector did not start in time. Check logs:" >&2
+          journalctl -u nrdot-collector --no-pager -n 50 >&2
+          exit 31
+
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: assert_mysql_version
+        - task: install_nrdot
+        - task: configure_database_user
+        - task: create_collector_config
+        - task: restart_nrdot
+
+postInstall:
+  info: |2
+      MySQL OTel config: /etc/nrdot-collector/mysql-config.yaml
+      Env file:           /etc/nrdot-collector/nrdot-collector.conf
+      Service status:     systemctl status nrdot-collector
+      View logs:           journalctl -u nrdot-collector -f
+      Restart service:     sudo systemctl restart nrdot-collector
+
+      Note: query plans for write statements are not collected by default
+      (explain_mode is left at its "inline" default). Enabling "procedure"
+      mode requires creating an explain_statement stored procedure and
+      granting EXECUTE on it to the monitoring user - see:
+      https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -66,7 +66,6 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -66,6 +66,7 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -730,17 +730,6 @@ install:
           journalctl -u nrdot-collector --no-pager -n 50 >&2
           exit 31
 
-    # TEMPORARY: diagnostic-only task to see why nrmysql receiver metrics
-    # aren't reaching NRDB. Remove once the root cause is confirmed.
-    debug_dump_collector_logs:
-      cmds:
-        - |
-          echo "Waiting 25s for a couple of nrmysql scrape cycles..."
-          sleep 25
-          echo "=== journalctl -u nrdot-collector (last 200 lines) ==="
-          journalctl -u nrdot-collector --no-pager -n 200
-          echo "=== end journalctl ==="
-
     default:
       cmds:
         - task: write_recipe_metadata
@@ -750,7 +739,6 @@ install:
         - task: configure_database_user
         - task: create_collector_config
         - task: restart_nrdot
-        - task: debug_dump_collector_logs
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -385,10 +385,11 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
+                insecure: true
                 insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
@@ -637,10 +638,11 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
+                insecure: true
                 insecure_skip_verify: true
               explain_mode: procedure
               statement_events:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -64,9 +64,6 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -277,7 +274,6 @@ install:
           fi
           SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
           ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
           {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
           NR_ROOT_PW_EOF
@@ -308,11 +304,6 @@ install:
             echo "Failed to set the monitoring user's password:" >&2
             echo "$ALTER_RESULT" >&2
             exit 1
-          fi
-
-          DATABASE_LINE=""
-          if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: \"${DATABASE}\""
           fi
 
           case "$REGION" in
@@ -384,7 +375,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
               collection_interval: 10s
@@ -637,7 +627,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
               collection_interval: 10s

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -385,11 +385,10 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: true
+                insecure: false
                 insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
@@ -638,11 +637,10 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: true
+                insecure: false
                 insecure_skip_verify: true
               explain_mode: procedure
               statement_events:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -64,15 +64,9 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-
-# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
-# newrelic-cli's non-interactive mode requires every declared inputVar to
-# either have a non-empty default or be explicitly provided, even when the
-# field is meant to be optional (default: "" is not sufficient - see
-# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
-# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
-# string when unset, which is exactly the "monitor all databases" behavior
-# documented for this field - while still letting users set it via env var.
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -132,10 +126,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
           if [ $? -ne 0 ]; then
@@ -246,10 +240,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
@@ -302,10 +296,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -730,6 +730,17 @@ install:
           journalctl -u nrdot-collector --no-pager -n 50 >&2
           exit 31
 
+    # TEMPORARY: diagnostic-only task to see why nrmysql receiver metrics
+    # aren't reaching NRDB. Remove once the root cause is confirmed.
+    debug_dump_collector_logs:
+      cmds:
+        - |
+          echo "Waiting 25s for a couple of nrmysql scrape cycles..."
+          sleep 25
+          echo "=== journalctl -u nrdot-collector (last 200 lines) ==="
+          journalctl -u nrdot-collector --no-pager -n 200
+          echo "=== end journalctl ==="
+
     default:
       cmds:
         - task: write_recipe_metadata
@@ -739,6 +750,7 @@ install:
         - task: configure_database_user
         - task: create_collector_config
         - task: restart_nrdot
+        - task: debug_dump_collector_logs
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -1,0 +1,907 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+# WORK IN PROGRESS - not for use.
+
+name: nrdot-collector-mysql-rds
+displayName: NRDOT MySQL RDS (Debian/Ubuntu)
+description: New Relic install recipe for MySQL monitoring via NRDOT Collector on Debian/Ubuntu hosts connecting to AWS RDS/Aurora MySQL instances
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platformFamily: debian
+  - type: host
+    os: linux
+    platform: ubuntu
+
+keywords:
+  - MySQL
+  - MariaDB
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Database
+  - Linux
+  - Debian
+  - Ubuntu
+  - RDS
+  - AWS
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+  info: |
+    To capture data from your AWS RDS/Aurora MySQL instance, we need to create/authorize
+    a monitoring identity (a MySQL user). This requires the RDS master user credentials
+    for your instance, and network connectivity from this host to the RDS endpoint
+    (inbound access on the MySQL port in the RDS security group).
+
+inputVars:
+  - name: NR_CLI_MYSQL_CONFIG_PRESET
+    prompt: "NRDOT configuration - 1) Standard  2) Full-feature: "
+    default: "1"
+  - name: NR_CLI_MYSQL_SERVER
+    prompt: "RDS MySQL/Aurora endpoint (e.g. mydb.xxxxxxxxxx.us-east-1.rds.amazonaws.com): "
+  - name: NR_CLI_MYSQL_PORT
+    prompt: "MySQL port: "
+    default: "3306"
+  - name: NR_CLI_MYSQL_MASTER_USER
+    prompt: "RDS master username: "
+  - name: NR_CLI_MYSQL_MASTER_PASSWORD
+    prompt: "RDS master user password (used once to create the monitoring user): "
+    secret: true
+  - name: NR_CLI_MYSQL_LOGIN_NAME
+    prompt: "Monitoring username: "
+    default: "newrelic"
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
+    default: ""
+  - name: NR_CLI_MYSQL_TLS_CA_FILE
+    prompt: "Path to a CA bundle for validating the RDS TLS certificate (optional): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+successLinkConfig:
+  type: EXPLORER
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+
+  tasks:
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 131
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if ! command -v mysql > /dev/null 2>&1; then
+            echo "The mysql client is required to configure MySQL monitoring. Please install the mysql-client package and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    assert_mysql_version:
+      cmds:
+        - |
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to connect to MySQL to check its version:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+
+          MAJOR=$(echo "$RESULT" | grep -oE '^[0-9]+' | head -1)
+          MINOR=$(echo "$RESULT" | grep -oE '^[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+
+          if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 5 ] || { [ "$MAJOR" -eq 5 ] && [ "${MINOR:-0}" -lt 7 ]; }; then
+            echo "MySQL version ${RESULT:-unknown} is not supported. MySQL 5.7 or later is required." >&2
+            exit 1
+          fi
+
+          echo "MySQL version ${RESULT} detected - supported."
+
+          PS_STATUS=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SHOW VARIABLES LIKE 'performance_schema';" 2>&1 | awk '{print $2}')
+          if [ "$PS_STATUS" != "ON" ]; then
+            echo "performance_schema is disabled on this MySQL server." >&2
+            echo "Enable it (performance_schema=ON in my.cnf) and restart MySQL, then re-run this installation." >&2
+            exit 1
+          fi
+
+          echo "performance_schema is enabled."
+
+    install_nrdot:
+      cmds:
+        - |
+          COLLECTOR_DISTRO="nrdot-collector"
+
+          if dpkg -l | grep -q "^ii.*${COLLECTOR_DISTRO} "; then
+            echo "NRDOT Collector is already installed."
+            echo ""
+            echo "Please follow the steps below to complete the setup:"
+            echo ""
+            echo "  1. Create mysql-config.yaml"
+            echo "     if not present. Refer to:"
+            echo "     https://docs.newrelic.com/docs/opentelemetry/database/mysql/rds/"
+            echo ""
+            echo "  2. Make sure the monitoring user is created"
+            echo "     and has the required permissions granted."
+            echo ""
+            echo "  3. After making the above changes, restart the NRDOT Collector:"
+            echo "     sudo systemctl restart nrdot-collector"
+            echo ""
+            exit 131
+          fi
+
+          COLLECTOR_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name":' | awk -F'"' '{print $4}')
+          if [ -z "$COLLECTOR_VERSION" ]; then
+            echo "Failed to fetch the latest release version from GitHub. Please check your internet connection." >&2
+            exit 1
+          fi
+
+          if [ "$(uname -m)" = "aarch64" ]; then
+            ARCH="arm64"
+          else
+            ARCH="amd64"
+          fi
+
+          DOWNLOAD_URL="https://github.com/newrelic/nrdot-collector-releases/releases/download/${COLLECTOR_VERSION}/${COLLECTOR_DISTRO}_${COLLECTOR_VERSION}_linux_${ARCH}.deb"
+          echo "Installing ${COLLECTOR_DISTRO} version: ${COLLECTOR_VERSION}"
+          echo "Downloading from: ${DOWNLOAD_URL}"
+
+          curl -L --output /tmp/nrdot-collector.deb "$DOWNLOAD_URL"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          dpkg -i /tmp/nrdot-collector.deb
+          if [ $? -ne 0 ]; then
+            echo "Failed to install the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rm -f /tmp/nrdot-collector.deb
+          echo "${COLLECTOR_DISTRO} installed successfully."
+
+    configure_database_user:
+      cmds:
+        - |
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
+          chmod 600 "$CNF_FILE" "$SQL_FILE"
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          cat > "$SQL_FILE" << EOF
+          CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          GRANT SELECT ON performance_schema.* TO '${LOGIN_NAME}'@'%';
+          GRANT UPDATE ON performance_schema.setup_consumers TO '${LOGIN_NAME}'@'%';
+          FLUSH PRIVILEGES;
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" < "$SQL_FILE" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "SQL script failed:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+          echo "$RESULT"
+
+          echo "MySQL monitoring identity configured successfully."
+
+    create_collector_config:
+      cmds:
+        - |
+          PRESET="{{.NR_CLI_MYSQL_CONFIG_PRESET}}"
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
+          TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+          REGION="{{.NEW_RELIC_REGION}}"
+          LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
+          CONFIG_DIR="/etc/nrdot-collector"
+          CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
+          ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+
+          mkdir -p "$CONFIG_DIR"
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to set the monitoring user's password:" >&2
+            echo "$ALTER_RESULT" >&2
+            exit 1
+          fi
+
+          if [ "$PRESET" = "2" ]; then
+            COLLECTION_INTERVAL="30s"
+            LIMIT_MIB=500
+          else
+            COLLECTION_INTERVAL="15s"
+            LIMIT_MIB=200
+          fi
+
+          DATABASE_LINE=""
+          if [ -n "$DATABASE" ]; then
+            DATABASE_LINE="    database: ${DATABASE}"
+          fi
+
+          case "$REGION" in
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+          esac
+
+          if [ "$PRESET" = "2" ]; then
+            cat > "$CONFIG_PATH" << EOF
+          extensions:
+            health_check:
+
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                http:
+
+            host_metrics:
+              collection_interval: 30s
+              scrapers:
+                cpu:
+                  metrics:
+                    system.cpu.time:
+                      enabled: false
+                    system.cpu.utilization:
+                      enabled: true
+                load:
+                memory:
+                  metrics:
+                    system.memory.utilization:
+                      enabled: true
+                paging:
+                  metrics:
+                    system.paging.utilization:
+                      enabled: false
+                    system.paging.faults:
+                      enabled: false
+                disk:
+                  metrics:
+                    system.disk.merged:
+                      enabled: false
+                    system.disk.pending_operations:
+                      enabled: false
+                    system.disk.weighted_io_time:
+                      enabled: false
+                network:
+                  metrics:
+                    system.network.connections:
+                      enabled: false
+                processes:
+                process:
+                  mute_process_name_error: true
+                  mute_process_exe_error: true
+                  mute_process_user_error: true
+                  mute_process_io_error: true
+                  metrics:
+                    process.cpu.utilization:
+                      enabled: true
+                    process.memory.utilization:
+                      enabled: true
+
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+          EOF
+            if [ -n "$TLS_CA_FILE" ]; then
+              echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            fi
+            cat >> "$CONFIG_PATH" << EOF
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+                mysql.connection.count:
+                  enabled: true
+                mysql.connection.errors:
+                  enabled: true
+                mysql.max_used_connections:
+                  enabled: true
+                mysql.client.network.io:
+                  enabled: true
+                mysql.mysqlx_worker_threads:
+                  enabled: true
+                mysql.commands:
+                  enabled: true
+                mysql.query.count:
+                  enabled: true
+                mysql.query.client.count:
+                  enabled: true
+                mysql.query.slow.count:
+                  enabled: true
+                mysql.joins:
+                  enabled: true
+                mysql.statement_event.count:
+                  enabled: true
+                mysql.statement_event.wait.time:
+                  enabled: true
+                mysql.table.average_row_length:
+                  enabled: true
+                mysql.table.rows:
+                  enabled: true
+                mysql.table.size:
+                  enabled: true
+                mysql.table_open_cache:
+                  enabled: true
+                mysql.table.lock_wait.read.count:
+                  enabled: true
+                mysql.table.lock_wait.read.time:
+                  enabled: true
+                mysql.table.lock_wait.write.count:
+                  enabled: true
+                mysql.table.lock_wait.write.time:
+                  enabled: true
+                mysql.replica.sql_delay:
+                  enabled: true
+                mysql.replica.time_behind_source:
+                  enabled: true
+                mysql.page_size:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+            metrics_transform:
+              transforms:
+                - include: system.cpu.utilization
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [state]
+                      aggregation_type: mean
+                - include: system.paging.operations
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [direction]
+                      aggregation_type: sum
+
+            filter/exclude_cpu_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+            filter/exclude_memory_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+            filter/exclude_memory_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+            filter/exclude_filesystem_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+            filter/exclude_filesystem_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_filesystem_inodes_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_system_disk:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+            filter/exclude_network:
+              metrics:
+                datapoint:
+                  - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+            attributes/exclude_system_paging:
+              include:
+                match_type: strict
+                metric_names:
+                  - system.paging.operations
+              actions:
+                - key: type
+                  action: delete
+
+            cumulativetodelta:
+
+            transform/host:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(metric.description, "")
+                    - set(metric.unit, "")
+
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+            batch/logs:
+              send_batch_size: 15
+              send_batch_max_size: 15
+              timeout: 5s
+
+            resource_detection:
+              detectors: ["system"]
+              system:
+                hostname_sources: ["os"]
+                resource_attributes:
+                  host.id:
+                    enabled: true
+            resource_detection/cloud:
+              detectors: ["gcp", "ec2", "azure"]
+              timeout: 2s
+              override: true
+            resource_detection/env:
+              detectors: ["env"]
+              timeout: 2s
+              override: true
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            extensions: [health_check]
+
+            pipelines:
+              metrics/host:
+                receivers: [host_metrics, nrmysql]
+                processors:
+                  - metrics_transform
+                  - filter/exclude_cpu_utilization
+                  - filter/exclude_memory_utilization
+                  - filter/exclude_memory_usage
+                  - filter/exclude_filesystem_utilization
+                  - filter/exclude_filesystem_usage
+                  - filter/exclude_filesystem_inodes_usage
+                  - filter/exclude_system_disk
+                  - filter/exclude_network
+                  - attributes/exclude_system_paging
+                  - transform/host
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - cumulativetodelta
+                  - memory_limiter
+                  - batch
+                exporters: [otlphttp]
+
+              logs/host:
+                receivers: [nrmysql]
+                processors:
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch/logs
+                exporters: [otlphttp]
+
+              traces:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              metrics:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+          EOF
+          else
+            cat > "$CONFIG_PATH" << EOF
+          receivers:
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+          EOF
+            if [ -n "$TLS_CA_FILE" ]; then
+              echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            fi
+            cat >> "$CONFIG_PATH" << EOF
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            pipelines:
+              metrics:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+          EOF
+          fi
+
+          cat > "$ENV_FILE" << EOF
+          OTELCOL_OPTIONS="--config=${CONFIG_PATH}"
+          EOF
+
+          chown nrdot-collector:nrdot-collector "$CONFIG_PATH"
+          chmod 600 "$CONFIG_PATH"
+
+          echo "MySQL OTel config written to ${CONFIG_PATH}"
+          echo "Env file written to ${ENV_FILE}"
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl restart nrdot-collector
+
+          echo "Waiting for NRDOT Collector to start..."
+          for i in $(seq 1 30); do
+            if systemctl is-active --quiet nrdot-collector; then
+              echo "NRDOT Collector is running."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "NRDOT Collector did not start in time. Check logs:" >&2
+          journalctl -u nrdot-collector --no-pager -n 50 >&2
+          exit 31
+
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: assert_mysql_version
+        - task: install_nrdot
+        - task: configure_database_user
+        - task: create_collector_config
+        - task: restart_nrdot
+
+postInstall:
+  info: |2
+      MySQL OTel config: /etc/nrdot-collector/mysql-config.yaml
+      Env file:           /etc/nrdot-collector/nrdot-collector.conf
+      Service status:     systemctl status nrdot-collector
+      View logs:           journalctl -u nrdot-collector -f
+      Restart service:     sudo systemctl restart nrdot-collector
+
+      Note: query plans for write statements are not collected by default
+      (explain_mode is left at its "inline" default). Enabling "procedure"
+      mode requires creating an explain_statement stored procedure and
+      granting EXECUTE on it to the monitoring user - see:
+      https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/
+
+      Note: on RDS/Aurora, the events_waits_current Performance Schema
+      consumer does not persist across restarts or failovers (the
+      mysql8.0/mysql8.4 parameter group families do not expose
+      performance_schema_consumer_* parameters). The monitoring user's
+      GRANT UPDATE ON performance_schema.setup_consumers privilege lets the
+      collector re-enable it on reconnect; otherwise re-run:
+        UPDATE performance_schema.setup_consumers SET enabled='YES'
+          WHERE name = 'events_waits_current';
+      after every restart/failover.

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -56,12 +56,22 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
-    default: ""
-  - name: NR_CLI_MYSQL_TLS_CA_FILE
-    prompt: "Path to a CA bundle for validating the RDS TLS certificate (optional): "
-    default: ""
+# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
+# newrelic-cli's non-interactive mode requires every declared inputVar to
+# either have a non-empty default or be explicitly provided, even when the
+# field is meant to be optional (default: "" is not sufficient - see
+# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
+# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
+# string when unset, which is exactly the "monitor all databases" behavior
+# documented for this field - while still letting users set it via env var.
+
+# NR_CLI_MYSQL_TLS_CA_FILE is intentionally not declared as an inputVar, for
+# the same reason as NR_CLI_MYSQL_DATABASE above: the newrelic-cli's
+# non-interactive mode requires every declared inputVar to have a non-empty
+# default or be explicitly provided, even when the field is optional
+# (default: "" is not sufficient). Leaving it undeclared lets
+# {{.NR_CLI_MYSQL_TLS_CA_FILE}} below resolve to an empty string when unset,
+# which is exactly the "no ca_file set" behavior this field is meant to have.
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -246,7 +246,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           cat > "$SQL_FILE" << EOF
           CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
@@ -304,7 +304,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
           if [ $? -ne 0 ]; then
@@ -313,24 +313,16 @@ install:
             exit 1
           fi
 
-          if [ "$PRESET" = "2" ]; then
-            COLLECTION_INTERVAL="30s"
-            LIMIT_MIB=500
-          else
-            COLLECTION_INTERVAL="15s"
-            LIMIT_MIB=200
-          fi
-
           DATABASE_LINE=""
           if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: ${DATABASE}"
+            DATABASE_LINE="    database: \"${DATABASE}\""
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4317" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4317" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4317" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -364,6 +356,10 @@ install:
                       enabled: false
                     system.paging.faults:
                       enabled: false
+                filesystem:
+                  metrics:
+                    system.filesystem.utilization:
+                      enabled: true
                 disk:
                   metrics:
                     system.disk.merged:
@@ -376,48 +372,54 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
-                processes:
-                process:
-                  mute_process_name_error: true
-                  mute_process_exe_error: true
-                  mute_process_user_error: true
-                  mute_process_io_error: true
-                  metrics:
-                    process.cpu.utilization:
-                      enabled: true
-                    process.memory.utilization:
-                      enabled: true
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                # process:
+                #  metrics:
+                #    process.cpu.utilization:
+                #      enabled: true
+                #    process.cpu.time:
+                #      enabled: false
 
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
               tls:
                 insecure: false
                 insecure_skip_verify: false
+                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
+                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
           EOF
             if [ -n "$TLS_CA_FILE" ]; then
               echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            else
+              echo "      # ca_file: /path/to/global-bundle.pem" >> "$CONFIG_PATH"
             fi
             cat >> "$CONFIG_PATH" << EOF
-
+              # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
+              # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
+              # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
+              # Requires one-time setup per schema -- see Prerequisites -> DML query plan collection.
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                # APM-DB correlation: surfaces the nr_service_guid SQL comment tag (e.g. injected by
+                # transaction_tracer.sql_metadata_comments in the Java agent) as db.query.comment_tags /
+                # db.query.comment_tags.nr_service_guid. Empty list by default -- nothing is extracted
+                # unless the key is explicitly allow-listed here.
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -425,109 +427,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-                mysql.connection.count:
-                  enabled: true
-                mysql.connection.errors:
-                  enabled: true
-                mysql.max_used_connections:
-                  enabled: true
-                mysql.client.network.io:
-                  enabled: true
-                mysql.mysqlx_worker_threads:
-                  enabled: true
-                mysql.commands:
-                  enabled: true
-                mysql.query.count:
-                  enabled: true
-                mysql.query.client.count:
-                  enabled: true
-                mysql.query.slow.count:
-                  enabled: true
-                mysql.joins:
-                  enabled: true
-                mysql.statement_event.count:
-                  enabled: true
-                mysql.statement_event.wait.time:
-                  enabled: true
-                mysql.table.average_row_length:
-                  enabled: true
-                mysql.table.rows:
-                  enabled: true
-                mysql.table.size:
-                  enabled: true
-                mysql.table_open_cache:
-                  enabled: true
-                mysql.table.lock_wait.read.count:
-                  enabled: true
-                mysql.table.lock_wait.read.time:
-                  enabled: true
-                mysql.table.lock_wait.write.count:
-                  enabled: true
-                mysql.table.lock_wait.write.time:
-                  enabled: true
-                mysql.replica.sql_delay:
-                  enabled: true
-                mysql.replica.time_behind_source:
-                  enabled: true
-                mysql.page_size:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -612,7 +512,14 @@ install:
                 - key: type
                   action: delete
 
-            cumulativetodelta:
+            cumulative_to_delta:
+
+            transform:
+              trace_statements:
+                - context: span
+                  statements:
+                    - truncate_all(span.attributes, 4095)
+                    - truncate_all(resource.attributes, 4095)
 
             transform/host:
               metric_statements:
@@ -623,17 +530,21 @@ install:
 
           EOF
             cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+            # Static server.address/server.port, reusing the same ${SERVER}/${PORT}
+            # values already set on the receiver's own \`endpoint\` field above -- nrmysqlreceiver
+            # itself emits no server.address/server.port, only its own mysql.instance.endpoint
+            # (a combined "host:port" string). Applies uniformly to both metrics and logs
+            # pipelines since neither depends on how that string is derived.
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
             batch:
-
-            batch/logs:
-              send_batch_size: 15
-              send_batch_max_size: 15
-              timeout: 5s
 
             resource_detection:
               detectors: ["system"]
@@ -642,23 +553,28 @@ install:
                 resource_attributes:
                   host.id:
                     enabled: true
+
             resource_detection/cloud:
               detectors: ["gcp", "ec2", "azure"]
               timeout: 2s
               override: true
+
             resource_detection/env:
               detectors: ["env"]
               timeout: 2s
               override: true
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
             telemetry:
@@ -669,7 +585,7 @@ install:
 
             pipelines:
               metrics/host:
-                receivers: [host_metrics, nrmysql]
+                receivers: [host_metrics]
                 processors:
                   - metrics_transform
                   - filter/exclude_cpu_utilization
@@ -685,48 +601,58 @@ install:
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - cumulativetodelta
-                  - memory_limiter
+                  - cumulative_to_delta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
-              logs/host:
+              metrics/mysql:
                 receivers: [nrmysql]
                 processors:
+                  - resource/mysql
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - batch/logs
-                exporters: [otlphttp]
+                  - batch
+                exporters: [otlp/newrelic]
+
+              logs/mysql:
+                receivers: [nrmysql]
+                processors:
+                  - resource/mysql
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch
+                exporters: [otlp/newrelic]
 
               traces:
                 receivers: [otlp]
-                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                processors: [transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlp/newrelic]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
           receivers:
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
               tls:
                 insecure: false
@@ -734,19 +660,18 @@ install:
           EOF
             if [ -n "$TLS_CA_FILE" ]; then
               echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            else
+              echo "      # ca_file: /path/to/global-bundle.pem" >> "$CONFIG_PATH"
             fi
             cat >> "$CONFIG_PATH" << EOF
-
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -754,63 +679,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -818,39 +687,38 @@ install:
                   enabled: true
 
           processors:
-          EOF
-            cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
-
             batch:
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
-            telemetry:
-              metrics:
-                level: none
-
             pipelines:
               metrics:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
-
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
               logs:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
           EOF
           fi
 
@@ -900,10 +768,11 @@ postInstall:
       View logs:           journalctl -u nrdot-collector -f
       Restart service:     sudo systemctl restart nrdot-collector
 
-      Note: query plans for write statements are not collected by default
-      (explain_mode is left at its "inline" default). Enabling "procedure"
-      mode requires creating an explain_statement stored procedure and
-      granting EXECUTE on it to the monitoring user - see:
+      Note: explain_mode is set to "procedure" to collect query plans for
+      write statements without granting DML privileges to the monitoring
+      user. This falls back to "inline" automatically for any schema where
+      the one-time explain_statement stored procedure hasn't been created -
+      see:
       https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/
 
       Note: on RDS/Aurora, the events_waits_current Performance Schema

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -56,22 +56,12 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
-# newrelic-cli's non-interactive mode requires every declared inputVar to
-# either have a non-empty default or be explicitly provided, even when the
-# field is meant to be optional (default: "" is not sufficient - see
-# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
-# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
-# string when unset, which is exactly the "monitor all databases" behavior
-# documented for this field - while still letting users set it via env var.
-
-# NR_CLI_MYSQL_TLS_CA_FILE is intentionally not declared as an inputVar, for
-# the same reason as NR_CLI_MYSQL_DATABASE above: the newrelic-cli's
-# non-interactive mode requires every declared inputVar to have a non-empty
-# default or be explicitly provided, even when the field is optional
-# (default: "" is not sufficient). Leaving it undeclared lets
-# {{.NR_CLI_MYSQL_TLS_CA_FILE}} below resolve to an empty string when unset,
-# which is exactly the "no ca_file set" behavior this field is meant to have.
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
+  - name: NR_CLI_MYSQL_TLS_CA_FILE
+    prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -132,10 +122,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
           if [ $? -ne 0 ]; then
@@ -241,10 +231,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
@@ -299,10 +289,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -377,7 +377,6 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
@@ -639,7 +638,6 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -56,9 +56,6 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
     default: ""
@@ -268,7 +265,6 @@ install:
           fi
           SERVER="{{.NR_CLI_MYSQL_SERVER}}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
           TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
           MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
@@ -303,10 +299,6 @@ install:
             exit 1
           fi
 
-          DATABASE_LINE=""
-          if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: \"${DATABASE}\""
-          fi
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
@@ -377,7 +369,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               collection_interval: 10s
               initial_delay: 1s
@@ -638,7 +629,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               collection_interval: 10s
               initial_delay: 1s

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -58,8 +58,10 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -58,10 +58,8 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
-    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -1,0 +1,907 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+# WORK IN PROGRESS - not for use.
+
+name: nrdot-collector-mysql-rds
+displayName: NRDOT MySQL RDS (RHEL/CentOS)
+description: New Relic install recipe for MySQL monitoring via NRDOT Collector on RHEL/CentOS hosts connecting to AWS RDS/Aurora MySQL instances
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platform: centos
+  - type: host
+    os: linux
+    platform: redhat
+
+keywords:
+  - MySQL
+  - MariaDB
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Database
+  - Linux
+  - CentOS
+  - RHEL
+  - RDS
+  - AWS
+
+processMatch: []
+
+preInstall:
+  discoveryMode:
+    - targeted
+  info: |
+    To capture data from your AWS RDS/Aurora MySQL instance, we need to create/authorize
+    a monitoring identity (a MySQL user). This requires the RDS master user credentials
+    for your instance, and network connectivity from this host to the RDS endpoint
+    (inbound access on the MySQL port in the RDS security group).
+
+inputVars:
+  - name: NR_CLI_MYSQL_CONFIG_PRESET
+    prompt: "NRDOT configuration - 1) Standard  2) Full-feature: "
+    default: "1"
+  - name: NR_CLI_MYSQL_SERVER
+    prompt: "RDS MySQL/Aurora endpoint (e.g. mydb.xxxxxxxxxx.us-east-1.rds.amazonaws.com): "
+  - name: NR_CLI_MYSQL_PORT
+    prompt: "MySQL port: "
+    default: "3306"
+  - name: NR_CLI_MYSQL_MASTER_USER
+    prompt: "RDS master username: "
+  - name: NR_CLI_MYSQL_MASTER_PASSWORD
+    prompt: "RDS master user password (used once to create the monitoring user): "
+    secret: true
+  - name: NR_CLI_MYSQL_LOGIN_NAME
+    prompt: "Monitoring username: "
+    default: "newrelic"
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
+    default: ""
+  - name: NR_CLI_MYSQL_TLS_CA_FILE
+    prompt: "Path to a CA bundle for validating the RDS TLS certificate (optional): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+successLinkConfig:
+  type: EXPLORER
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+
+  tasks:
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 131
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if ! command -v mysql > /dev/null 2>&1; then
+            echo "The mysql client is required to configure MySQL monitoring. Please install the mysql-client package and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    assert_mysql_version:
+      cmds:
+        - |
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to connect to MySQL to check its version:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+
+          MAJOR=$(echo "$RESULT" | grep -oE '^[0-9]+' | head -1)
+          MINOR=$(echo "$RESULT" | grep -oE '^[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+
+          if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 5 ] || { [ "$MAJOR" -eq 5 ] && [ "${MINOR:-0}" -lt 7 ]; }; then
+            echo "MySQL version ${RESULT:-unknown} is not supported. MySQL 5.7 or later is required." >&2
+            exit 1
+          fi
+
+          echo "MySQL version ${RESULT} detected - supported."
+
+          PS_STATUS=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SHOW VARIABLES LIKE 'performance_schema';" 2>&1 | awk '{print $2}')
+          if [ "$PS_STATUS" != "ON" ]; then
+            echo "performance_schema is disabled on this MySQL server." >&2
+            echo "Enable it (performance_schema=ON in my.cnf) and restart MySQL, then re-run this installation." >&2
+            exit 1
+          fi
+
+          echo "performance_schema is enabled."
+
+    install_nrdot:
+      cmds:
+        - |
+          COLLECTOR_DISTRO="nrdot-collector"
+
+          if rpm -q "$COLLECTOR_DISTRO" > /dev/null 2>&1; then
+            echo "NRDOT Collector is already installed."
+            echo ""
+            echo "Please follow the steps below to complete the setup:"
+            echo ""
+            echo "  1. Create mysql-config.yaml"
+            echo "     if not present. Refer to:"
+            echo "     https://docs.newrelic.com/docs/opentelemetry/database/mysql/rds/"
+            echo ""
+            echo "  2. Make sure the monitoring user is created"
+            echo "     and has the required permissions granted."
+            echo ""
+            echo "  3. After making the above changes, restart the NRDOT Collector:"
+            echo "     sudo systemctl restart nrdot-collector"
+            echo ""
+            exit 131
+          fi
+
+          COLLECTOR_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name":' | awk -F'"' '{print $4}')
+          if [ -z "$COLLECTOR_VERSION" ]; then
+            echo "Failed to fetch the latest release version from GitHub. Please check your internet connection." >&2
+            exit 1
+          fi
+
+          if [ "$(uname -m)" = "aarch64" ]; then
+            ARCH="arm64"
+          else
+            ARCH="x86_64"
+          fi
+
+          DOWNLOAD_URL="https://github.com/newrelic/nrdot-collector-releases/releases/download/${COLLECTOR_VERSION}/${COLLECTOR_DISTRO}_${COLLECTOR_VERSION}_linux_${ARCH}.rpm"
+          echo "Installing ${COLLECTOR_DISTRO} version: ${COLLECTOR_VERSION}"
+          echo "Downloading from: ${DOWNLOAD_URL}"
+
+          curl -L --output /tmp/nrdot-collector.rpm "$DOWNLOAD_URL"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rpm -ivh /tmp/nrdot-collector.rpm
+          if [ $? -ne 0 ]; then
+            echo "Failed to install the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rm -f /tmp/nrdot-collector.rpm
+          echo "${COLLECTOR_DISTRO} installed successfully."
+
+    configure_database_user:
+      cmds:
+        - |
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
+          chmod 600 "$CNF_FILE" "$SQL_FILE"
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          cat > "$SQL_FILE" << EOF
+          CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          GRANT SELECT ON performance_schema.* TO '${LOGIN_NAME}'@'%';
+          GRANT UPDATE ON performance_schema.setup_consumers TO '${LOGIN_NAME}'@'%';
+          FLUSH PRIVILEGES;
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" < "$SQL_FILE" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "SQL script failed:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+          echo "$RESULT"
+
+          echo "MySQL monitoring identity configured successfully."
+
+    create_collector_config:
+      cmds:
+        - |
+          PRESET="{{.NR_CLI_MYSQL_CONFIG_PRESET}}"
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="{{.NR_CLI_MYSQL_SERVER}}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
+          TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
+          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
+          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
+          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
+          NR_MASTER_PW_EOF
+          )
+          REGION="{{.NEW_RELIC_REGION}}"
+          LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
+          CONFIG_DIR="/etc/nrdot-collector"
+          CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
+          ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+
+          mkdir -p "$CONFIG_DIR"
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=${MASTER_USER}
+          password=${MASTER_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to set the monitoring user's password:" >&2
+            echo "$ALTER_RESULT" >&2
+            exit 1
+          fi
+
+          if [ "$PRESET" = "2" ]; then
+            COLLECTION_INTERVAL="30s"
+            LIMIT_MIB=500
+          else
+            COLLECTION_INTERVAL="15s"
+            LIMIT_MIB=200
+          fi
+
+          DATABASE_LINE=""
+          if [ -n "$DATABASE" ]; then
+            DATABASE_LINE="    database: ${DATABASE}"
+          fi
+
+          case "$REGION" in
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+          esac
+
+          if [ "$PRESET" = "2" ]; then
+            cat > "$CONFIG_PATH" << EOF
+          extensions:
+            health_check:
+
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                http:
+
+            host_metrics:
+              collection_interval: 30s
+              scrapers:
+                cpu:
+                  metrics:
+                    system.cpu.time:
+                      enabled: false
+                    system.cpu.utilization:
+                      enabled: true
+                load:
+                memory:
+                  metrics:
+                    system.memory.utilization:
+                      enabled: true
+                paging:
+                  metrics:
+                    system.paging.utilization:
+                      enabled: false
+                    system.paging.faults:
+                      enabled: false
+                disk:
+                  metrics:
+                    system.disk.merged:
+                      enabled: false
+                    system.disk.pending_operations:
+                      enabled: false
+                    system.disk.weighted_io_time:
+                      enabled: false
+                network:
+                  metrics:
+                    system.network.connections:
+                      enabled: false
+                processes:
+                process:
+                  mute_process_name_error: true
+                  mute_process_exe_error: true
+                  mute_process_user_error: true
+                  mute_process_io_error: true
+                  metrics:
+                    process.cpu.utilization:
+                      enabled: true
+                    process.memory.utilization:
+                      enabled: true
+
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+          EOF
+            if [ -n "$TLS_CA_FILE" ]; then
+              echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            fi
+            cat >> "$CONFIG_PATH" << EOF
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+                mysql.connection.count:
+                  enabled: true
+                mysql.connection.errors:
+                  enabled: true
+                mysql.max_used_connections:
+                  enabled: true
+                mysql.client.network.io:
+                  enabled: true
+                mysql.mysqlx_worker_threads:
+                  enabled: true
+                mysql.commands:
+                  enabled: true
+                mysql.query.count:
+                  enabled: true
+                mysql.query.client.count:
+                  enabled: true
+                mysql.query.slow.count:
+                  enabled: true
+                mysql.joins:
+                  enabled: true
+                mysql.statement_event.count:
+                  enabled: true
+                mysql.statement_event.wait.time:
+                  enabled: true
+                mysql.table.average_row_length:
+                  enabled: true
+                mysql.table.rows:
+                  enabled: true
+                mysql.table.size:
+                  enabled: true
+                mysql.table_open_cache:
+                  enabled: true
+                mysql.table.lock_wait.read.count:
+                  enabled: true
+                mysql.table.lock_wait.read.time:
+                  enabled: true
+                mysql.table.lock_wait.write.count:
+                  enabled: true
+                mysql.table.lock_wait.write.time:
+                  enabled: true
+                mysql.replica.sql_delay:
+                  enabled: true
+                mysql.replica.time_behind_source:
+                  enabled: true
+                mysql.page_size:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+            metrics_transform:
+              transforms:
+                - include: system.cpu.utilization
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [state]
+                      aggregation_type: mean
+                - include: system.paging.operations
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [direction]
+                      aggregation_type: sum
+
+            filter/exclude_cpu_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+            filter/exclude_memory_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+            filter/exclude_memory_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+            filter/exclude_filesystem_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+            filter/exclude_filesystem_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_filesystem_inodes_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_system_disk:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+            filter/exclude_network:
+              metrics:
+                datapoint:
+                  - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+            attributes/exclude_system_paging:
+              include:
+                match_type: strict
+                metric_names:
+                  - system.paging.operations
+              actions:
+                - key: type
+                  action: delete
+
+            cumulativetodelta:
+
+            transform/host:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(metric.description, "")
+                    - set(metric.unit, "")
+
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+            batch/logs:
+              send_batch_size: 15
+              send_batch_max_size: 15
+              timeout: 5s
+
+            resource_detection:
+              detectors: ["system"]
+              system:
+                hostname_sources: ["os"]
+                resource_attributes:
+                  host.id:
+                    enabled: true
+            resource_detection/cloud:
+              detectors: ["gcp", "ec2", "azure"]
+              timeout: 2s
+              override: true
+            resource_detection/env:
+              detectors: ["env"]
+              timeout: 2s
+              override: true
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            extensions: [health_check]
+
+            pipelines:
+              metrics/host:
+                receivers: [host_metrics, nrmysql]
+                processors:
+                  - metrics_transform
+                  - filter/exclude_cpu_utilization
+                  - filter/exclude_memory_utilization
+                  - filter/exclude_memory_usage
+                  - filter/exclude_filesystem_utilization
+                  - filter/exclude_filesystem_usage
+                  - filter/exclude_filesystem_inodes_usage
+                  - filter/exclude_system_disk
+                  - filter/exclude_network
+                  - attributes/exclude_system_paging
+                  - transform/host
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - cumulativetodelta
+                  - memory_limiter
+                  - batch
+                exporters: [otlphttp]
+
+              logs/host:
+                receivers: [nrmysql]
+                processors:
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch/logs
+                exporters: [otlphttp]
+
+              traces:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              metrics:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+          EOF
+          else
+            cat > "$CONFIG_PATH" << EOF
+          receivers:
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+          EOF
+            if [ -n "$TLS_CA_FILE" ]; then
+              echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            fi
+            cat >> "$CONFIG_PATH" << EOF
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            pipelines:
+              metrics:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+          EOF
+          fi
+
+          cat > "$ENV_FILE" << EOF
+          OTELCOL_OPTIONS="--config=${CONFIG_PATH}"
+          EOF
+
+          chown nrdot-collector:nrdot-collector "$CONFIG_PATH"
+          chmod 600 "$CONFIG_PATH"
+
+          echo "MySQL OTel config written to ${CONFIG_PATH}"
+          echo "Env file written to ${ENV_FILE}"
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl restart nrdot-collector
+
+          echo "Waiting for NRDOT Collector to start..."
+          for i in $(seq 1 30); do
+            if systemctl is-active --quiet nrdot-collector; then
+              echo "NRDOT Collector is running."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "NRDOT Collector did not start in time. Check logs:" >&2
+          journalctl -u nrdot-collector --no-pager -n 50 >&2
+          exit 31
+
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: assert_mysql_version
+        - task: install_nrdot
+        - task: configure_database_user
+        - task: create_collector_config
+        - task: restart_nrdot
+
+postInstall:
+  info: |2
+      MySQL OTel config: /etc/nrdot-collector/mysql-config.yaml
+      Env file:           /etc/nrdot-collector/nrdot-collector.conf
+      Service status:     systemctl status nrdot-collector
+      View logs:           journalctl -u nrdot-collector -f
+      Restart service:     sudo systemctl restart nrdot-collector
+
+      Note: query plans for write statements are not collected by default
+      (explain_mode is left at its "inline" default). Enabling "procedure"
+      mode requires creating an explain_statement stored procedure and
+      granting EXECUTE on it to the monitoring user - see:
+      https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/
+
+      Note: on RDS/Aurora, the events_waits_current Performance Schema
+      consumer does not persist across restarts or failovers (the
+      mysql8.0/mysql8.4 parameter group families do not expose
+      performance_schema_consumer_* parameters). The monitoring user's
+      GRANT UPDATE ON performance_schema.setup_consumers privilege lets the
+      collector re-enable it on reconnect; otherwise re-run:
+        UPDATE performance_schema.setup_consumers SET enabled='YES'
+          WHERE name = 'events_waits_current';
+      after every restart/failover.

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -56,12 +56,22 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
-    default: ""
-  - name: NR_CLI_MYSQL_TLS_CA_FILE
-    prompt: "Path to a CA bundle for validating the RDS TLS certificate (optional): "
-    default: ""
+# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
+# newrelic-cli's non-interactive mode requires every declared inputVar to
+# either have a non-empty default or be explicitly provided, even when the
+# field is meant to be optional (default: "" is not sufficient - see
+# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
+# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
+# string when unset, which is exactly the "monitor all databases" behavior
+# documented for this field - while still letting users set it via env var.
+
+# NR_CLI_MYSQL_TLS_CA_FILE is intentionally not declared as an inputVar, for
+# the same reason as NR_CLI_MYSQL_DATABASE above: the newrelic-cli's
+# non-interactive mode requires every declared inputVar to have a non-empty
+# default or be explicitly provided, even when the field is optional
+# (default: "" is not sufficient). Leaving it undeclared lets
+# {{.NR_CLI_MYSQL_TLS_CA_FILE}} below resolve to an empty string when unset,
+# which is exactly the "no ca_file set" behavior this field is meant to have.
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -246,7 +246,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           cat > "$SQL_FILE" << EOF
           CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
@@ -304,7 +304,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
           if [ $? -ne 0 ]; then
@@ -313,24 +313,16 @@ install:
             exit 1
           fi
 
-          if [ "$PRESET" = "2" ]; then
-            COLLECTION_INTERVAL="30s"
-            LIMIT_MIB=500
-          else
-            COLLECTION_INTERVAL="15s"
-            LIMIT_MIB=200
-          fi
-
           DATABASE_LINE=""
           if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: ${DATABASE}"
+            DATABASE_LINE="    database: \"${DATABASE}\""
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4317" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4317" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4317" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -364,6 +356,10 @@ install:
                       enabled: false
                     system.paging.faults:
                       enabled: false
+                filesystem:
+                  metrics:
+                    system.filesystem.utilization:
+                      enabled: true
                 disk:
                   metrics:
                     system.disk.merged:
@@ -376,48 +372,54 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
-                processes:
-                process:
-                  mute_process_name_error: true
-                  mute_process_exe_error: true
-                  mute_process_user_error: true
-                  mute_process_io_error: true
-                  metrics:
-                    process.cpu.utilization:
-                      enabled: true
-                    process.memory.utilization:
-                      enabled: true
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                # process:
+                #  metrics:
+                #    process.cpu.utilization:
+                #      enabled: true
+                #    process.cpu.time:
+                #      enabled: false
 
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
               tls:
                 insecure: false
                 insecure_skip_verify: false
+                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
+                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
           EOF
             if [ -n "$TLS_CA_FILE" ]; then
               echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            else
+              echo "      # ca_file: /path/to/global-bundle.pem" >> "$CONFIG_PATH"
             fi
             cat >> "$CONFIG_PATH" << EOF
-
+              # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
+              # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
+              # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
+              # Requires one-time setup per schema -- see Prerequisites -> DML query plan collection.
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                # APM-DB correlation: surfaces the nr_service_guid SQL comment tag (e.g. injected by
+                # transaction_tracer.sql_metadata_comments in the Java agent) as db.query.comment_tags /
+                # db.query.comment_tags.nr_service_guid. Empty list by default -- nothing is extracted
+                # unless the key is explicitly allow-listed here.
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -425,109 +427,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-                mysql.connection.count:
-                  enabled: true
-                mysql.connection.errors:
-                  enabled: true
-                mysql.max_used_connections:
-                  enabled: true
-                mysql.client.network.io:
-                  enabled: true
-                mysql.mysqlx_worker_threads:
-                  enabled: true
-                mysql.commands:
-                  enabled: true
-                mysql.query.count:
-                  enabled: true
-                mysql.query.client.count:
-                  enabled: true
-                mysql.query.slow.count:
-                  enabled: true
-                mysql.joins:
-                  enabled: true
-                mysql.statement_event.count:
-                  enabled: true
-                mysql.statement_event.wait.time:
-                  enabled: true
-                mysql.table.average_row_length:
-                  enabled: true
-                mysql.table.rows:
-                  enabled: true
-                mysql.table.size:
-                  enabled: true
-                mysql.table_open_cache:
-                  enabled: true
-                mysql.table.lock_wait.read.count:
-                  enabled: true
-                mysql.table.lock_wait.read.time:
-                  enabled: true
-                mysql.table.lock_wait.write.count:
-                  enabled: true
-                mysql.table.lock_wait.write.time:
-                  enabled: true
-                mysql.replica.sql_delay:
-                  enabled: true
-                mysql.replica.time_behind_source:
-                  enabled: true
-                mysql.page_size:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -612,7 +512,14 @@ install:
                 - key: type
                   action: delete
 
-            cumulativetodelta:
+            cumulative_to_delta:
+
+            transform:
+              trace_statements:
+                - context: span
+                  statements:
+                    - truncate_all(span.attributes, 4095)
+                    - truncate_all(resource.attributes, 4095)
 
             transform/host:
               metric_statements:
@@ -623,17 +530,21 @@ install:
 
           EOF
             cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+            # Static server.address/server.port, reusing the same ${SERVER}/${PORT}
+            # values already set on the receiver's own \`endpoint\` field above -- nrmysqlreceiver
+            # itself emits no server.address/server.port, only its own mysql.instance.endpoint
+            # (a combined "host:port" string). Applies uniformly to both metrics and logs
+            # pipelines since neither depends on how that string is derived.
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
             batch:
-
-            batch/logs:
-              send_batch_size: 15
-              send_batch_max_size: 15
-              timeout: 5s
 
             resource_detection:
               detectors: ["system"]
@@ -642,23 +553,28 @@ install:
                 resource_attributes:
                   host.id:
                     enabled: true
+
             resource_detection/cloud:
               detectors: ["gcp", "ec2", "azure"]
               timeout: 2s
               override: true
+
             resource_detection/env:
               detectors: ["env"]
               timeout: 2s
               override: true
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
             telemetry:
@@ -669,7 +585,7 @@ install:
 
             pipelines:
               metrics/host:
-                receivers: [host_metrics, nrmysql]
+                receivers: [host_metrics]
                 processors:
                   - metrics_transform
                   - filter/exclude_cpu_utilization
@@ -685,48 +601,58 @@ install:
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - cumulativetodelta
-                  - memory_limiter
+                  - cumulative_to_delta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
-              logs/host:
+              metrics/mysql:
                 receivers: [nrmysql]
                 processors:
+                  - resource/mysql
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - batch/logs
-                exporters: [otlphttp]
+                  - batch
+                exporters: [otlp/newrelic]
+
+              logs/mysql:
+                receivers: [nrmysql]
+                processors:
+                  - resource/mysql
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch
+                exporters: [otlp/newrelic]
 
               traces:
                 receivers: [otlp]
-                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                processors: [transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlp/newrelic]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
           receivers:
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
               tls:
                 insecure: false
@@ -734,19 +660,18 @@ install:
           EOF
             if [ -n "$TLS_CA_FILE" ]; then
               echo "      ca_file: ${TLS_CA_FILE}" >> "$CONFIG_PATH"
+            else
+              echo "      # ca_file: /path/to/global-bundle.pem" >> "$CONFIG_PATH"
             fi
             cat >> "$CONFIG_PATH" << EOF
-
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -754,63 +679,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -818,39 +687,38 @@ install:
                   enabled: true
 
           processors:
-          EOF
-            cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
-
             batch:
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
-            telemetry:
-              metrics:
-                level: none
-
             pipelines:
               metrics:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
-
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
               logs:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
           EOF
           fi
 
@@ -900,10 +768,11 @@ postInstall:
       View logs:           journalctl -u nrdot-collector -f
       Restart service:     sudo systemctl restart nrdot-collector
 
-      Note: query plans for write statements are not collected by default
-      (explain_mode is left at its "inline" default). Enabling "procedure"
-      mode requires creating an explain_statement stored procedure and
-      granting EXECUTE on it to the monitoring user - see:
+      Note: explain_mode is set to "procedure" to collect query plans for
+      write statements without granting DML privileges to the monitoring
+      user. This falls back to "inline" automatically for any schema where
+      the one-time explain_statement stored procedure hasn't been created -
+      see:
       https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/
 
       Note: on RDS/Aurora, the events_waits_current Performance Schema

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -56,22 +56,12 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
-# newrelic-cli's non-interactive mode requires every declared inputVar to
-# either have a non-empty default or be explicitly provided, even when the
-# field is meant to be optional (default: "" is not sufficient - see
-# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
-# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
-# string when unset, which is exactly the "monitor all databases" behavior
-# documented for this field - while still letting users set it via env var.
-
-# NR_CLI_MYSQL_TLS_CA_FILE is intentionally not declared as an inputVar, for
-# the same reason as NR_CLI_MYSQL_DATABASE above: the newrelic-cli's
-# non-interactive mode requires every declared inputVar to have a non-empty
-# default or be explicitly provided, even when the field is optional
-# (default: "" is not sufficient). Leaving it undeclared lets
-# {{.NR_CLI_MYSQL_TLS_CA_FILE}} below resolve to an empty string when unset,
-# which is exactly the "no ca_file set" behavior this field is meant to have.
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
+  - name: NR_CLI_MYSQL_TLS_CA_FILE
+    prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -132,10 +122,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
           if [ $? -ne 0 ]; then
@@ -241,10 +231,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
@@ -299,10 +289,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
-          password=${MASTER_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$MASTER_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -377,7 +377,6 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
@@ -639,7 +638,6 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -56,9 +56,6 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
     default: ""
@@ -268,7 +265,6 @@ install:
           fi
           SERVER="{{.NR_CLI_MYSQL_SERVER}}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
           TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
           MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
@@ -303,10 +299,6 @@ install:
             exit 1
           fi
 
-          DATABASE_LINE=""
-          if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: \"${DATABASE}\""
-          fi
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
@@ -377,7 +369,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               collection_interval: 10s
               initial_delay: 1s
@@ -638,7 +629,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               collection_interval: 10s
               initial_delay: 1s

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -58,8 +58,10 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -58,10 +58,8 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
   - name: NR_CLI_MYSQL_TLS_CA_FILE
     prompt: "Path to a CA certificate file for validating the server's TLS certificate (leave blank to skip CA validation): "
-    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -53,9 +53,15 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
-    default: ""
+# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
+# newrelic-cli's non-interactive mode requires every declared inputVar to
+# either have a non-empty default or be explicitly provided, even when the
+# field is meant to be optional (default: "" is not sufficient - see
+# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
+# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
+# string when unset, which is exactly the "monitor all databases" behavior
+# documented for this field - while still letting users set it via env var.
+
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -234,7 +234,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           cat > "$SQL_FILE" << EOF
           CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
@@ -290,7 +290,7 @@ install:
           port=${PORT}
           EOF
 
-          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
           ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
           if [ $? -ne 0 ]; then
@@ -299,24 +299,16 @@ install:
             exit 1
           fi
 
-          if [ "$PRESET" = "2" ]; then
-            COLLECTION_INTERVAL="30s"
-            LIMIT_MIB=500
-          else
-            COLLECTION_INTERVAL="15s"
-            LIMIT_MIB=200
-          fi
-
           DATABASE_LINE=""
           if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: ${DATABASE}"
+            DATABASE_LINE="    database: \"${DATABASE}\""
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4317" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4317" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4317" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -350,6 +342,10 @@ install:
                       enabled: false
                     system.paging.faults:
                       enabled: false
+                filesystem:
+                  metrics:
+                    system.filesystem.utilization:
+                      enabled: true
                 disk:
                   metrics:
                     system.disk.merged:
@@ -362,40 +358,48 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
-                processes:
-                process:
-                  mute_process_name_error: true
-                  mute_process_exe_error: true
-                  mute_process_user_error: true
-                  mute_process_io_error: true
-                  metrics:
-                    process.cpu.utilization:
-                      enabled: true
-                    process.memory.utilization:
-                      enabled: true
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                # process:
+                #  metrics:
+                #    process.cpu.utilization:
+                #      enabled: true
+                #    process.cpu.time:
+                #      enabled: false
 
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
-
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
+                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
+                # ca_file: /path/to/global-bundle.pem
+              # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
+              # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
+              # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
+              # Requires one-time setup per schema -- see Prerequisites -> DML query plan collection.
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                # APM-DB correlation: surfaces the nr_service_guid SQL comment tag (e.g. injected by
+                # transaction_tracer.sql_metadata_comments in the Java agent) as db.query.comment_tags /
+                # db.query.comment_tags.nr_service_guid. Empty list by default -- nothing is extracted
+                # unless the key is explicitly allow-listed here.
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -403,109 +407,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-                mysql.connection.count:
-                  enabled: true
-                mysql.connection.errors:
-                  enabled: true
-                mysql.max_used_connections:
-                  enabled: true
-                mysql.client.network.io:
-                  enabled: true
-                mysql.mysqlx_worker_threads:
-                  enabled: true
-                mysql.commands:
-                  enabled: true
-                mysql.query.count:
-                  enabled: true
-                mysql.query.client.count:
-                  enabled: true
-                mysql.query.slow.count:
-                  enabled: true
-                mysql.joins:
-                  enabled: true
-                mysql.statement_event.count:
-                  enabled: true
-                mysql.statement_event.wait.time:
-                  enabled: true
-                mysql.table.average_row_length:
-                  enabled: true
-                mysql.table.rows:
-                  enabled: true
-                mysql.table.size:
-                  enabled: true
-                mysql.table_open_cache:
-                  enabled: true
-                mysql.table.lock_wait.read.count:
-                  enabled: true
-                mysql.table.lock_wait.read.time:
-                  enabled: true
-                mysql.table.lock_wait.write.count:
-                  enabled: true
-                mysql.table.lock_wait.write.time:
-                  enabled: true
-                mysql.replica.sql_delay:
-                  enabled: true
-                mysql.replica.time_behind_source:
-                  enabled: true
-                mysql.page_size:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -590,7 +492,14 @@ install:
                 - key: type
                   action: delete
 
-            cumulativetodelta:
+            cumulative_to_delta:
+
+            transform:
+              trace_statements:
+                - context: span
+                  statements:
+                    - truncate_all(span.attributes, 4095)
+                    - truncate_all(resource.attributes, 4095)
 
             transform/host:
               metric_statements:
@@ -601,17 +510,21 @@ install:
 
           EOF
             cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+            # Static server.address/server.port, reusing the same ${SERVER}/${PORT}
+            # values already set on the receiver's own \`endpoint\` field above -- nrmysqlreceiver
+            # itself emits no server.address/server.port, only its own mysql.instance.endpoint
+            # (a combined "host:port" string). Applies uniformly to both metrics and logs
+            # pipelines since neither depends on how that string is derived.
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
             batch:
-
-            batch/logs:
-              send_batch_size: 15
-              send_batch_max_size: 15
-              timeout: 5s
 
             resource_detection:
               detectors: ["system"]
@@ -620,23 +533,28 @@ install:
                 resource_attributes:
                   host.id:
                     enabled: true
+
             resource_detection/cloud:
               detectors: ["gcp", "ec2", "azure"]
               timeout: 2s
               override: true
+
             resource_detection/env:
               detectors: ["env"]
               timeout: 2s
               override: true
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
             telemetry:
@@ -647,7 +565,7 @@ install:
 
             pipelines:
               metrics/host:
-                receivers: [host_metrics, nrmysql]
+                receivers: [host_metrics]
                 processors:
                   - metrics_transform
                   - filter/exclude_cpu_utilization
@@ -663,60 +581,71 @@ install:
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - cumulativetodelta
-                  - memory_limiter
+                  - cumulative_to_delta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
-              logs/host:
+              metrics/mysql:
                 receivers: [nrmysql]
                 processors:
+                  - resource/mysql
                   - resource_detection
                   - resource_detection/cloud
                   - resource_detection/env
-                  - batch/logs
-                exporters: [otlphttp]
+                  - batch
+                exporters: [otlp/newrelic]
+
+              logs/mysql:
+                receivers: [nrmysql]
+                processors:
+                  - resource/mysql
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch
+                exporters: [otlp/newrelic]
 
               traces:
                 receivers: [otlp]
-                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                processors: [transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlp/newrelic]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp/newrelic]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
           receivers:
             nrmysql:
-              endpoint: ${SERVER}:${PORT}
+              endpoint: "${SERVER}:${PORT}"
               transport: tcp
-              username: ${LOGIN_NAME}
-              password: ${NR_PASSWORD}
+              username: "${LOGIN_NAME}"
+              password: "${NR_PASSWORD}"
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
-              collection_interval: ${COLLECTION_INTERVAL}
+              collection_interval: 10s
               initial_delay: 1s
-
+              tls:
+                insecure: false
+                insecure_skip_verify: false
+                # ca_file: /path/to/global-bundle.pem
+              explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096
                 time_limit: 24h
                 limit: 500
-
               query_sample_collection:
                 max_rows_per_query: 100
-                allowed_comment_keys:
-                  - nr_service_guid
-
+                allowed_comment_keys: [nr_service_guid]
               top_query_collection:
                 lookback_time: 120
                 max_query_sample_count: 5000
@@ -724,63 +653,7 @@ install:
                 collection_interval: 60s
                 query_plan_cache_size: 1000
                 query_plan_cache_ttl: 1h
-                allowed_comment_keys:
-                  - nr_service_guid
-
-              metrics:
-          EOF
-            cat >> "$CONFIG_PATH" << 'EOF'
-                mysql.buffer_pool.data_pages:
-                  enabled: true
-                mysql.buffer_pool.limit:
-                  enabled: true
-                mysql.buffer_pool.operations:
-                  enabled: true
-                mysql.buffer_pool.page_flushes:
-                  enabled: true
-                mysql.buffer_pool.pages:
-                  enabled: true
-                mysql.buffer_pool.usage:
-                  enabled: true
-                mysql.double_writes:
-                  enabled: true
-                mysql.handlers:
-                  enabled: true
-                mysql.index.io.wait.count:
-                  enabled: true
-                mysql.index.io.wait.time:
-                  enabled: true
-                mysql.locks:
-                  enabled: true
-                mysql.log_operations:
-                  enabled: true
-                mysql.mysqlx_connections:
-                  enabled: true
-                mysql.opened_resources:
-                  enabled: true
-                mysql.operations:
-                  enabled: true
-                mysql.page_operations:
-                  enabled: true
-                mysql.prepared_statements:
-                  enabled: true
-                mysql.row_locks:
-                  enabled: true
-                mysql.row_operations:
-                  enabled: true
-                mysql.sorts:
-                  enabled: true
-                mysql.table.io.wait.count:
-                  enabled: true
-                mysql.table.io.wait.time:
-                  enabled: true
-                mysql.threads:
-                  enabled: true
-                mysql.tmp_resources:
-                  enabled: true
-                mysql.uptime:
-                  enabled: true
-
+                allowed_comment_keys: [nr_service_guid]
               events:
                 db.server.query_sample:
                   enabled: true
@@ -788,39 +661,38 @@ install:
                   enabled: true
 
           processors:
-          EOF
-            cat >> "$CONFIG_PATH" << EOF
-            memory_limiter:
-              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
-              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
-
             batch:
+            resource/mysql:
+              attributes:
+                - key: server.address
+                  value: "${SERVER}"
+                  action: upsert
+                - key: server.port
+                  value: ${PORT}
+                  action: upsert
 
           exporters:
-            otlphttp:
-              endpoint: ${OTLP_ENDPOINT}
+            otlp/newrelic:
+              endpoint: "${OTLP_ENDPOINT}"
               headers:
-                api-key: ${LICENSE_KEY}
-              tls:
-                insecure: false
+                api-key: "${LICENSE_KEY}"
               compression: gzip
+              retry_on_failure:
+                enabled: true
+                initial_interval: 5s
+                max_interval: 30s
+                max_elapsed_time: 300s
 
           service:
-            telemetry:
-              metrics:
-                level: none
-
             pipelines:
               metrics:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
-
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
               logs:
                 receivers: [nrmysql]
-                processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                processors: [resource/mysql, batch]
+                exporters: [otlp/newrelic]
           EOF
           fi
 
@@ -870,8 +742,9 @@ postInstall:
       View logs:           journalctl -u nrdot-collector -f
       Restart service:     sudo systemctl restart nrdot-collector
 
-      Note: query plans for write statements are not collected by default
-      (explain_mode is left at its "inline" default). Enabling "procedure"
-      mode requires creating an explain_statement stored procedure and
-      granting EXECUTE on it to the monitoring user - see:
+      Note: explain_mode is set to "procedure" to collect query plans for
+      write statements without granting DML privileges to the monitoring
+      user. This falls back to "inline" automatically for any schema where
+      the one-time explain_statement stored procedure hasn't been created -
+      see:
       https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -379,11 +379,8 @@ install:
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
-                insecure_skip_verify: false
-                # Required for Amazon RDS/Aurora with SSL/TLS enforcement -- see
-                # Prerequisites -> Network access -> Amazon RDS / Aurora for MySQL.
-                # ca_file: /path/to/global-bundle.pem
+                insecure: true
+                insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
               # Falls back to "inline" (default) automatically if the procedure is absent for a schema.
@@ -635,9 +632,8 @@ install:
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
-                insecure_skip_verify: false
-                # ca_file: /path/to/global-bundle.pem
+                insecure: true
+                insecure_skip_verify: true
               explain_mode: procedure
               statement_events:
                 digest_text_limit: 4096

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -1,0 +1,871 @@
+# Visit our schema definition for additional information on this file format.
+# https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
+# WORK IN PROGRESS - not for use.
+
+name: nrdot-collector-mysql
+displayName: NRDOT MySQL (RHEL/CentOS)
+description: New Relic install recipe for MySQL monitoring via NRDOT Collector on RHEL/CentOS self-hosted environments
+repository: https://github.com/newrelic/nrdot-collector-releases
+
+installTargets:
+  - type: host
+    os: linux
+    platform: centos
+  - type: host
+    os: linux
+    platform: redhat
+
+keywords:
+  - MySQL
+  - MariaDB
+  - NRDOT
+  - OpenTelemetry
+  - OTel
+  - Database
+  - Linux
+  - CentOS
+  - RHEL
+
+processMatch:
+  - mysqld
+
+preInstall:
+  discoveryMode:
+    - targeted
+  info: |
+    To capture data from MySQL, we need to create/authorize a monitoring identity
+    (a MySQL user). This requires administrative access to your MySQL server
+    (the 'root' account or equivalent) on the account running this installation.
+
+inputVars:
+  - name: NR_CLI_MYSQL_CONFIG_PRESET
+    prompt: "NRDOT configuration - 1) Standard  2) Full-feature: "
+    default: "1"
+  - name: NR_CLI_MYSQL_SERVER
+    prompt: "MySQL host (e.g. localhost): "
+    default: "localhost"
+  - name: NR_CLI_MYSQL_PORT
+    prompt: "MySQL port: "
+    default: "3306"
+  - name: NR_CLI_MYSQL_ROOT_PASSWORD
+    prompt: "MySQL 'root' password (used once to create the monitoring user): "
+    secret: true
+  - name: NR_CLI_MYSQL_LOGIN_NAME
+    prompt: "Monitoring username: "
+    default: "newrelic"
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Restrict monitoring to a specific database (optional, leave blank to monitor all): "
+    default: ""
+
+validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
+
+successLinkConfig:
+  type: EXPLORER
+
+install:
+  version: "3"
+  silent: true
+
+  vars:
+    IS_SYSTEMCTL:
+      sh: command -v systemctl | wc -l
+
+  tasks:
+    write_recipe_metadata:
+      cmds:
+        - |
+          echo '{"Metadata":{"CapturedCliOutput":"true"}}' | tee {{.NR_CLI_OUTPUT}} > /dev/null
+
+    assert_pre_req:
+      cmds:
+        - |
+          if [ "$(id -u)" != "0" ]; then
+            echo "This newrelic install must be run under sudo or root" >&2
+            exit 131
+          fi
+        - |
+          if ! command -v curl > /dev/null 2>&1; then
+            echo "curl is required to run the newrelic install. Please install curl and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if ! command -v mysql > /dev/null 2>&1; then
+            echo "The mysql client is required to configure MySQL monitoring. Please install the mysql-client package and re-run the installation." >&2
+            exit 16
+          fi
+        - |
+          if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
+            echo "systemd is required for the nrdot-collector service configuration." >&2
+            exit 131
+          fi
+
+    assert_mysql_version:
+      cmds:
+        - |
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to connect to MySQL to check its version:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+
+          MAJOR=$(echo "$RESULT" | grep -oE '^[0-9]+' | head -1)
+          MINOR=$(echo "$RESULT" | grep -oE '^[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+
+          if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 5 ] || { [ "$MAJOR" -eq 5 ] && [ "${MINOR:-0}" -lt 7 ]; }; then
+            echo "MySQL version ${RESULT:-unknown} is not supported. MySQL 5.7 or later is required." >&2
+            exit 1
+          fi
+
+          echo "MySQL version ${RESULT} detected - supported."
+
+          PS_STATUS=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SHOW VARIABLES LIKE 'performance_schema';" 2>&1 | awk '{print $2}')
+          if [ "$PS_STATUS" != "ON" ]; then
+            echo "performance_schema is disabled on this MySQL server." >&2
+            echo "Enable it (performance_schema=ON in my.cnf) and restart MySQL, then re-run this installation." >&2
+            exit 1
+          fi
+
+          echo "performance_schema is enabled."
+
+    install_nrdot:
+      cmds:
+        - |
+          COLLECTOR_DISTRO="nrdot-collector"
+
+          if rpm -q "$COLLECTOR_DISTRO" > /dev/null 2>&1; then
+            echo "NRDOT Collector is already installed."
+            echo ""
+            echo "Please follow the steps below to complete the setup:"
+            echo ""
+            echo "  1. Create mysql-config.yaml"
+            echo "     if not present. Refer to:"
+            echo "     https://docs.newrelic.com/docs/opentelemetry/database/mysql/hosted/"
+            echo ""
+            echo "  2. Make sure the monitoring user is created"
+            echo "     and has the required permissions granted."
+            echo ""
+            echo "  3. After making the above changes, restart the NRDOT Collector:"
+            echo "     sudo systemctl restart nrdot-collector"
+            echo ""
+            exit 131
+          fi
+
+          COLLECTOR_VERSION=$(curl -sf "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest" | grep '"tag_name":' | awk -F'"' '{print $4}')
+          if [ -z "$COLLECTOR_VERSION" ]; then
+            echo "Failed to fetch the latest release version from GitHub. Please check your internet connection." >&2
+            exit 1
+          fi
+
+          if [ "$(uname -m)" = "aarch64" ]; then
+            ARCH="arm64"
+          else
+            ARCH="x86_64"
+          fi
+
+          DOWNLOAD_URL="https://github.com/newrelic/nrdot-collector-releases/releases/download/${COLLECTOR_VERSION}/${COLLECTOR_DISTRO}_${COLLECTOR_VERSION}_linux_${ARCH}.rpm"
+          echo "Installing ${COLLECTOR_DISTRO} version: ${COLLECTOR_VERSION}"
+          echo "Downloading from: ${DOWNLOAD_URL}"
+
+          curl -L --output /tmp/nrdot-collector.rpm "$DOWNLOAD_URL"
+          if [ $? -ne 0 ]; then
+            echo "Failed to download the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rpm -ivh /tmp/nrdot-collector.rpm
+          if [ $? -ne 0 ]; then
+            echo "Failed to install the nrdot-collector package." >&2
+            exit 1
+          fi
+
+          rm -f /tmp/nrdot-collector.rpm
+          echo "${COLLECTOR_DISTRO} installed successfully."
+
+    configure_database_user:
+      cmds:
+        - |
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
+          chmod 600 "$CNF_FILE" "$SQL_FILE"
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          cat > "$SQL_FILE" << EOF
+          CREATE USER IF NOT EXISTS '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';
+          GRANT SELECT ON performance_schema.* TO '${LOGIN_NAME}'@'%';
+          GRANT UPDATE ON performance_schema.setup_consumers TO '${LOGIN_NAME}'@'%';
+          FLUSH PRIVILEGES;
+          EOF
+
+          RESULT=$(mysql --defaults-extra-file="$CNF_FILE" < "$SQL_FILE" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "SQL script failed:" >&2
+            echo "$RESULT" >&2
+            exit 1
+          fi
+          echo "$RESULT"
+
+          echo "MySQL monitoring identity configured successfully."
+
+    create_collector_config:
+      cmds:
+        - |
+          PRESET="{{.NR_CLI_MYSQL_CONFIG_PRESET}}"
+          LOGIN_NAME="{{.NR_CLI_MYSQL_LOGIN_NAME}}"
+          if ! printf '%s' "$LOGIN_NAME" | grep -qE '^[A-Za-z][A-Za-z0-9_]*$'; then
+            echo "Invalid monitoring username: $LOGIN_NAME" >&2
+            echo "Usernames must start with a letter and contain only letters, digits, and underscores." >&2
+            exit 131
+          fi
+          SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
+          PORT="{{.NR_CLI_MYSQL_PORT}}"
+          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
+          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
+          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
+          NR_ROOT_PW_EOF
+          )
+          REGION="{{.NEW_RELIC_REGION}}"
+          LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
+          CONFIG_DIR="/etc/nrdot-collector"
+          CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
+          ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+
+          mkdir -p "$CONFIG_DIR"
+
+          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
+          chmod 600 "$CNF_FILE"
+          trap 'rm -f "$CNF_FILE"' EXIT
+          cat > "$CNF_FILE" << EOF
+          [client]
+          user=root
+          password=${ROOT_PASSWORD}
+          host=${SERVER}
+          port=${PORT}
+          EOF
+
+          NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "Failed to set the monitoring user's password:" >&2
+            echo "$ALTER_RESULT" >&2
+            exit 1
+          fi
+
+          if [ "$PRESET" = "2" ]; then
+            COLLECTION_INTERVAL="30s"
+            LIMIT_MIB=500
+          else
+            COLLECTION_INTERVAL="15s"
+            LIMIT_MIB=200
+          fi
+
+          DATABASE_LINE=""
+          if [ -n "$DATABASE" ]; then
+            DATABASE_LINE="    database: ${DATABASE}"
+          fi
+
+          case "$REGION" in
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+          esac
+
+          if [ "$PRESET" = "2" ]; then
+            cat > "$CONFIG_PATH" << EOF
+          extensions:
+            health_check:
+
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                http:
+
+            host_metrics:
+              collection_interval: 30s
+              scrapers:
+                cpu:
+                  metrics:
+                    system.cpu.time:
+                      enabled: false
+                    system.cpu.utilization:
+                      enabled: true
+                load:
+                memory:
+                  metrics:
+                    system.memory.utilization:
+                      enabled: true
+                paging:
+                  metrics:
+                    system.paging.utilization:
+                      enabled: false
+                    system.paging.faults:
+                      enabled: false
+                disk:
+                  metrics:
+                    system.disk.merged:
+                      enabled: false
+                    system.disk.pending_operations:
+                      enabled: false
+                    system.disk.weighted_io_time:
+                      enabled: false
+                network:
+                  metrics:
+                    system.network.connections:
+                      enabled: false
+                processes:
+                process:
+                  mute_process_name_error: true
+                  mute_process_exe_error: true
+                  mute_process_user_error: true
+                  mute_process_io_error: true
+                  metrics:
+                    process.cpu.utilization:
+                      enabled: true
+                    process.memory.utilization:
+                      enabled: true
+
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+                mysql.connection.count:
+                  enabled: true
+                mysql.connection.errors:
+                  enabled: true
+                mysql.max_used_connections:
+                  enabled: true
+                mysql.client.network.io:
+                  enabled: true
+                mysql.mysqlx_worker_threads:
+                  enabled: true
+                mysql.commands:
+                  enabled: true
+                mysql.query.count:
+                  enabled: true
+                mysql.query.client.count:
+                  enabled: true
+                mysql.query.slow.count:
+                  enabled: true
+                mysql.joins:
+                  enabled: true
+                mysql.statement_event.count:
+                  enabled: true
+                mysql.statement_event.wait.time:
+                  enabled: true
+                mysql.table.average_row_length:
+                  enabled: true
+                mysql.table.rows:
+                  enabled: true
+                mysql.table.size:
+                  enabled: true
+                mysql.table_open_cache:
+                  enabled: true
+                mysql.table.lock_wait.read.count:
+                  enabled: true
+                mysql.table.lock_wait.read.time:
+                  enabled: true
+                mysql.table.lock_wait.write.count:
+                  enabled: true
+                mysql.table.lock_wait.write.time:
+                  enabled: true
+                mysql.replica.sql_delay:
+                  enabled: true
+                mysql.replica.time_behind_source:
+                  enabled: true
+                mysql.page_size:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+            metrics_transform:
+              transforms:
+                - include: system.cpu.utilization
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [state]
+                      aggregation_type: mean
+                - include: system.paging.operations
+                  action: update
+                  operations:
+                    - action: aggregate_labels
+                      label_set: [direction]
+                      aggregation_type: sum
+
+            filter/exclude_cpu_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+                  - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+            filter/exclude_memory_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+                  - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+            filter/exclude_memory_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+                  - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+            filter/exclude_filesystem_utilization:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+            filter/exclude_filesystem_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_filesystem_inodes_usage:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+                  - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+            filter/exclude_system_disk:
+              metrics:
+                datapoint:
+                  - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+                  - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+            filter/exclude_network:
+              metrics:
+                datapoint:
+                  - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+            attributes/exclude_system_paging:
+              include:
+                match_type: strict
+                metric_names:
+                  - system.paging.operations
+              actions:
+                - key: type
+                  action: delete
+
+            cumulativetodelta:
+
+            transform/host:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - set(metric.description, "")
+                    - set(metric.unit, "")
+
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+            batch/logs:
+              send_batch_size: 15
+              send_batch_max_size: 15
+              timeout: 5s
+
+            resource_detection:
+              detectors: ["system"]
+              system:
+                hostname_sources: ["os"]
+                resource_attributes:
+                  host.id:
+                    enabled: true
+            resource_detection/cloud:
+              detectors: ["gcp", "ec2", "azure"]
+              timeout: 2s
+              override: true
+            resource_detection/env:
+              detectors: ["env"]
+              timeout: 2s
+              override: true
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            extensions: [health_check]
+
+            pipelines:
+              metrics/host:
+                receivers: [host_metrics, nrmysql]
+                processors:
+                  - metrics_transform
+                  - filter/exclude_cpu_utilization
+                  - filter/exclude_memory_utilization
+                  - filter/exclude_memory_usage
+                  - filter/exclude_filesystem_utilization
+                  - filter/exclude_filesystem_usage
+                  - filter/exclude_filesystem_inodes_usage
+                  - filter/exclude_system_disk
+                  - filter/exclude_network
+                  - attributes/exclude_system_paging
+                  - transform/host
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - cumulativetodelta
+                  - memory_limiter
+                  - batch
+                exporters: [otlphttp]
+
+              logs/host:
+                receivers: [nrmysql]
+                processors:
+                  - resource_detection
+                  - resource_detection/cloud
+                  - resource_detection/env
+                  - batch/logs
+                exporters: [otlphttp]
+
+              traces:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              metrics:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [otlp]
+                processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+                exporters: [otlphttp]
+          EOF
+          else
+            cat > "$CONFIG_PATH" << EOF
+          receivers:
+            nrmysql:
+              endpoint: ${SERVER}:${PORT}
+              transport: tcp
+              username: ${LOGIN_NAME}
+              password: ${NR_PASSWORD}
+          EOF
+            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
+            cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
+              collection_interval: ${COLLECTION_INTERVAL}
+              initial_delay: 1s
+
+              statement_events:
+                digest_text_limit: 4096
+                time_limit: 24h
+                limit: 500
+
+              query_sample_collection:
+                max_rows_per_query: 100
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              top_query_collection:
+                lookback_time: 120
+                max_query_sample_count: 5000
+                top_query_count: 200
+                collection_interval: 60s
+                query_plan_cache_size: 1000
+                query_plan_cache_ttl: 1h
+                allowed_comment_keys:
+                  - nr_service_guid
+
+              metrics:
+          EOF
+            cat >> "$CONFIG_PATH" << 'EOF'
+                mysql.buffer_pool.data_pages:
+                  enabled: true
+                mysql.buffer_pool.limit:
+                  enabled: true
+                mysql.buffer_pool.operations:
+                  enabled: true
+                mysql.buffer_pool.page_flushes:
+                  enabled: true
+                mysql.buffer_pool.pages:
+                  enabled: true
+                mysql.buffer_pool.usage:
+                  enabled: true
+                mysql.double_writes:
+                  enabled: true
+                mysql.handlers:
+                  enabled: true
+                mysql.index.io.wait.count:
+                  enabled: true
+                mysql.index.io.wait.time:
+                  enabled: true
+                mysql.locks:
+                  enabled: true
+                mysql.log_operations:
+                  enabled: true
+                mysql.mysqlx_connections:
+                  enabled: true
+                mysql.opened_resources:
+                  enabled: true
+                mysql.operations:
+                  enabled: true
+                mysql.page_operations:
+                  enabled: true
+                mysql.prepared_statements:
+                  enabled: true
+                mysql.row_locks:
+                  enabled: true
+                mysql.row_operations:
+                  enabled: true
+                mysql.sorts:
+                  enabled: true
+                mysql.table.io.wait.count:
+                  enabled: true
+                mysql.table.io.wait.time:
+                  enabled: true
+                mysql.threads:
+                  enabled: true
+                mysql.tmp_resources:
+                  enabled: true
+                mysql.uptime:
+                  enabled: true
+
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+
+          processors:
+          EOF
+            cat >> "$CONFIG_PATH" << EOF
+            memory_limiter:
+              check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+              limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-${LIMIT_MIB}}
+              spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+            batch:
+
+          exporters:
+            otlphttp:
+              endpoint: ${OTLP_ENDPOINT}
+              headers:
+                api-key: ${LICENSE_KEY}
+              tls:
+                insecure: false
+              compression: gzip
+
+          service:
+            telemetry:
+              metrics:
+                level: none
+
+            pipelines:
+              metrics:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+
+              logs:
+                receivers: [nrmysql]
+                processors: [memory_limiter, batch]
+                exporters: [otlphttp]
+          EOF
+          fi
+
+          cat > "$ENV_FILE" << EOF
+          OTELCOL_OPTIONS="--config=${CONFIG_PATH}"
+          EOF
+
+          chown nrdot-collector:nrdot-collector "$CONFIG_PATH"
+          chmod 600 "$CONFIG_PATH"
+
+          echo "MySQL OTel config written to ${CONFIG_PATH}"
+          echo "Env file written to ${ENV_FILE}"
+
+    restart_nrdot:
+      cmds:
+        - |
+          systemctl restart nrdot-collector
+
+          echo "Waiting for NRDOT Collector to start..."
+          for i in $(seq 1 30); do
+            if systemctl is-active --quiet nrdot-collector; then
+              echo "NRDOT Collector is running."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "NRDOT Collector did not start in time. Check logs:" >&2
+          journalctl -u nrdot-collector --no-pager -n 50 >&2
+          exit 31
+
+    default:
+      cmds:
+        - task: write_recipe_metadata
+        - task: assert_pre_req
+        - task: assert_mysql_version
+        - task: install_nrdot
+        - task: configure_database_user
+        - task: create_collector_config
+        - task: restart_nrdot
+
+postInstall:
+  info: |2
+      MySQL OTel config: /etc/nrdot-collector/mysql-config.yaml
+      Env file:           /etc/nrdot-collector/nrdot-collector.conf
+      Service status:     systemctl status nrdot-collector
+      View logs:           journalctl -u nrdot-collector -f
+      Restart service:     sudo systemctl restart nrdot-collector
+
+      Note: query plans for write statements are not collected by default
+      (explain_mode is left at its "inline" default). Enabling "procedure"
+      mode requires creating an explain_statement stored procedure and
+      granting EXECUTE on it to the monitoring user - see:
+      https://docs.newrelic.com/docs/opentelemetry/database/mysql/advanced-config/

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -368,10 +368,11 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
+                insecure: true
                 insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
@@ -620,10 +621,11 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: false
+                insecure: true
                 insecure_skip_verify: true
               explain_mode: procedure
               statement_events:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -713,17 +713,6 @@ install:
           journalctl -u nrdot-collector --no-pager -n 50 >&2
           exit 31
 
-    # TEMPORARY: diagnostic-only task to see why nrmysql receiver metrics
-    # aren't reaching NRDB. Remove once the root cause is confirmed.
-    debug_dump_collector_logs:
-      cmds:
-        - |
-          echo "Waiting 25s for a couple of nrmysql scrape cycles..."
-          sleep 25
-          echo "=== journalctl -u nrdot-collector (last 200 lines) ==="
-          journalctl -u nrdot-collector --no-pager -n 200
-          echo "=== end journalctl ==="
-
     default:
       cmds:
         - task: write_recipe_metadata
@@ -733,7 +722,6 @@ install:
         - task: configure_database_user
         - task: create_collector_config
         - task: restart_nrdot
-        - task: debug_dump_collector_logs
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -368,11 +368,10 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: true
+                insecure: false
                 insecure_skip_verify: true
               # "procedure" collects EXPLAIN plans for write statements (UPDATE/DELETE/INSERT/REPLACE)
               # without granting DML to the monitoring user, via a SQL SECURITY DEFINER procedure.
@@ -621,11 +620,10 @@ install:
           EOF
             [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
-              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
-                insecure: true
+                insecure: false
                 insecure_skip_verify: true
               explain_mode: procedure
               statement_events:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -55,8 +55,6 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
-
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -53,9 +53,6 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-  - name: NR_CLI_MYSQL_DATABASE
-    prompt: "Database to monitor (leave blank to monitor all databases): "
-    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -260,7 +257,6 @@ install:
           fi
           SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          DATABASE="{{.NR_CLI_MYSQL_DATABASE}}"
           ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
           {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
           NR_ROOT_PW_EOF
@@ -293,10 +289,6 @@ install:
             exit 1
           fi
 
-          DATABASE_LINE=""
-          if [ -n "$DATABASE" ]; then
-            DATABASE_LINE="    database: \"${DATABASE}\""
-          fi
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
@@ -367,7 +359,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
               collection_interval: 10s
@@ -620,7 +611,6 @@ install:
               username: "${LOGIN_NAME}"
               password: "${NR_PASSWORD}"
           EOF
-            [ -n "$DATABASE_LINE" ] && echo "$DATABASE_LINE" >> "$CONFIG_PATH"
             cat >> "$CONFIG_PATH" << EOF
               allow_native_passwords: true
               collection_interval: 10s

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -53,14 +53,9 @@ inputVars:
   - name: NR_CLI_MYSQL_LOGIN_NAME
     prompt: "Monitoring username: "
     default: "newrelic"
-# NR_CLI_MYSQL_DATABASE is intentionally not declared as an inputVar: the
-# newrelic-cli's non-interactive mode requires every declared inputVar to
-# either have a non-empty default or be explicitly provided, even when the
-# field is meant to be optional (default: "" is not sufficient - see
-# b5becc66 for the same fix applied to NR_CLI_MSSQL_LOGIN_PASSWORD). Leaving
-# it undeclared lets {{.NR_CLI_MYSQL_DATABASE}} below resolve to an empty
-# string when unset, which is exactly the "monitor all databases" behavior
-# documented for this field - while still letting users set it via env var.
+  - name: NR_CLI_MYSQL_DATABASE
+    prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
 
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
@@ -121,10 +116,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -N -e "SELECT VERSION();" 2>&1)
           if [ $? -ne 0 ]; then
@@ -229,10 +224,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 
@@ -285,10 +280,10 @@ install:
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
-          password=${ROOT_PASSWORD}
           host=${SERVER}
           port=${PORT}
           EOF
+          export MYSQL_PWD="$ROOT_PASSWORD"
 
           NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -713,6 +713,17 @@ install:
           journalctl -u nrdot-collector --no-pager -n 50 >&2
           exit 31
 
+    # TEMPORARY: diagnostic-only task to see why nrmysql receiver metrics
+    # aren't reaching NRDB. Remove once the root cause is confirmed.
+    debug_dump_collector_logs:
+      cmds:
+        - |
+          echo "Waiting 25s for a couple of nrmysql scrape cycles..."
+          sleep 25
+          echo "=== journalctl -u nrdot-collector (last 200 lines) ==="
+          journalctl -u nrdot-collector --no-pager -n 200
+          echo "=== end journalctl ==="
+
     default:
       cmds:
         - task: write_recipe_metadata
@@ -722,6 +733,7 @@ install:
         - task: configure_database_user
         - task: create_collector_config
         - task: restart_nrdot
+        - task: debug_dump_collector_logs
 
 postInstall:
   info: |2

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -55,6 +55,7 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_MYSQL_DATABASE
     prompt: "Database to monitor (leave blank to monitor all databases): "
+    default: ""
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'mysql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 

--- a/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "database-integrations",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "database-integrations"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "RHEL-9.*_HVM-????????-x86_64-?-Hourly2-GP3",
+      "user_name": "ec2-user"
+    }
+  ],
+  "services": [
+    {
+      "id": "mysql1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-mysql/install/rhel/roles",
+      "port": 3306
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_mysql_rhel9_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml",
+          "recipe_targeted": "nrdot-collector-mysql",
+          "validate_output": "NRDOT MySQL \\(RHEL/CentOS\\)\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
@@ -39,7 +39,7 @@
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml",
           "recipe_targeted": "nrdot-collector-mysql",
           "validate_output": "NRDOT MySQL \\(RHEL/CentOS\\)\\s+\\(installed\\)",
-          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic NR_CLI_MYSQL_DATABASE=mysql"
         },
         "provider": "newrelic"
       }

--- a/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-rhel9-amd64.json
@@ -39,7 +39,7 @@
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml",
           "recipe_targeted": "nrdot-collector-mysql",
           "validate_output": "NRDOT MySQL \\(RHEL/CentOS\\)\\s+\\(installed\\)",
-          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic NR_CLI_MYSQL_DATABASE=mysql"
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
         },
         "provider": "newrelic"
       }

--- a/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
@@ -1,0 +1,48 @@
+{
+  "global_tags": {
+    "owning_team": "database-integrations",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "database-integrations"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.medium",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "services": [
+    {
+      "id": "mysql1",
+      "destinations": [
+        "host1"
+      ],
+      "source_repository": "https://github.com/newrelic/open-install-library.git",
+      "deploy_script_path": "test/deploy/linux/nrdot-mysql/install/debian/roles",
+      "port": 3306
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "nr_nrdot_mysql_ubuntu22_amd64",
+        "resource_ids": [
+          "host1"
+        ],
+        "source_repository": "https://github.com/newrelic/open-install-library.git",
+        "deploy_script_path": "test/deploy/linux/newrelic-cli/install-recipe/roles",
+        "params": {
+          "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml",
+          "recipe_targeted": "nrdot-collector-mysql",
+          "validate_output": "NRDOT MySQL \\(Debian/Ubuntu\\)\\s+\\(installed\\)",
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
+        },
+        "provider": "newrelic"
+      }
+    ]
+  }
+}

--- a/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
@@ -39,7 +39,7 @@
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml",
           "recipe_targeted": "nrdot-collector-mysql",
           "validate_output": "NRDOT MySQL \\(Debian/Ubuntu\\)\\s+\\(installed\\)",
-          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic NR_CLI_MYSQL_DATABASE=mysql"
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
         },
         "provider": "newrelic"
       }

--- a/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
+++ b/test/definitions/nrdot/mysql-otel/mysql-ubuntu22-amd64.json
@@ -39,7 +39,7 @@
           "recipe_content_url": "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml",
           "recipe_targeted": "nrdot-collector-mysql",
           "validate_output": "NRDOT MySQL \\(Debian/Ubuntu\\)\\s+\\(installed\\)",
-          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic"
+          "env_var": "NEW_RELIC_CLI_SKIP_CORE=1 NR_CLI_MYSQL_CONFIG_PRESET=1 NR_CLI_MYSQL_SERVER=localhost NR_CLI_MYSQL_PORT=3306 NR_CLI_MYSQL_ROOT_PASSWORD=YourStrong@Passw0rd NR_CLI_MYSQL_LOGIN_NAME=newrelic NR_CLI_MYSQL_DATABASE=mysql"
         },
         "provider": "newrelic"
       }

--- a/test/deploy/linux/nrdot-mysql/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-mysql/install/debian/roles/configure/tasks/main.yml
@@ -31,10 +31,16 @@
     exit 1
   become: yes
 
+# root@localhost's actual default auth state on Ubuntu's mysql-server has
+# proven inconsistent to assume (auth_socket vs. a password plugin with no
+# known password). Bootstrap through /etc/mysql/debian.cnf's debian-sys-maint
+# account instead - the mysql-server package always creates it with known,
+# working admin credentials for its own maintenance scripts, regardless of
+# root's auth state.
 - name: Switch root to password-based auth and set its password
   shell: |
-    mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'YourStrong@Passw0rd';"
-    mysql -u root -e "FLUSH PRIVILEGES;"
+    mysql --defaults-file=/etc/mysql/debian.cnf -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'YourStrong@Passw0rd';"
+    mysql --defaults-file=/etc/mysql/debian.cnf -e "FLUSH PRIVILEGES;"
   become: yes
 
 - name: Enable performance_schema and required consumers

--- a/test/deploy/linux/nrdot-mysql/install/debian/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-mysql/install/debian/roles/configure/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- debug:
+    msg: Install MySQL Server for NRDOT MySQL Testing on Debian/Ubuntu
+
+- name: Update package list
+  shell: "apt-get update -y"
+  become: yes
+
+- name: Install MySQL server and client
+  shell: "DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server mysql-client"
+  become: yes
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Start and enable MySQL service
+  shell: |
+    systemctl enable mysql
+    systemctl restart mysql
+  become: yes
+
+- name: Wait for MySQL to accept connections
+  shell: |
+    for i in $(seq 1 30); do
+      if mysqladmin ping --silent > /dev/null 2>&1; then
+        echo "MySQL is accepting connections."
+        exit 0
+      fi
+      sleep 2
+    done
+    echo "MySQL did not start accepting connections in time." >&2
+    exit 1
+  become: yes
+
+- name: Switch root to password-based auth and set its password
+  shell: |
+    mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'YourStrong@Passw0rd';"
+    mysql -u root -e "FLUSH PRIVILEGES;"
+  become: yes
+
+- name: Enable performance_schema and required consumers
+  shell: |
+    mysql -u root -e "UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';"
+  become: yes
+  environment:
+    MYSQL_PWD: 'YourStrong@Passw0rd'
+
+- name: Verify MySQL is running
+  shell: "systemctl status mysql --no-pager"
+  become: yes

--- a/test/deploy/linux/nrdot-mysql/install/rhel/roles/configure/tasks/main.yml
+++ b/test/deploy/linux/nrdot-mysql/install/rhel/roles/configure/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- debug:
+    msg: Install MySQL Server for NRDOT MySQL Testing on RHEL/CentOS
+
+- name: Install wget
+  yum:
+    name: "wget"
+    state: latest
+  become: yes
+
+- name: Download MySQL Community repository RPM
+  shell: "wget https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm"
+  become: yes
+
+# GPG keys must be imported before the repo .rpm install - a strict dnf/yum
+# refuses to install an unverified package otherwise. Both keys are needed:
+# the repo .rpm itself is signed with one key, while mysql-community-server
+# pulled from the configured repo is signed with the other.
+- name: Import MySQL GPG keys
+  shell: "rpm --import {{ item }}"
+  loop:
+    - https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+    - https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
+  become: yes
+
+- name: Add MySQL Community repository
+  ansible.builtin.yum:
+    name: mysql80-community-release-el9-1.noarch.rpm
+    state: present
+    lock_timeout: 180
+  become: yes
+
+- name: Install MySQL server
+  ansible.builtin.yum:
+    name: mysql-community-server
+    state: present
+    lock_timeout: 180
+  become: yes
+
+- name: Start and enable MySQL service
+  shell: |
+    systemctl enable mysqld
+    systemctl restart mysqld
+  become: yes
+
+- name: Wait for MySQL to accept connections
+  shell: |
+    for i in $(seq 1 30); do
+      if mysqladmin ping --silent > /dev/null 2>&1; then
+        echo "MySQL is accepting connections."
+        exit 0
+      fi
+      sleep 2
+    done
+    echo "MySQL did not start accepting connections in time." >&2
+    exit 1
+  become: yes
+
+- name: Get temporary root password
+  shell: "grep 'temporary password' /var/log/mysqld.log | awk '{print $NF}'"
+  register: mysql_temp_pw
+  become: yes
+
+- name: Set root password (using the generated temporary password)
+  shell: |
+    mysql -u root -p'{{ mysql_temp_pw.stdout }}' --connect-expired-password -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'YourStrong@Passw0rd';"
+    mysql -u root -e "FLUSH PRIVILEGES;"
+  become: yes
+  environment:
+    MYSQL_PWD: 'YourStrong@Passw0rd'
+
+- name: Enable performance_schema and required consumers
+  shell: |
+    mysql -u root -e "UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';"
+  become: yes
+  environment:
+    MYSQL_PWD: 'YourStrong@Passw0rd'
+
+- name: Verify MySQL is running
+  shell: "systemctl status mysqld --no-pager"
+  become: yes


### PR DESCRIPTION
## Summary
- Adds `nrdot-collector-mysql` recipes for Debian/Ubuntu and RHEL/CentOS, both self-hosted and RDS/Aurora, using the `nrmysql` receiver — mirrors the existing mssql-otel pattern (Standard/Full-feature presets, scoped monitoring-user provisioning, injection-safe credential handling).
- MySQL NRDOT support is Linux-only per docs (no Windows/WinAuth), so this ships 4 recipe files instead of mssql-otel's 8.
- Adds test definitions (`test/definitions/nrdot/mysql-otel/`) and Ansible deploy roles (`test/deploy/linux/nrdot-mysql/`) for CI provisioning.
- Design spec: `docs/superpowers/specs/2026-08-31-mysql-otel-recipe-design.md` (local/gitignored, per repo convention).

All 4 recipes marked `WORK IN PROGRESS - not for use`, consistent with the current mssql-otel recipes' status.



I’ve attached the test [documentation](https://docs.google.com/document/d/1nRgqw-w1_-lAIal17GwUQsR9pATpR1VN6wm02ALOPiQ/edit?tab=t.0) covering several key integration scenarios for your review
