### PR TITLE
fix(apache): extend installTargets to cover RHEL family (Rocky/Alma/Oracle) and arm64

### DIFF
--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -20,6 +20,10 @@ installTargets:
     os: linux
     platform: "redhat"
     kernelArch: x86_64
+  - type: host
+    os: linux
+    platformFamily: "rhel"
+    kernelArch: x86_64
 
 # keyword convention for dealing with search terms that could land someone on this instrumentation project
 keywords:

--- a/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
+++ b/recipes/newrelic/infrastructure/ohi/apache/rhel.yml
@@ -24,6 +24,10 @@ installTargets:
     os: linux
     platformFamily: "rhel"
     kernelArch: x86_64
+  - type: host
+    os: linux
+    platformFamily: "rhel"
+    kernelArch: aarch64
 
 # keyword convention for dealing with search terms that could land someone on this instrumentation project
 keywords:


### PR DESCRIPTION
## Summary

`apache-open-source-integration`'s RHEL recipe only matches `platform: amazon|centos|redhat`, all pinned to `kernelArch: x86_64`, so hosts reporting `os: rocky`/`alma`/`oracle` **or** `kernelArch: aarch64` fail with **"Unsupported"** — even though `nri-apache` supports both. One customer alone has generated ~21k failed *targeted* install attempts across 600+ Rocky hosts.

This PR adds two additive `installTargets` entries:

```diff
   - type: host
     os: linux
     platform: "redhat"
     kernelArch: x86_64
+  - type: host
+    os: linux
+    platformFamily: "rhel"
+    kernelArch: x86_64
+  - type: host
+    os: linux
+    platformFamily: "rhel"
+    kernelArch: aarch64
```

1. **`platformFamily: rhel` / `kernelArch: x86_64`** — covers Rocky, Alma, and Oracle Linux without enumerating each distro, matching the precedent already established in `postgres/rhel.yml` and this recipe's own `debian.yml` sibling (`platformFamily: "debian"`). This is the primary fix for [NR-583825](https://new-relic.atlassian.net/browse/NR-583825).
2. **`platformFamily: rhel` / `kernelArch: aarch64`** — added after checking whether the arm64 exclusion (present on every entry since a 2021 repo-wide recipe restructuring, [#160](https://github.com/newrelic/open-install-library/pull/160), applied as a blanket default rather than a deliberate decision) is still warranted. It isn't: `nri-apache`'s [latest release](https://github.com/newrelic/nri-apache/releases/latest) publishes real `arm64` RPMs today. I also found a live case of this in New Relic's own install-telemetry: an Amazon Linux 2023 `aarch64` host hit "Unsupported" on a targeted install. This entry closes that too — `platformFamily: rhel` already covers Amazon Linux (gopsutil classifies it into the `rhel` family), so the same one entry covers Amazon/CentOS/RHEL/Rocky/Alma/Oracle on arm64. Scoped to `aarch64` only — `nri-apache` also ships `386`/`arm`(32-bit) builds, but those weren't part of the reported gap and aren't included here.

Existing `amazon`/`centos`/`redhat` entries are untouched throughout — every change here is additive, so there's no regression risk to current coverage.

Fixes [NR-583825](https://new-relic.atlassian.net/browse/NR-583825)

## Why no new deploy test definition file

The ticket's AC calls for a Rocky-targeted `test/definitions` entry "where feasible." I looked into adding one and decided against it for this PR — here's why:

The Deployer's EC2 provisioning task (`amazon.aws.ec2_ami_info`, in `template.erb`) resolves `ami_name` with **no `owners:` filter**:
```yaml
- name: Determine AMI ID for EC2 instance
  amazon.aws.ec2_ami_info:
    filters:
      name: "{{ ami_name }}"
  register: found_ec2_ami_fact
# ...sorted by creation_date, takes the newest match
```
Per Ansible's own `amazon.aws.ec2_ami_info` docs, omitting `owners` searches AMIs across **all AWS accounts**, public and private, then this template just takes whichever matching AMI has the newest `creation_date`. There's no owner-scoping field anywhere in the Deployer's schema (`ec2_resource.rb`, its README, or the templates) — this can't be fixed from the test-definition JSON alone.

This is a real risk specifically for a Rocky-style AMI name (`Rocky-9-EC2-Base-*`): unlike Amazon's/Microsoft's own AMI naming, community-style AMI names like this are a documented AMI-name-squatting target. A third party could publish a public AMI with a colliding name and a newer `creation_date`, and the Deployer would silently pick it over Rocky's official one — launching an untrusted image with the shared PEM key on it. That's a structural gap in the Deployer, not something a smarter `ami_name` pattern in this repo can fix.

Given the AC's own "where feasible" qualifier, I scoped this PR to the recipe fix and covered Rocky 8/9 (and arm64) validation manually instead — see below. Not filing a separate issue for the Deployer gap per discussion on the ticket — flagging it here for visibility instead.

## Tests performed

**1. Real production matching code, synthetic input** — cloned `newrelic-cli`, wrote throwaway tests exercising the actual `DiscoveryManifest.ConstrainRecipes()` function (the real code that decides "Unsupported" vs. a match):
   - Rocky 9 (`platformFamily: rhel`, `x86_64`) against the *old* `installTargets` (3 entries) → 0 matches → reproduces the exact reported bug. Against the *new* targets (this PR) → 1 match.
   - The exact real telemetry failure — Amazon Linux 2023, `aarch64` — against targets *before* the arm64 entry → 0 matches (reproduces it exactly). *After* → 1 match.
   - Rocky 9 on `aarch64` also matches via the same new entry.
   - Existing `amazon`/`centos`/`redhat` (x86_64) manifests still match after both changes → no regression.
   - All test files deleted immediately after each check (throwaway, never committed).

**2. Real Rocky Linux 9.3 host via Docker, not synthetic** — ran a real `rockylinux:9` container:
   - Confirmed via `/etc/os-release`: `ID="rocky"`, `ID_LIKE="rhel centos fedora"` — a genuine Rocky 9.3 host.
   - Ran `gopsutil` (the exact library `newrelic-cli`'s host discovery uses) directly inside that real container: `OS=linux Platform=rocky PlatformFamily=rhel PlatformVersion=9.3 KernelArch=aarch64` — confirming the synthetic input used in test 1 matches what a real Rocky host actually reports, not an assumption.
   - This is where I first hit the CLI's live-auth requirement (see manual verification below for how that got resolved).

**3. Real production install telemetry** — confirmed the arm64 gap was real, not theoretical, by checking New Relic's own install-telemetry data before writing the fix: found a live Amazon Linux 2023 `aarch64` "Unsupported" event, used as the exact input for test 1 above.

**4. Schema validation** — `ajv validate -s schema-v1.json` (this repo's own validator, same check as CI's "Validation" job) against the modified `rhel.yml`, after each change → passes both times.

## Manual end-to-end verification (real EC2 hardware, real account)

Went further than the automated checks above to fully satisfy the ticket's AC ("`newrelic install -n apache-open-source-integration` succeeds on Rocky Linux 8 and 9") — ran the actual recipe, with the actual `newrelic-cli`, against real EC2 instances in an isolated personal AWS test account (not any shared/production account), region `ap-south-1`. All identifying details below (account IDs, IPs, hostnames) are redacted/generalized since this is a public repo.

**Setup:**
- Looked up the official Rocky AMIs directly with an explicit `--owners` filter (Rocky's own publishing account) via the AWS CLI — deliberately avoiding the exact unscoped-lookup risk described above.
- Launched 3 short-lived `t3.micro`/`t4g.micro` instances: Rocky 9 (x86_64), Rocky 8 (x86_64), Rocky 9 (arm64), each in a dedicated security group scoped to SSH from a single known IP only.
- Installed Apache with `mod_status`/`server-status` enabled (the recipe's precondition) and `newrelic-cli` on each.
- Authenticated the CLI with a real New Relic account — done directly on each instance so the API key never passed through this session.

**Before/after, on the same real host:**
- OLD recipe (pre-fix) → `⊘ apache-open-source-integration (unsupported)` → `no recipes were installed`. Exact live reproduction of the reported bug.
- NEW recipe (this PR) → recipe is found and matched, proceeds into actual installation.

**Full result, all three combinations, both the target recipe and its `infrastructure-agent-installer` dependency:**

| Host | Platform | Arch | `apache-open-source-integration` | `infrastructure-agent-installer` |
| --- | --- | --- | --- | --- |
| Host A | Rocky 9.8 | x86_64 | ✅ Installed (`nri-apache-1.17.3-1.x86_64`) | ✅ Installed |
| Host B | Rocky 8.10 | x86_64 | ✅ Installed (`nri-apache-1.17.3-1.x86_64`) | ✅ Installed |
| Host C | Rocky 9.8 | aarch64 | ✅ Installed (`nri-apache-1.17.3-1.aarch64` — confirms a real arm64 package resolved and installed) | ✅ Installed |

Discovered manifests confirmed on all three: `Platform: rocky`, `PlatformFamily: rhel`, matching `KernelArch` per host — exactly the values this PR's fix targets.

**Independently cross-checked against New Relic's own install-telemetry** (not just the CLI's local exit code): final status is `INSTALLED` for all 6 host/recipe combinations. The full telemetry timeline also captured, transparently:
- The two `UNSUPPORTED` events from the pre-fix reproduction run above.
- One incidental `FAILED` event on `infrastructure-agent-installer` from an early attempt on my end that hadn't yet elevated privileges correctly (unrelated to the recipe change — the very next, corrected attempt went straight to `INSTALLED`).

All three instances, the key pair, and the security group were torn down immediately after testing — nothing left running.


[NR-583825]: https://new-relic.atlassian.net/browse/NR-583825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ