### PR TITLE
fix(nrdot): rename oracle oci-linux recipe to nrdot-collector-oracle

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/oracle-otel/oci-linux.yml
+++ b/recipes/newrelic/infrastructure/nrdot/oracle-otel/oci-linux.yml
@@ -2,7 +2,7 @@
 # https://github.com/newrelic/open-install-library/blob/main/docs/recipe-spec/recipe-spec.md#schema-definition
 # WORK IN PROGRESS - not for use.
 
-name: nrdot-collector-oracle-linux
+name: nrdot-collector-oracle
 displayName: NRDOT Oracle Database (Oracle Linux)
 description: New Relic install recipe for Oracle Database monitoring via NRDOT Collector on Oracle Linux (OCI) self-hosted environments
 repository: https://github.com/newrelic/nrdot-collector-releases


### PR DESCRIPTION
## Summary
- Renamed the NRDOT Oracle Database (Oracle Linux) recipe from `nrdot-collector-oracle-linux` to `nrdot-collector-oracle` for naming consistency.