### PR TITLE
fix(nrdot-otel): align Oracle, MSSQL, MySQL, and PostgreSQL recipes with docs

### DIFF
--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/debian.yml
@@ -86,6 +86,12 @@ install:
             exit 16
           fi
         - |
+          export PATH="/opt/mssql-tools18/bin:/opt/mssql-tools/bin:$PATH"
+          if ! command -v sqlcmd > /dev/null 2>&1; then
+            echo "sqlcmd is required to configure SQL Server monitoring. Install the sqlcmd utility (https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) and re-run this recipe." >&2
+            exit 16
+          fi
+        - |
           if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
             echo "systemd is required for the nrdot-collector service configuration." >&2
             exit 131
@@ -290,10 +296,10 @@ install:
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4318" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4318" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4318" ;;
           esac
 
           cat > "$CONFIG_PATH" << EOF
@@ -334,32 +340,6 @@ install:
                   enabled: true
                 sqlserver.database.tempdb.version_store.size:
                   enabled: true
-                sqlserver.database.principals.count:
-                  enabled: true
-                sqlserver.database.principals.old:
-                  enabled: true
-                sqlserver.database.principals.orphaned_users:
-                  enabled: true
-                sqlserver.database.principals.recently_created:
-                  enabled: true
-                sqlserver.database.role.members.count:
-                  enabled: true
-                sqlserver.database.role.memberships.count:
-                  enabled: true
-                sqlserver.database.role.permission.risk_level:
-                  enabled: true
-                sqlserver.database.role.roles.count:
-                  enabled: true
-                sqlserver.database.security.role_membership.count:
-                  enabled: true
-                sqlserver.server.security.principal.count:
-                  enabled: true
-                sqlserver.server.security.role_membership.count:
-                  enabled: true
-                sqlserver.lock.by_mode.count:
-                  enabled: true
-                sqlserver.lock.by_resource.count:
-                  enabled: true
                 sqlserver.lock.timeout.rate:
                   enabled: true
                 sqlserver.lock.wait.count:
@@ -385,8 +365,6 @@ install:
                 sqlserver.memory.grants.pending.count:
                   enabled: true
                 sqlserver.memory.page.count:
-                  enabled: true
-                sqlserver.memory.target:
                   enabled: true
                 sqlserver.memory.usage:
                   enabled: true
@@ -500,8 +478,6 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
-                sqlserver.kill_connection.error.rate:
-                  enabled: true
           EOF
           else
             cat >> "$CONFIG_PATH" << 'EOF'
@@ -540,6 +516,26 @@ install:
                 db.server.top_query:
                   enabled: true
 
+          EOF
+
+          if [ "$PRESET" = "2" ]; then
+            cat >> "$CONFIG_PATH" << 'EOF'
+              top_query_collection:
+                lookback_time: 60s
+                max_query_sample_count: 500
+                top_query_count: 200
+                collection_interval: 60s
+
+              collect_full_query_text: true
+              allowed_comment_keys:
+                - nr_service_guid
+
+              query_sample_collection:
+                max_rows_per_query: 100
+
+          EOF
+          else
+            cat >> "$CONFIG_PATH" << 'EOF'
               top_query_collection:
                 lookback_time: 60s
                 max_query_sample_count: 1000
@@ -553,6 +549,10 @@ install:
               query_sample_collection:
                 max_rows_per_query: 100
 
+          EOF
+          fi
+
+          cat >> "$CONFIG_PATH" << 'EOF'
           processors:
           EOF
 
@@ -568,7 +568,7 @@ install:
 
           cat >> "$CONFIG_PATH" << EOF
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -585,12 +585,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
 
           cat > "$ENV_FILE" << EOF

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/rds-debian.yml
@@ -89,6 +89,12 @@ install:
             exit 16
           fi
         - |
+          export PATH="/opt/mssql-tools18/bin:/opt/mssql-tools/bin:$PATH"
+          if ! command -v sqlcmd > /dev/null 2>&1; then
+            echo "sqlcmd is required to configure SQL Server monitoring. Install the sqlcmd utility (https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) and re-run this recipe." >&2
+            exit 16
+          fi
+        - |
           if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
             echo "systemd is required for the nrdot-collector service configuration." >&2
             exit 131
@@ -290,10 +296,10 @@ install:
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4318" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4318" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4318" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -508,17 +514,17 @@ install:
                   enabled: true
 
               top_query_collection:
-                lookback_time: 45s
-                max_query_sample_count: 100
-                top_query_count: 30
-                collection_interval: 30s
+                lookback_time: 60s
+                max_query_sample_count: 500
+                top_query_count: 200
+                collection_interval: 60s
 
               collect_full_query_text: true
               allowed_comment_keys:
                 - nr_service_guid
 
               query_sample_collection:
-                max_rows_per_query: 50
+                max_rows_per_query: 100
 
           processors:
             metrics_transform:
@@ -636,7 +642,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -672,7 +678,7 @@ install:
                   - cumulativetodelta
                   - memory_limiter
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -681,22 +687,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch/logs
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
@@ -762,7 +768,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -779,12 +785,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
           fi
 

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/rds-rhel.yml
@@ -89,6 +89,12 @@ install:
             exit 16
           fi
         - |
+          export PATH="/opt/mssql-tools18/bin:/opt/mssql-tools/bin:$PATH"
+          if ! command -v sqlcmd > /dev/null 2>&1; then
+            echo "sqlcmd is required to configure SQL Server monitoring. Install the sqlcmd utility (https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) and re-run this recipe." >&2
+            exit 16
+          fi
+        - |
           if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
             echo "systemd is required for the nrdot-collector service configuration." >&2
             exit 131
@@ -290,10 +296,10 @@ install:
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4318" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4318" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4318" ;;
           esac
 
           if [ "$PRESET" = "2" ]; then
@@ -508,17 +514,17 @@ install:
                   enabled: true
 
               top_query_collection:
-                lookback_time: 45s
-                max_query_sample_count: 100
-                top_query_count: 30
-                collection_interval: 30s
+                lookback_time: 60s
+                max_query_sample_count: 500
+                top_query_count: 200
+                collection_interval: 60s
 
               collect_full_query_text: true
               allowed_comment_keys:
                 - nr_service_guid
 
               query_sample_collection:
-                max_rows_per_query: 50
+                max_rows_per_query: 100
 
           processors:
             metrics_transform:
@@ -636,7 +642,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -672,7 +678,7 @@ install:
                   - cumulativetodelta
                   - memory_limiter
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -681,22 +687,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch/logs
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
           else
             cat > "$CONFIG_PATH" << EOF
@@ -762,7 +768,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -779,12 +785,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
           fi
 

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/rhel.yml
@@ -86,6 +86,12 @@ install:
             exit 16
           fi
         - |
+          export PATH="/opt/mssql-tools18/bin:/opt/mssql-tools/bin:$PATH"
+          if ! command -v sqlcmd > /dev/null 2>&1; then
+            echo "sqlcmd is required to configure SQL Server monitoring. Install the sqlcmd utility (https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) and re-run this recipe." >&2
+            exit 16
+          fi
+        - |
           if [ "{{.IS_SYSTEMCTL}}" -eq 0 ]; then
             echo "systemd is required for the nrdot-collector service configuration." >&2
             exit 131
@@ -290,10 +296,10 @@ install:
           fi
 
           case "$REGION" in
-            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net" ;;
-            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net" ;;
-            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net" ;;
-            *)       OTLP_ENDPOINT="https://otlp.nr-data.net" ;;
+            staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4318" ;;
+            EU)      OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4318" ;;
+            JP)      OTLP_ENDPOINT="https://otlp.jp.nr-data.net:4318" ;;
+            *)       OTLP_ENDPOINT="https://otlp.nr-data.net:4318" ;;
           esac
 
           cat > "$CONFIG_PATH" << EOF
@@ -334,32 +340,6 @@ install:
                   enabled: true
                 sqlserver.database.tempdb.version_store.size:
                   enabled: true
-                sqlserver.database.principals.count:
-                  enabled: true
-                sqlserver.database.principals.old:
-                  enabled: true
-                sqlserver.database.principals.orphaned_users:
-                  enabled: true
-                sqlserver.database.principals.recently_created:
-                  enabled: true
-                sqlserver.database.role.members.count:
-                  enabled: true
-                sqlserver.database.role.memberships.count:
-                  enabled: true
-                sqlserver.database.role.permission.risk_level:
-                  enabled: true
-                sqlserver.database.role.roles.count:
-                  enabled: true
-                sqlserver.database.security.role_membership.count:
-                  enabled: true
-                sqlserver.server.security.principal.count:
-                  enabled: true
-                sqlserver.server.security.role_membership.count:
-                  enabled: true
-                sqlserver.lock.by_mode.count:
-                  enabled: true
-                sqlserver.lock.by_resource.count:
-                  enabled: true
                 sqlserver.lock.timeout.rate:
                   enabled: true
                 sqlserver.lock.wait.count:
@@ -385,8 +365,6 @@ install:
                 sqlserver.memory.grants.pending.count:
                   enabled: true
                 sqlserver.memory.page.count:
-                  enabled: true
-                sqlserver.memory.target:
                   enabled: true
                 sqlserver.memory.usage:
                   enabled: true
@@ -500,8 +478,6 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
-                sqlserver.kill_connection.error.rate:
-                  enabled: true
           EOF
           else
             cat >> "$CONFIG_PATH" << 'EOF'
@@ -540,6 +516,26 @@ install:
                 db.server.top_query:
                   enabled: true
 
+          EOF
+
+          if [ "$PRESET" = "2" ]; then
+            cat >> "$CONFIG_PATH" << 'EOF'
+              top_query_collection:
+                lookback_time: 60s
+                max_query_sample_count: 500
+                top_query_count: 200
+                collection_interval: 60s
+
+              collect_full_query_text: true
+              allowed_comment_keys:
+                - nr_service_guid
+
+              query_sample_collection:
+                max_rows_per_query: 100
+
+          EOF
+          else
+            cat >> "$CONFIG_PATH" << 'EOF'
               top_query_collection:
                 lookback_time: 60s
                 max_query_sample_count: 1000
@@ -553,6 +549,10 @@ install:
               query_sample_collection:
                 max_rows_per_query: 100
 
+          EOF
+          fi
+
+          cat >> "$CONFIG_PATH" << 'EOF'
           processors:
           EOF
 
@@ -568,7 +568,7 @@ install:
 
           cat >> "$CONFIG_PATH" << EOF
           exporters:
-            otlphttp:
+            otlp:
               endpoint: ${OTLP_ENDPOINT}
               headers:
                 api-key: ${LICENSE_KEY}
@@ -585,12 +585,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           EOF
 
           cat > "$ENV_FILE" << EOF

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-rds-winauth.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-rds-winauth.yml
@@ -398,10 +398,10 @@ install:
           $receiverFields = "    collection_interval: $interval`n    datasource: `"server=$server;port=$port;integrated security=true;encrypt=true;TrustServerCertificate=true;`""
 
           switch ($region) {
-            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net" }
-            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net" }
-            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net" }
-            default   { $otlpEndpoint = "https://otlp.nr-data.net" }
+            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net:4318" }
+            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net:4318" }
+            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net:4318" }
+            default   { $otlpEndpoint = "https://otlp.nr-data.net:4318" }
           }
 
           if ($preset -eq "2") {
@@ -602,6 +602,26 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
+                sqlserver.performance_counter.buffer.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.cache.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.compilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.connections:
+                  enabled: true
+                sqlserver.performance_counter.locks.count:
+                  enabled: true
+                sqlserver.performance_counter.locks.timeout.rate:
+                  enabled: true
+                sqlserver.performance_counter.memory.grant_pending:
+                  enabled: true
+                sqlserver.performance_counter.page.operations.rate:
+                  enabled: true
+                sqlserver.performance_counter.recompilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.transactions.rate:
+                  enabled: true
 
               events:
                 db.server.query_sample:
@@ -736,7 +756,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -771,7 +791,7 @@ install:
                   - resource_detection/env
                   - cumulativetodelta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -780,22 +800,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           } else {
             $template = @'
@@ -856,7 +876,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -873,12 +893,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           }
 

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-rds.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-rds.yml
@@ -343,10 +343,10 @@ install:
           $receiverFields = "    collection_interval: $interval`n    username: $loginName`n    password: $NrPassword`n    server: $server`n    port: $port"
 
           switch ($region) {
-            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net" }
-            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net" }
-            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net" }
-            default   { $otlpEndpoint = "https://otlp.nr-data.net" }
+            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net:4318" }
+            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net:4318" }
+            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net:4318" }
+            default   { $otlpEndpoint = "https://otlp.nr-data.net:4318" }
           }
 
           if ($preset -eq "2") {
@@ -547,6 +547,26 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
+                sqlserver.performance_counter.buffer.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.cache.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.compilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.connections:
+                  enabled: true
+                sqlserver.performance_counter.locks.count:
+                  enabled: true
+                sqlserver.performance_counter.locks.timeout.rate:
+                  enabled: true
+                sqlserver.performance_counter.memory.grant_pending:
+                  enabled: true
+                sqlserver.performance_counter.page.operations.rate:
+                  enabled: true
+                sqlserver.performance_counter.recompilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.transactions.rate:
+                  enabled: true
 
               events:
                 db.server.query_sample:
@@ -681,7 +701,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -716,7 +736,7 @@ install:
                   - resource_detection/env
                   - cumulativetodelta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -725,22 +745,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           } else {
             $template = @'
@@ -801,7 +821,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -818,12 +838,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           }
 

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-winauth.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows-winauth.yml
@@ -325,10 +325,10 @@ install:
           $receiverFields = "    collection_interval: $interval`n    datasource: `"server=$server;port=$port;integrated security=true;encrypt=true;TrustServerCertificate=true;`""
 
           switch ($region) {
-            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net" }
-            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net" }
-            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net" }
-            default   { $otlpEndpoint = "https://otlp.nr-data.net" }
+            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net:4318" }
+            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net:4318" }
+            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net:4318" }
+            default   { $otlpEndpoint = "https://otlp.nr-data.net:4318" }
           }
 
           if ($preset -eq "2") {
@@ -531,6 +531,26 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
+                sqlserver.performance_counter.buffer.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.cache.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.compilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.connections:
+                  enabled: true
+                sqlserver.performance_counter.locks.count:
+                  enabled: true
+                sqlserver.performance_counter.locks.timeout.rate:
+                  enabled: true
+                sqlserver.performance_counter.memory.grant_pending:
+                  enabled: true
+                sqlserver.performance_counter.page.operations.rate:
+                  enabled: true
+                sqlserver.performance_counter.recompilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.transactions.rate:
+                  enabled: true
 
               events:
                 db.server.query_sample:
@@ -665,7 +685,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -700,7 +720,7 @@ install:
                   - resource_detection/env
                   - cumulativetodelta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -709,22 +729,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           } else {
             $template = @'
@@ -785,7 +805,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -802,12 +822,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           }
 

--- a/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mssql-otel/windows.yml
@@ -298,10 +298,10 @@ install:
           $receiverFields = "    collection_interval: $interval`n    username: $loginName`n    password: $NrPassword`n    server: $server`n    port: $port"
 
           switch ($region) {
-            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net" }
-            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net" }
-            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net" }
-            default   { $otlpEndpoint = "https://otlp.nr-data.net" }
+            "staging" { $otlpEndpoint = "https://staging-otlp.nr-data.net:4318" }
+            "EU"      { $otlpEndpoint = "https://otlp.eu01.nr-data.net:4318" }
+            "JP"      { $otlpEndpoint = "https://otlp.jp.nr-data.net:4318" }
+            default   { $otlpEndpoint = "https://otlp.nr-data.net:4318" }
           }
 
           if ($preset -eq "2") {
@@ -504,6 +504,26 @@ install:
                   enabled: true
                 sqlserver.table.count:
                   enabled: true
+                sqlserver.performance_counter.buffer.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.cache.hit_ratio:
+                  enabled: true
+                sqlserver.performance_counter.compilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.connections:
+                  enabled: true
+                sqlserver.performance_counter.locks.count:
+                  enabled: true
+                sqlserver.performance_counter.locks.timeout.rate:
+                  enabled: true
+                sqlserver.performance_counter.memory.grant_pending:
+                  enabled: true
+                sqlserver.performance_counter.page.operations.rate:
+                  enabled: true
+                sqlserver.performance_counter.recompilations.rate:
+                  enabled: true
+                sqlserver.performance_counter.transactions.rate:
+                  enabled: true
 
               events:
                 db.server.query_sample:
@@ -638,7 +658,7 @@ install:
               override: true
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -673,7 +693,7 @@ install:
                   - resource_detection/env
                   - cumulativetodelta
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs/host:
                 receivers: [nrsqlserver]
@@ -682,22 +702,22 @@ install:
                   - resource_detection/cloud
                   - resource_detection/env
                   - batch
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               traces:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               metrics:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [otlp]
                 processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           } else {
             $template = @'
@@ -758,7 +778,7 @@ install:
             batch:
 
           exporters:
-            otlphttp:
+            otlp:
               endpoint: __OTLP_ENDPOINT__
               headers:
                 api-key: __LICENSE_KEY__
@@ -775,12 +795,12 @@ install:
               metrics:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
 
               logs:
                 receivers: [nrsqlserver]
                 processors: [memory_limiter, batch]
-                exporters: [otlphttp]
+                exporters: [otlp]
           '@
           }
 

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/debian.yml
@@ -230,10 +230,12 @@ install:
           NR_ROOT_PW_EOF
           )
 
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
           CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
           SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
           chmod 600 "$CNF_FILE" "$SQL_FILE"
-          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          NR_SUCCESS=""
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"; if [ "$NR_SUCCESS" != "1" ]; then rm -f "$PW_FILE"; fi' EXIT
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
@@ -260,6 +262,10 @@ install:
           fi
           echo "$RESULT"
 
+          printf '%s' "$NR_PASSWORD" > "$PW_FILE"
+          chmod 600 "$PW_FILE"
+          NR_SUCCESS=1
+
           echo "MySQL monitoring identity configured successfully."
 
     create_collector_config:
@@ -274,37 +280,17 @@ install:
           fi
           SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
-          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
-          NR_ROOT_PW_EOF
-          )
           REGION="{{.NEW_RELIC_REGION}}"
           LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
           CONFIG_DIR="/etc/nrdot-collector"
           CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
           ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
 
           mkdir -p "$CONFIG_DIR"
 
-          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
-          chmod 600 "$CNF_FILE"
-          trap 'rm -f "$CNF_FILE"' EXIT
-          cat > "$CNF_FILE" << EOF
-          [client]
-          user=root
-          host=${SERVER}
-          port=${PORT}
-          EOF
-          export MYSQL_PWD="$ROOT_PASSWORD"
-
-          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
-
-          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
-          if [ $? -ne 0 ]; then
-            echo "Failed to set the monitoring user's password:" >&2
-            echo "$ALTER_RESULT" >&2
-            exit 1
-          fi
+          NR_PASSWORD=$(cat "$PW_FILE")
+          rm -f "$PW_FILE"
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-debian.yml
@@ -221,10 +221,12 @@ install:
           NR_MASTER_PW_EOF
           )
 
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
           CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
           SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
           chmod 600 "$CNF_FILE" "$SQL_FILE"
-          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          NR_SUCCESS=""
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"; if [ "$NR_SUCCESS" != "1" ]; then rm -f "$PW_FILE"; fi' EXIT
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
@@ -251,6 +253,10 @@ install:
           fi
           echo "$RESULT"
 
+          printf '%s' "$NR_PASSWORD" > "$PW_FILE"
+          chmod 600 "$PW_FILE"
+          NR_SUCCESS=1
+
           echo "MySQL monitoring identity configured successfully."
 
     create_collector_config:
@@ -266,39 +272,17 @@ install:
           SERVER="{{.NR_CLI_MYSQL_SERVER}}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
           TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
-          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
-          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
-          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
-          NR_MASTER_PW_EOF
-          )
           REGION="{{.NEW_RELIC_REGION}}"
           LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
           CONFIG_DIR="/etc/nrdot-collector"
           CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
           ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
 
           mkdir -p "$CONFIG_DIR"
 
-          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
-          chmod 600 "$CNF_FILE"
-          trap 'rm -f "$CNF_FILE"' EXIT
-          cat > "$CNF_FILE" << EOF
-          [client]
-          user=${MASTER_USER}
-          host=${SERVER}
-          port=${PORT}
-          EOF
-          export MYSQL_PWD="$MASTER_PASSWORD"
-
-          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
-
-          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
-          if [ $? -ne 0 ]; then
-            echo "Failed to set the monitoring user's password:" >&2
-            echo "$ALTER_RESULT" >&2
-            exit 1
-          fi
-
+          NR_PASSWORD=$(cat "$PW_FILE")
+          rm -f "$PW_FILE"
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
@@ -370,6 +354,7 @@ install:
               password: "${NR_PASSWORD}"
           EOF
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
@@ -630,6 +615,7 @@ install:
               password: "${NR_PASSWORD}"
           EOF
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rds-rhel.yml
@@ -221,10 +221,12 @@ install:
           NR_MASTER_PW_EOF
           )
 
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
           CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
           SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
           chmod 600 "$CNF_FILE" "$SQL_FILE"
-          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          NR_SUCCESS=""
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"; if [ "$NR_SUCCESS" != "1" ]; then rm -f "$PW_FILE"; fi' EXIT
           cat > "$CNF_FILE" << EOF
           [client]
           user=${MASTER_USER}
@@ -251,6 +253,10 @@ install:
           fi
           echo "$RESULT"
 
+          printf '%s' "$NR_PASSWORD" > "$PW_FILE"
+          chmod 600 "$PW_FILE"
+          NR_SUCCESS=1
+
           echo "MySQL monitoring identity configured successfully."
 
     create_collector_config:
@@ -266,39 +272,17 @@ install:
           SERVER="{{.NR_CLI_MYSQL_SERVER}}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
           TLS_CA_FILE="{{.NR_CLI_MYSQL_TLS_CA_FILE}}"
-          MASTER_USER="{{.NR_CLI_MYSQL_MASTER_USER}}"
-          MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
-          {{.NR_CLI_MYSQL_MASTER_PASSWORD}}
-          NR_MASTER_PW_EOF
-          )
           REGION="{{.NEW_RELIC_REGION}}"
           LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
           CONFIG_DIR="/etc/nrdot-collector"
           CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
           ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
 
           mkdir -p "$CONFIG_DIR"
 
-          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
-          chmod 600 "$CNF_FILE"
-          trap 'rm -f "$CNF_FILE"' EXIT
-          cat > "$CNF_FILE" << EOF
-          [client]
-          user=${MASTER_USER}
-          host=${SERVER}
-          port=${PORT}
-          EOF
-          export MYSQL_PWD="$MASTER_PASSWORD"
-
-          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
-
-          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
-          if [ $? -ne 0 ]; then
-            echo "Failed to set the monitoring user's password:" >&2
-            echo "$ALTER_RESULT" >&2
-            exit 1
-          fi
-
+          NR_PASSWORD=$(cat "$PW_FILE")
+          rm -f "$PW_FILE"
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;
@@ -370,6 +354,7 @@ install:
               password: "${NR_PASSWORD}"
           EOF
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:
@@ -630,6 +615,7 @@ install:
               password: "${NR_PASSWORD}"
           EOF
             cat >> "$CONFIG_PATH" << EOF
+              allow_native_passwords: true
               collection_interval: 10s
               initial_delay: 1s
               tls:

--- a/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/mysql-otel/rhel.yml
@@ -213,10 +213,12 @@ install:
           NR_ROOT_PW_EOF
           )
 
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
           CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
           SQL_FILE=$(mktemp /tmp/nr-mysql-grant.sql.XXXXXX)
           chmod 600 "$CNF_FILE" "$SQL_FILE"
-          trap 'rm -f "$CNF_FILE" "$SQL_FILE"' EXIT
+          NR_SUCCESS=""
+          trap 'rm -f "$CNF_FILE" "$SQL_FILE"; if [ "$NR_SUCCESS" != "1" ]; then rm -f "$PW_FILE"; fi' EXIT
           cat > "$CNF_FILE" << EOF
           [client]
           user=root
@@ -243,6 +245,10 @@ install:
           fi
           echo "$RESULT"
 
+          printf '%s' "$NR_PASSWORD" > "$PW_FILE"
+          chmod 600 "$PW_FILE"
+          NR_SUCCESS=1
+
           echo "MySQL monitoring identity configured successfully."
 
     create_collector_config:
@@ -257,38 +263,17 @@ install:
           fi
           SERVER="${NR_CLI_MYSQL_SERVER:-localhost}"
           PORT="{{.NR_CLI_MYSQL_PORT}}"
-          ROOT_PASSWORD=$(cat << 'NR_ROOT_PW_EOF'
-          {{.NR_CLI_MYSQL_ROOT_PASSWORD}}
-          NR_ROOT_PW_EOF
-          )
           REGION="{{.NEW_RELIC_REGION}}"
           LICENSE_KEY="{{.NEW_RELIC_LICENSE_KEY}}"
           CONFIG_DIR="/etc/nrdot-collector"
           CONFIG_PATH="${CONFIG_DIR}/mysql-config.yaml"
           ENV_FILE="${CONFIG_DIR}/nrdot-collector.conf"
+          PW_FILE="/tmp/nr-mysql-newrelic-pw.tmp"
 
           mkdir -p "$CONFIG_DIR"
 
-          CNF_FILE=$(mktemp /tmp/nr-mysql-admin.cnf.XXXXXX)
-          chmod 600 "$CNF_FILE"
-          trap 'rm -f "$CNF_FILE"' EXIT
-          cat > "$CNF_FILE" << EOF
-          [client]
-          user=root
-          host=${SERVER}
-          port=${PORT}
-          EOF
-          export MYSQL_PWD="$ROOT_PASSWORD"
-
-          NR_PASSWORD="$(tr -dc 'a-z' < /dev/urandom | head -c 6)$(tr -dc 'A-Z' < /dev/urandom | head -c 6)$(tr -dc '0-9' < /dev/urandom | head -c 6)$(tr -dc '_+=.~^-' < /dev/urandom | head -c 6)"
-
-          ALTER_RESULT=$(mysql --defaults-extra-file="$CNF_FILE" -e "ALTER USER '${LOGIN_NAME}'@'%' IDENTIFIED BY '${NR_PASSWORD}';" 2>&1)
-          if [ $? -ne 0 ]; then
-            echo "Failed to set the monitoring user's password:" >&2
-            echo "$ALTER_RESULT" >&2
-            exit 1
-          fi
-
+          NR_PASSWORD=$(cat "$PW_FILE")
+          rm -f "$PW_FILE"
 
           case "$REGION" in
             staging) OTLP_ENDPOINT="https://staging-otlp.nr-data.net:4317" ;;

--- a/recipes/newrelic/infrastructure/nrdot/oracle-otel/oci-linux.yml
+++ b/recipes/newrelic/infrastructure/nrdot/oracle-otel/oci-linux.yml
@@ -355,11 +355,13 @@ install:
           GRANT SELECT ON DBA_FREE_SPACE TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON DBA_RECYCLEBIN TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON V_\$SQL TO ${DB_USER} CONTAINER=ALL;
-          GRANT SELECT ON V_\$SQL_PLAN TO ${DB_USER} CONTAINER=ALL;
+          GRANT SELECT ON V_\$SQL_PLAN_STATISTICS_ALL TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON V_\$LOCK TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON V_\$SESSION_EVENT TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON DBA_PROCEDURES TO ${DB_USER} CONTAINER=ALL;
           GRANT SELECT ON DBA_OBJECTS TO ${DB_USER} CONTAINER=ALL;
+          GRANT SELECT ON V_\$PDBS TO ${DB_USER} CONTAINER=ALL;
+          GRANT SELECT ON CDB_SERVICES TO ${DB_USER} CONTAINER=ALL;
           EXIT;
           SQLEOF
             )
@@ -387,12 +389,13 @@ install:
           GRANT SELECT ON DBA_FREE_SPACE TO ${DB_USER};
           GRANT SELECT ON DBA_RECYCLEBIN TO ${DB_USER};
           GRANT SELECT ON V_\$SQL TO ${DB_USER};
-          GRANT SELECT ON V_\$SQL_PLAN TO ${DB_USER};
+          GRANT SELECT ON V_\$SQL_PLAN_STATISTICS_ALL TO ${DB_USER};
           GRANT SELECT ON V_\$LOCK TO ${DB_USER};
           GRANT SELECT ON V_\$SESSION_EVENT TO ${DB_USER};
           GRANT SELECT ON DBA_PROCEDURES TO ${DB_USER};
           GRANT SELECT ON DBA_OBJECTS TO ${DB_USER};
           GRANT SELECT ON V_\$PDBS TO ${DB_USER};
+          GRANT SELECT ON CDB_SERVICES TO ${DB_USER};
           EXIT;
           SQLEOF
             )
@@ -495,6 +498,12 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                #   process:
+                #     metrics:
+                #       process.cpu.utilization:
+                #         enabled: true
 
             filelog:
               include:
@@ -810,6 +819,8 @@ install:
                 oracle.db.hosting_type:
                   enabled: true
                 oracle.db.open_mode:
+                  enabled: true
+                oracle.db.pdb:
                   enabled: true
                 oracle.db.role:
                   enabled: true

--- a/recipes/newrelic/infrastructure/nrdot/oracle-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/oracle-otel/rds-debian.yml
@@ -289,7 +289,7 @@ install:
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SGAINFO', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQLSTATS', '${LOGIN_UPPER}', 'SELECT', false);
-          EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL_PLAN', '${LOGIN_UPPER}', 'SELECT', false);
+          EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL_PLAN_STATISTICS_ALL', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$PARAMETER', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$ROWCACHE', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$RESOURCE_LIMIT', '${LOGIN_UPPER}', 'SELECT', false);
@@ -407,6 +407,12 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                #   process:
+                #     metrics:
+                #       process.cpu.utilization:
+                #         enabled: true
 
             filelog:
               include:
@@ -733,6 +739,8 @@ install:
                 oracle.db.hosting_type:
                   enabled: true
                 oracle.db.open_mode:
+                  enabled: true
+                oracle.db.pdb:
                   enabled: true
                 oracle.db.role:
                   enabled: true

--- a/recipes/newrelic/infrastructure/nrdot/oracle-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/oracle-otel/rds-rhel.yml
@@ -289,7 +289,7 @@ install:
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SGAINFO', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQLSTATS', '${LOGIN_UPPER}', 'SELECT', false);
-          EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL_PLAN', '${LOGIN_UPPER}', 'SELECT', false);
+          EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$SQL_PLAN_STATISTICS_ALL', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$PARAMETER', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$ROWCACHE', '${LOGIN_UPPER}', 'SELECT', false);
           EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_\$RESOURCE_LIMIT', '${LOGIN_UPPER}', 'SELECT', false);
@@ -407,6 +407,12 @@ install:
                   metrics:
                     system.network.connections:
                       enabled: false
+                # Uncomment to enable process metrics, which can be noisy but valuable.
+                # processes:
+                #   process:
+                #     metrics:
+                #       process.cpu.utilization:
+                #         enabled: true
 
             filelog:
               include:
@@ -733,6 +739,8 @@ install:
                 oracle.db.hosting_type:
                   enabled: true
                 oracle.db.open_mode:
+                  enabled: true
+                oracle.db.pdb:
                   enabled: true
                 oracle.db.role:
                   enabled: true

--- a/recipes/newrelic/infrastructure/nrdot/postgresql-otel/debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/postgresql-otel/debian.yml
@@ -63,6 +63,12 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_POSTGRES_DATABASES
     prompt: "Databases to monitor (comma-separated, at least one required): "
+  - name: NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS
+    prompt: "Enable pgvector similarity-search metrics? Requires the pgvector extension (y/n): "
+    default: "n"
+  - name: NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER
+    prompt: "Enable EXPLAIN plan collection for locking/write statements? Creates a SECURITY DEFINER helper function (y/n): "
+    default: "n"
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'postgresql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -221,6 +227,8 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
+          ENABLE_EXPLAIN="{{.NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER}}"
           SUPERUSER_PASSWORD=$(cat << 'NR_PG_PW_EOF'
           {{.NR_CLI_POSTGRES_SUPERUSER_PASSWORD}}
           NR_PG_PW_EOF
@@ -228,6 +236,14 @@ install:
           export PGPASSWORD="$SUPERUSER_PASSWORD"
 
           NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          # ALTER ROLE ... INHERIT is only needed on PostgreSQL 15+ - on 14 the
+          # monitoring role inherits privileges by default already.
+          VERSION_NUM=$(psql -h "$SERVER" -p "$PORT" -U postgres -d postgres -tA -c "SELECT current_setting('server_version_num');" 2>&1 | tr -d '[:space:]')
+          INHERIT_LINE=""
+          if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" -ge 150000 ] 2>/dev/null; then
+            INHERIT_LINE="ALTER ROLE ${LOGIN_NAME} INHERIT;"
+          fi
 
           SQL_FILE=$(mktemp /tmp/nr-postgres-grant.sql.XXXXXX)
           trap 'rm -f "$SQL_FILE"' EXIT
@@ -240,7 +256,7 @@ install:
           END
           \$\$;
           ALTER ROLE ${LOGIN_NAME} WITH LOGIN PASSWORD '${NR_PASSWORD}';
-          ALTER ROLE ${LOGIN_NAME} INHERIT;
+          ${INHERIT_LINE}
           GRANT pg_monitor TO ${LOGIN_NAME};
           EOF
 
@@ -261,6 +277,52 @@ install:
           GRANT USAGE ON SCHEMA public TO ${LOGIN_NAME};
           GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${LOGIN_NAME};
           EOF
+          case "$ENABLE_VECTOR" in
+            y|Y|yes|YES|Yes)
+              echo "CREATE EXTENSION IF NOT EXISTS vector;" >> "$PERDB_SQL_FILE"
+              ;;
+          esac
+          case "$ENABLE_EXPLAIN" in
+            y|Y|yes|YES|Yes)
+              cat >> "$PERDB_SQL_FILE" << EOF
+          CREATE OR REPLACE FUNCTION otel.explain_statement(l_query text)
+          RETURNS json
+          LANGUAGE plpgsql
+          SECURITY DEFINER
+          AS \$\$
+          DECLARE
+            v_plan json;
+            v_param_count int;
+            v_nulls text := '';
+            i int;
+          BEGIN
+            SET TRANSACTION READ ONLY;
+            SET plan_cache_mode = force_generic_plan;
+            EXECUTE 'PREPARE otel_explain_stmt AS ' || l_query;
+            SELECT COALESCE(array_length(parameter_types, 1), 0)
+              INTO v_param_count
+              FROM pg_prepared_statements
+              WHERE name = 'otel_explain_stmt';
+            IF v_param_count > 0 THEN
+              FOR i IN 1..v_param_count LOOP
+                v_nulls := v_nulls || CASE WHEN i > 1 THEN ', ' ELSE '' END || 'null';
+              END LOOP;
+              v_nulls := '(' || v_nulls || ')';
+            END IF;
+            EXECUTE 'EXPLAIN (FORMAT JSON) EXECUTE otel_explain_stmt' || v_nulls INTO v_plan;
+            DEALLOCATE otel_explain_stmt;
+            RETURN v_plan;
+          EXCEPTION WHEN OTHERS THEN
+            IF EXISTS (SELECT 1 FROM pg_prepared_statements WHERE name = 'otel_explain_stmt') THEN
+              DEALLOCATE otel_explain_stmt;
+            END IF;
+            RAISE;
+          END;
+          \$\$;
+          GRANT EXECUTE ON FUNCTION otel.explain_statement(text) TO ${LOGIN_NAME};
+          EOF
+              ;;
+          esac
 
           OLD_IFS="$IFS"
           IFS=','
@@ -301,6 +363,7 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
           SUPERUSER_PASSWORD=$(cat << 'NR_PG_PW_EOF'
           {{.NR_CLI_POSTGRES_SUPERUSER_PASSWORD}}
           NR_PG_PW_EOF
@@ -445,6 +508,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
             metrics_transform:
@@ -698,6 +779,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
           EOF
@@ -753,6 +852,19 @@ install:
           echo "PostgreSQL OTel config written to ${CONFIG_PATH}"
           echo "Env file written to ${ENV_FILE}"
 
+    validate_collector_config:
+      cmds:
+        - |
+          CONFIG_PATH="/etc/nrdot-collector/postgresql-config.yaml"
+          VALIDATE_RESULT=$(sudo /usr/bin/nrdot-collector validate --config="$CONFIG_PATH" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "NRDOT Collector configuration validation failed:" >&2
+            echo "$VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "$VALIDATE_RESULT"
+          echo "NRDOT Collector configuration is valid."
+
     restart_nrdot:
       cmds:
         - |
@@ -779,6 +891,7 @@ install:
         - task: install_nrdot
         - task: configure_database_user
         - task: create_collector_config
+        - task: validate_collector_config
         - task: restart_nrdot
 
 postInstall:
@@ -790,7 +903,7 @@ postInstall:
       Restart service:         sudo systemctl restart nrdot-collector
 
       Note: query plans for locking or write statements are not collected by
-      default. Enabling that requires creating an otel.explain_statement()
-      SECURITY DEFINER helper function in each monitored database and granting
-      EXECUTE on it to the monitoring user - see:
+      default. If you enabled the EXPLAIN helper function during install, the
+      otel.explain_statement() SECURITY DEFINER function was already created in
+      each monitored database and granted to the monitoring user. Otherwise, see:
       https://docs.newrelic.com/docs/opentelemetry/database/postgresql/explain-permissions/

--- a/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rds-debian.yml
+++ b/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rds-debian.yml
@@ -59,6 +59,12 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_POSTGRES_DATABASES
     prompt: "Databases to monitor (comma-separated, at least one required): "
+  - name: NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS
+    prompt: "Enable pgvector similarity-search metrics? Requires the pgvector extension (y/n): "
+    default: "n"
+  - name: NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER
+    prompt: "Enable EXPLAIN plan collection for locking/write statements? Creates a SECURITY DEFINER helper function (y/n): "
+    default: "n"
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'postgresql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -218,6 +224,8 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
+          ENABLE_EXPLAIN="{{.NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER}}"
           MASTER_USER="{{.NR_CLI_POSTGRES_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
           {{.NR_CLI_POSTGRES_MASTER_PASSWORD}}
@@ -226,6 +234,14 @@ install:
           export PGPASSWORD="$MASTER_PASSWORD"
 
           NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          # ALTER ROLE ... INHERIT is only needed on PostgreSQL 15+ - on 14 the
+          # monitoring role inherits privileges by default already.
+          VERSION_NUM=$(psql -h "$SERVER" -p "$PORT" -U "$MASTER_USER" -d postgres -tA -c "SELECT current_setting('server_version_num');" 2>&1 | tr -d '[:space:]')
+          INHERIT_LINE=""
+          if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" -ge 150000 ] 2>/dev/null; then
+            INHERIT_LINE="ALTER ROLE ${LOGIN_NAME} INHERIT;"
+          fi
 
           SQL_FILE=$(mktemp /tmp/nr-postgres-grant.sql.XXXXXX)
           trap 'rm -f "$SQL_FILE"' EXIT
@@ -238,7 +254,7 @@ install:
           END
           \$\$;
           ALTER ROLE ${LOGIN_NAME} WITH LOGIN PASSWORD '${NR_PASSWORD}';
-          ALTER ROLE ${LOGIN_NAME} INHERIT;
+          ${INHERIT_LINE}
           GRANT pg_monitor TO ${LOGIN_NAME};
           EOF
 
@@ -259,6 +275,52 @@ install:
           GRANT USAGE ON SCHEMA public TO ${LOGIN_NAME};
           GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${LOGIN_NAME};
           EOF
+          case "$ENABLE_VECTOR" in
+            y|Y|yes|YES|Yes)
+              echo "CREATE EXTENSION IF NOT EXISTS vector;" >> "$PERDB_SQL_FILE"
+              ;;
+          esac
+          case "$ENABLE_EXPLAIN" in
+            y|Y|yes|YES|Yes)
+              cat >> "$PERDB_SQL_FILE" << EOF
+          CREATE OR REPLACE FUNCTION otel.explain_statement(l_query text)
+          RETURNS json
+          LANGUAGE plpgsql
+          SECURITY DEFINER
+          AS \$\$
+          DECLARE
+            v_plan json;
+            v_param_count int;
+            v_nulls text := '';
+            i int;
+          BEGIN
+            SET TRANSACTION READ ONLY;
+            SET plan_cache_mode = force_generic_plan;
+            EXECUTE 'PREPARE otel_explain_stmt AS ' || l_query;
+            SELECT COALESCE(array_length(parameter_types, 1), 0)
+              INTO v_param_count
+              FROM pg_prepared_statements
+              WHERE name = 'otel_explain_stmt';
+            IF v_param_count > 0 THEN
+              FOR i IN 1..v_param_count LOOP
+                v_nulls := v_nulls || CASE WHEN i > 1 THEN ', ' ELSE '' END || 'null';
+              END LOOP;
+              v_nulls := '(' || v_nulls || ')';
+            END IF;
+            EXECUTE 'EXPLAIN (FORMAT JSON) EXECUTE otel_explain_stmt' || v_nulls INTO v_plan;
+            DEALLOCATE otel_explain_stmt;
+            RETURN v_plan;
+          EXCEPTION WHEN OTHERS THEN
+            IF EXISTS (SELECT 1 FROM pg_prepared_statements WHERE name = 'otel_explain_stmt') THEN
+              DEALLOCATE otel_explain_stmt;
+            END IF;
+            RAISE;
+          END;
+          \$\$;
+          GRANT EXECUTE ON FUNCTION otel.explain_statement(text) TO ${LOGIN_NAME};
+          EOF
+              ;;
+          esac
 
           OLD_IFS="$IFS"
           IFS=','
@@ -299,6 +361,7 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
           MASTER_USER="{{.NR_CLI_POSTGRES_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
           {{.NR_CLI_POSTGRES_MASTER_PASSWORD}}
@@ -446,6 +509,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
             metrics_transform:
@@ -701,6 +782,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
           EOF
@@ -756,6 +855,19 @@ install:
           echo "PostgreSQL OTel config written to ${CONFIG_PATH}"
           echo "Env file written to ${ENV_FILE}"
 
+    validate_collector_config:
+      cmds:
+        - |
+          CONFIG_PATH="/etc/nrdot-collector/postgresql-config.yaml"
+          VALIDATE_RESULT=$(sudo /usr/bin/nrdot-collector validate --config="$CONFIG_PATH" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "NRDOT Collector configuration validation failed:" >&2
+            echo "$VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "$VALIDATE_RESULT"
+          echo "NRDOT Collector configuration is valid."
+
     restart_nrdot:
       cmds:
         - |
@@ -782,6 +894,7 @@ install:
         - task: install_nrdot
         - task: configure_database_user
         - task: create_collector_config
+        - task: validate_collector_config
         - task: restart_nrdot
 
 postInstall:
@@ -793,9 +906,9 @@ postInstall:
       Restart service:         sudo systemctl restart nrdot-collector
 
       Note: query plans for locking or write statements are not collected by
-      default. Enabling that requires creating an otel.explain_statement()
-      SECURITY DEFINER helper function in each monitored database and granting
-      EXECUTE on it to the monitoring user - see:
+      default. If you enabled the EXPLAIN helper function during install, the
+      otel.explain_statement() SECURITY DEFINER function was already created in
+      each monitored database and granted to the monitoring user. Otherwise, see:
       https://docs.newrelic.com/docs/opentelemetry/database/postgresql/explain-permissions/
 
       Known limitation (RDS/Aurora only): the top_query feature reads from

--- a/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rds-rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rds-rhel.yml
@@ -59,6 +59,12 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_POSTGRES_DATABASES
     prompt: "Databases to monitor (comma-separated, at least one required): "
+  - name: NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS
+    prompt: "Enable pgvector similarity-search metrics? Requires the pgvector extension (y/n): "
+    default: "n"
+  - name: NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER
+    prompt: "Enable EXPLAIN plan collection for locking/write statements? Creates a SECURITY DEFINER helper function (y/n): "
+    default: "n"
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'postgresql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -218,6 +224,8 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
+          ENABLE_EXPLAIN="{{.NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER}}"
           MASTER_USER="{{.NR_CLI_POSTGRES_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
           {{.NR_CLI_POSTGRES_MASTER_PASSWORD}}
@@ -226,6 +234,14 @@ install:
           export PGPASSWORD="$MASTER_PASSWORD"
 
           NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          # ALTER ROLE ... INHERIT is only needed on PostgreSQL 15+ - on 14 the
+          # monitoring role inherits privileges by default already.
+          VERSION_NUM=$(psql -h "$SERVER" -p "$PORT" -U "$MASTER_USER" -d postgres -tA -c "SELECT current_setting('server_version_num');" 2>&1 | tr -d '[:space:]')
+          INHERIT_LINE=""
+          if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" -ge 150000 ] 2>/dev/null; then
+            INHERIT_LINE="ALTER ROLE ${LOGIN_NAME} INHERIT;"
+          fi
 
           SQL_FILE=$(mktemp /tmp/nr-postgres-grant.sql.XXXXXX)
           trap 'rm -f "$SQL_FILE"' EXIT
@@ -238,7 +254,7 @@ install:
           END
           \$\$;
           ALTER ROLE ${LOGIN_NAME} WITH LOGIN PASSWORD '${NR_PASSWORD}';
-          ALTER ROLE ${LOGIN_NAME} INHERIT;
+          ${INHERIT_LINE}
           GRANT pg_monitor TO ${LOGIN_NAME};
           EOF
 
@@ -259,6 +275,52 @@ install:
           GRANT USAGE ON SCHEMA public TO ${LOGIN_NAME};
           GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${LOGIN_NAME};
           EOF
+          case "$ENABLE_VECTOR" in
+            y|Y|yes|YES|Yes)
+              echo "CREATE EXTENSION IF NOT EXISTS vector;" >> "$PERDB_SQL_FILE"
+              ;;
+          esac
+          case "$ENABLE_EXPLAIN" in
+            y|Y|yes|YES|Yes)
+              cat >> "$PERDB_SQL_FILE" << EOF
+          CREATE OR REPLACE FUNCTION otel.explain_statement(l_query text)
+          RETURNS json
+          LANGUAGE plpgsql
+          SECURITY DEFINER
+          AS \$\$
+          DECLARE
+            v_plan json;
+            v_param_count int;
+            v_nulls text := '';
+            i int;
+          BEGIN
+            SET TRANSACTION READ ONLY;
+            SET plan_cache_mode = force_generic_plan;
+            EXECUTE 'PREPARE otel_explain_stmt AS ' || l_query;
+            SELECT COALESCE(array_length(parameter_types, 1), 0)
+              INTO v_param_count
+              FROM pg_prepared_statements
+              WHERE name = 'otel_explain_stmt';
+            IF v_param_count > 0 THEN
+              FOR i IN 1..v_param_count LOOP
+                v_nulls := v_nulls || CASE WHEN i > 1 THEN ', ' ELSE '' END || 'null';
+              END LOOP;
+              v_nulls := '(' || v_nulls || ')';
+            END IF;
+            EXECUTE 'EXPLAIN (FORMAT JSON) EXECUTE otel_explain_stmt' || v_nulls INTO v_plan;
+            DEALLOCATE otel_explain_stmt;
+            RETURN v_plan;
+          EXCEPTION WHEN OTHERS THEN
+            IF EXISTS (SELECT 1 FROM pg_prepared_statements WHERE name = 'otel_explain_stmt') THEN
+              DEALLOCATE otel_explain_stmt;
+            END IF;
+            RAISE;
+          END;
+          \$\$;
+          GRANT EXECUTE ON FUNCTION otel.explain_statement(text) TO ${LOGIN_NAME};
+          EOF
+              ;;
+          esac
 
           OLD_IFS="$IFS"
           IFS=','
@@ -299,6 +361,7 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
           MASTER_USER="{{.NR_CLI_POSTGRES_MASTER_USER}}"
           MASTER_PASSWORD=$(cat << 'NR_MASTER_PW_EOF'
           {{.NR_CLI_POSTGRES_MASTER_PASSWORD}}
@@ -446,6 +509,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
             metrics_transform:
@@ -701,6 +782,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
           EOF
@@ -756,6 +855,19 @@ install:
           echo "PostgreSQL OTel config written to ${CONFIG_PATH}"
           echo "Env file written to ${ENV_FILE}"
 
+    validate_collector_config:
+      cmds:
+        - |
+          CONFIG_PATH="/etc/nrdot-collector/postgresql-config.yaml"
+          VALIDATE_RESULT=$(sudo /usr/bin/nrdot-collector validate --config="$CONFIG_PATH" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "NRDOT Collector configuration validation failed:" >&2
+            echo "$VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "$VALIDATE_RESULT"
+          echo "NRDOT Collector configuration is valid."
+
     restart_nrdot:
       cmds:
         - |
@@ -782,6 +894,7 @@ install:
         - task: install_nrdot
         - task: configure_database_user
         - task: create_collector_config
+        - task: validate_collector_config
         - task: restart_nrdot
 
 postInstall:
@@ -793,9 +906,9 @@ postInstall:
       Restart service:         sudo systemctl restart nrdot-collector
 
       Note: query plans for locking or write statements are not collected by
-      default. Enabling that requires creating an otel.explain_statement()
-      SECURITY DEFINER helper function in each monitored database and granting
-      EXECUTE on it to the monitoring user - see:
+      default. If you enabled the EXPLAIN helper function during install, the
+      otel.explain_statement() SECURITY DEFINER function was already created in
+      each monitored database and granted to the monitoring user. Otherwise, see:
       https://docs.newrelic.com/docs/opentelemetry/database/postgresql/explain-permissions/
 
       Known limitation (RDS/Aurora only): the top_query feature reads from

--- a/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rhel.yml
+++ b/recipes/newrelic/infrastructure/nrdot/postgresql-otel/rhel.yml
@@ -63,6 +63,12 @@ inputVars:
     default: "newrelic"
   - name: NR_CLI_POSTGRES_DATABASES
     prompt: "Databases to monitor (comma-separated, at least one required): "
+  - name: NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS
+    prompt: "Enable pgvector similarity-search metrics? Requires the pgvector extension (y/n): "
+    default: "n"
+  - name: NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER
+    prompt: "Enable EXPLAIN plan collection for locking/write statements? Creates a SECURITY DEFINER helper function (y/n): "
+    default: "n"
 
 validationNrql: "SELECT count(*) FROM Metric WHERE metricName LIKE 'postgresql.%' AND instrumentation.provider = 'opentelemetry' SINCE 10 minutes ago"
 
@@ -221,6 +227,8 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
+          ENABLE_EXPLAIN="{{.NR_CLI_POSTGRES_ENABLE_EXPLAIN_HELPER}}"
           SUPERUSER_PASSWORD=$(cat << 'NR_PG_PW_EOF'
           {{.NR_CLI_POSTGRES_SUPERUSER_PASSWORD}}
           NR_PG_PW_EOF
@@ -228,6 +236,14 @@ install:
           export PGPASSWORD="$SUPERUSER_PASSWORD"
 
           NR_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)
+
+          # ALTER ROLE ... INHERIT is only needed on PostgreSQL 15+ - on 14 the
+          # monitoring role inherits privileges by default already.
+          VERSION_NUM=$(psql -h "$SERVER" -p "$PORT" -U postgres -d postgres -tA -c "SELECT current_setting('server_version_num');" 2>&1 | tr -d '[:space:]')
+          INHERIT_LINE=""
+          if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" -ge 150000 ] 2>/dev/null; then
+            INHERIT_LINE="ALTER ROLE ${LOGIN_NAME} INHERIT;"
+          fi
 
           SQL_FILE=$(mktemp /tmp/nr-postgres-grant.sql.XXXXXX)
           trap 'rm -f "$SQL_FILE"' EXIT
@@ -240,7 +256,7 @@ install:
           END
           \$\$;
           ALTER ROLE ${LOGIN_NAME} WITH LOGIN PASSWORD '${NR_PASSWORD}';
-          ALTER ROLE ${LOGIN_NAME} INHERIT;
+          ${INHERIT_LINE}
           GRANT pg_monitor TO ${LOGIN_NAME};
           EOF
 
@@ -261,6 +277,52 @@ install:
           GRANT USAGE ON SCHEMA public TO ${LOGIN_NAME};
           GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${LOGIN_NAME};
           EOF
+          case "$ENABLE_VECTOR" in
+            y|Y|yes|YES|Yes)
+              echo "CREATE EXTENSION IF NOT EXISTS vector;" >> "$PERDB_SQL_FILE"
+              ;;
+          esac
+          case "$ENABLE_EXPLAIN" in
+            y|Y|yes|YES|Yes)
+              cat >> "$PERDB_SQL_FILE" << EOF
+          CREATE OR REPLACE FUNCTION otel.explain_statement(l_query text)
+          RETURNS json
+          LANGUAGE plpgsql
+          SECURITY DEFINER
+          AS \$\$
+          DECLARE
+            v_plan json;
+            v_param_count int;
+            v_nulls text := '';
+            i int;
+          BEGIN
+            SET TRANSACTION READ ONLY;
+            SET plan_cache_mode = force_generic_plan;
+            EXECUTE 'PREPARE otel_explain_stmt AS ' || l_query;
+            SELECT COALESCE(array_length(parameter_types, 1), 0)
+              INTO v_param_count
+              FROM pg_prepared_statements
+              WHERE name = 'otel_explain_stmt';
+            IF v_param_count > 0 THEN
+              FOR i IN 1..v_param_count LOOP
+                v_nulls := v_nulls || CASE WHEN i > 1 THEN ', ' ELSE '' END || 'null';
+              END LOOP;
+              v_nulls := '(' || v_nulls || ')';
+            END IF;
+            EXECUTE 'EXPLAIN (FORMAT JSON) EXECUTE otel_explain_stmt' || v_nulls INTO v_plan;
+            DEALLOCATE otel_explain_stmt;
+            RETURN v_plan;
+          EXCEPTION WHEN OTHERS THEN
+            IF EXISTS (SELECT 1 FROM pg_prepared_statements WHERE name = 'otel_explain_stmt') THEN
+              DEALLOCATE otel_explain_stmt;
+            END IF;
+            RAISE;
+          END;
+          \$\$;
+          GRANT EXECUTE ON FUNCTION otel.explain_statement(text) TO ${LOGIN_NAME};
+          EOF
+              ;;
+          esac
 
           OLD_IFS="$IFS"
           IFS=','
@@ -301,6 +363,7 @@ install:
           SERVER="{{.NR_CLI_POSTGRES_SERVER}}"
           PORT="{{.NR_CLI_POSTGRES_PORT}}"
           DATABASES="{{.NR_CLI_POSTGRES_DATABASES}}"
+          ENABLE_VECTOR="{{.NR_CLI_POSTGRES_ENABLE_VECTOR_METRICS}}"
           SUPERUSER_PASSWORD=$(cat << 'NR_PG_PW_EOF'
           {{.NR_CLI_POSTGRES_SUPERUSER_PASSWORD}}
           NR_PG_PW_EOF
@@ -445,6 +508,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
             metrics_transform:
@@ -698,6 +779,24 @@ install:
                   enabled: true
                 postgresql.temp_files:
                   enabled: true
+          EOF
+            case "$ENABLE_VECTOR" in
+              y|Y|yes|YES|Yes)
+                cat >> "$CONFIG_PATH" << 'EOF'
+                postgresql.vector.search.calls:
+                  enabled: true
+                postgresql.vector.search.duration:
+                  enabled: true
+                postgresql.vector.search.rows_returned:
+                  enabled: true
+                postgresql.vector.insert.rows:
+                  enabled: true
+                postgresql.vector.insert.duration:
+                  enabled: true
+          EOF
+                ;;
+            esac
+            cat >> "$CONFIG_PATH" << 'EOF'
 
           processors:
           EOF
@@ -753,6 +852,19 @@ install:
           echo "PostgreSQL OTel config written to ${CONFIG_PATH}"
           echo "Env file written to ${ENV_FILE}"
 
+    validate_collector_config:
+      cmds:
+        - |
+          CONFIG_PATH="/etc/nrdot-collector/postgresql-config.yaml"
+          VALIDATE_RESULT=$(sudo /usr/bin/nrdot-collector validate --config="$CONFIG_PATH" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "NRDOT Collector configuration validation failed:" >&2
+            echo "$VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "$VALIDATE_RESULT"
+          echo "NRDOT Collector configuration is valid."
+
     restart_nrdot:
       cmds:
         - |
@@ -779,6 +891,7 @@ install:
         - task: install_nrdot
         - task: configure_database_user
         - task: create_collector_config
+        - task: validate_collector_config
         - task: restart_nrdot
 
 postInstall:
@@ -790,7 +903,7 @@ postInstall:
       Restart service:         sudo systemctl restart nrdot-collector
 
       Note: query plans for locking or write statements are not collected by
-      default. Enabling that requires creating an otel.explain_statement()
-      SECURITY DEFINER helper function in each monitored database and granting
-      EXECUTE on it to the monitoring user - see:
+      default. If you enabled the EXPLAIN helper function during install, the
+      otel.explain_statement() SECURITY DEFINER function was already created in
+      each monitored database and granted to the monitoring user. Otherwise, see:
       https://docs.newrelic.com/docs/opentelemetry/database/postgresql/explain-permissions/


### PR DESCRIPTION
## Summary
- Final verification pass comparing the NRDOT database OTel recipes (Oracle, MSSQL, MySQL, PostgreSQL) against their current New Relic docs, fixing the gaps that were confirmed as real issues.
- Two new optional PostgreSQL features (pgvector metrics, EXPLAIN helper function) are opt-in via new inputVars, defaulting to off — no behavior change for existing installs unless explicitly enabled.

## Test plan
- [ ] Dry-run each changed recipe's `create_collector_config` task and confirm valid YAML output for both Standard and Full-feature presets
- [ ] PostgreSQL: verify `nrdot-collector validate` step correctly fails the install on a malformed config, and passes on a good one
- [ ] PostgreSQL: verify pgvector and EXPLAIN-helper flags default to "no" and produce no config/SQL changes when left at default
- [ ] MySQL: verify RDS recipes still connect and configure the monitoring user successfully with the single-password-generation flow
- [ ] Oracle: verify CDB and PDB grant flows against a real Oracle 19c+ instance
- [ ] MSSQL: verify Windows Full-feature preset picks up the new performance-counter metrics; confirm Linux recipes fail cleanly with a clear message when `sqlcmd` is missing